### PR TITLE
Resolve remaining SRC contraction performance follow-ups

### DIFF
--- a/.github/workflows/CI_rs.yml
+++ b/.github/workflows/CI_rs.yml
@@ -159,6 +159,9 @@ jobs:
       - name: Test coverage threshold checker
         run: python3 scripts/test-check-coverage.py
 
+      - name: Test SRC benchmark gate runner
+        run: python3 scripts/test-run-src-benchmark-gates.py
+
   coverage:
     name: Coverage
     runs-on: ubuntu-22.04

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -37,6 +37,48 @@ Prepared local linsolve:
 RAYON_NUM_THREADS=1 cargo run -p tensor4all-treetn --example benchmark_local_linsolve --release -- 38 32 32 1 10 30 0
 ```
 
+### SRC performance gates
+
+`benchmark_src` uses deterministic MPO--MPS chains and maximum-degree-3 binary
+trees. It rejects oversized input fixtures and dense correctness oracles before
+allocation; override the 512 MiB input or 256 MiB oracle defaults only with an
+explicit memory budget:
+
+```bash
+commit=$(git rev-parse HEAD)
+T4A_BENCH_GIT_COMMIT=$commit \
+  cargo build --release -p tensor4all-treetn --example benchmark_src
+python3 scripts/run-src-benchmark-gates.py \
+  --candidate target/release/examples/benchmark_src \
+  --candidate-commit "$commit" --suite quick --pairs 1 --reps 1 \
+  --expected-backend tenferro --expected-features tenferro-cpu-faer \
+  --output /tmp/src-quick.json
+```
+
+A promotion study builds baseline and candidate binaries separately with their
+own `T4A_BENCH_GIT_COMMIT`, then passes both binaries and commits to the runner.
+Use at least 5 pairs for the quick suite and 10 for `--suite full`; declare
+`--primary`, `--required-improvement-percent`,
+`--allowed-regression-percent`, and `--max-dispersion-percent` before running.
+The runner rejects commit, release-profile, backend, or feature mismatches. The
+JSON report records binary SHA-256 values, raw output, timings, correctness,
+peak RSS, load, paired medians/MAD, and bootstrap intervals. All Rayon/BLAS
+thread counts are fixed to one. `T4A_BENCH_MAX_INPUT_BYTES` and
+`T4A_BENCH_MAX_DENSE_BYTES` control fixture/oracle preflight; runner flags
+`--max-rss-mib` and `--max-virtual-mib` separately control measured RSS and
+`RLIMIT_AS`.
+
+The required CPU lane uses the default tenferro/faer backend. Provider-injected
+and CUDA SRC are currently unsupported because the high-level SRC API does not
+own an execution context and constructs CPU probes. Do not infer SRC support
+from unrelated backend tests. On a CUDA host, verify the existing resident
+TreeTN contraction lane separately:
+
+```bash
+cargo test --release -p tensor4all-treetn \
+  --features tenferro-cuda --test cuda_tree_contraction -- --nocapture
+```
+
 Two-site TreeTN DMRG against a Pauli Heisenberg Hamiltonian
 `sum_(i,j in E) X_i X_j + Y_i Y_j + Z_i Z_j` on chain and star topologies.
 The benchmark compresses the summed MPO before timing, uses the repository

--- a/crates/tensor4all-core/src/defaults/contract.rs
+++ b/crates/tensor4all-core/src/defaults/contract.rs
@@ -10,6 +10,7 @@
 //!
 //! - [`contract`]: Contracts one connected tensor network
 //! - [`contract_with_options`]: Contracts one connected tensor network with retained indices
+//! - [`PreparedContraction`]: Reuses index matching and labels for compatible repeated calls
 //!
 //! # Structured Tensor Handling
 //!
@@ -170,6 +171,228 @@ impl<'a> ContractionOptions<'a> {
 impl Default for ContractionOptions<'_> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// A caller-owned plan for repeated contractions with fixed index metadata.
+///
+/// Prepare this once when repeated operands keep the same ordered indices,
+/// dimensions, and axis classes but their values, dtypes, or gradient state may
+/// change. Fresh index identities require a fresh plan.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::{ContractionOptions, DynIndex, IdxTensor, PreparedContraction};
+///
+/// let i = DynIndex::new_dyn(2);
+/// let j = DynIndex::new_dyn(2);
+/// let k = DynIndex::new_dyn(2);
+/// let a = IdxTensor::from_dense(vec![i.clone(), k.clone()], vec![1.0, 2.0, 3.0, 4.0])?;
+/// let b = IdxTensor::from_dense(vec![k, j.clone()], vec![5.0, 6.0, 7.0, 8.0])?;
+/// let c = IdxTensor::from_dense(vec![j], vec![1.0, 2.0])?;
+/// let plan = PreparedContraction::new(&[&a, &b, &c], ContractionOptions::new())?;
+/// let result = plan.execute(&[&a, &b, &c])?;
+/// assert_eq!(result.indices(), &[i]);
+/// assert_eq!(result.to_vec::<f64>()?, vec![85.0, 126.0]);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Clone)]
+pub struct PreparedContraction {
+    expected_indices: Vec<Vec<DynIndex>>,
+    expected_dims: Vec<Vec<usize>>,
+    expected_axis_classes: Vec<Vec<usize>>,
+    plan: ContractionPlan,
+    has_retained_indices: bool,
+}
+
+impl std::fmt::Debug for PreparedContraction {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PreparedContraction")
+            .field("operand_count", &self.expected_indices.len())
+            .field("result_rank", &self.plan.result_indices.len())
+            .field("has_retained_indices", &self.has_retained_indices)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PreparedContraction {
+    /// Prepare index matching, label assignment, and result ordering.
+    ///
+    /// # Arguments
+    ///
+    /// * `tensors` - Representative operands whose ordered index metadata defines
+    ///   the execution contract.
+    /// * `options` - Retained indices to preserve in every execution result.
+    ///
+    /// # Returns
+    ///
+    /// An immutable caller-owned plan reusable with compatible operands.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdxTensorError`] when no operands are supplied, retained indices
+    /// are absent, the index relationships do not form the requested connected
+    /// network, or the result would contain duplicate output indices.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{ContractionOptions, DynIndex, IdxTensor, PreparedContraction};
+    ///
+    /// let shared = DynIndex::new_dyn(2);
+    /// let a = IdxTensor::from_dense(vec![shared.clone()], vec![1.0, 2.0])?;
+    /// let b = IdxTensor::from_dense(vec![shared], vec![3.0, 4.0])?;
+    /// let plan = PreparedContraction::new(&[&a, &b], ContractionOptions::new())?;
+    /// assert_eq!(plan.execute(&[&a, &b])?.to_vec::<f64>()?, vec![11.0]);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn new(
+        tensors: &[&IdxTensor],
+        options: ContractionOptions<'_>,
+    ) -> std::result::Result<Self, IdxTensorError> {
+        Self::new_impl(tensors, options).map_err(IdxTensorError::from)
+    }
+
+    fn new_impl(tensors: &[&IdxTensor], options: ContractionOptions<'_>) -> Result<Self> {
+        if tensors.is_empty() {
+            return Err(anyhow::anyhow!("No tensors to contract"));
+        }
+        validate_retained_indices_exist(tensors, options.retain_indices)?;
+        if tensors.len() > 1 {
+            let components =
+                find_tensor_connected_components_with_retained(tensors, options.retain_indices);
+            if components.len() > 1 {
+                return Err(anyhow::anyhow!(
+                    "Disconnected tensor network: {} components found",
+                    components.len()
+                ));
+            }
+        }
+        let plan = build_contraction_plan(tensors, options)?;
+        Ok(Self {
+            expected_indices: tensors
+                .iter()
+                .map(|tensor| tensor.indices().to_vec())
+                .collect(),
+            expected_dims: tensors.iter().map(|tensor| tensor.dims()).collect(),
+            expected_axis_classes: tensors
+                .iter()
+                .map(|tensor| tensor.axis_classes().to_vec())
+                .collect(),
+            plan,
+            has_retained_indices: !options.retain_indices.is_empty(),
+        })
+    }
+
+    /// Execute this plan with compatible operands.
+    ///
+    /// Operand values, dtypes, and gradient state may differ from preparation;
+    /// ordered full indices, dimensions, and axis classes must match exactly.
+    ///
+    /// # Returns
+    ///
+    /// The contracted tensor in the result-index order fixed at preparation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdxTensorError::ShapeMismatch`] before backend execution when
+    /// operand count, indices, dimensions, or axis classes differ. Storage,
+    /// dtype-promotion, AD, or backend execution failures retain their ordinary
+    /// [`IdxTensorError`] diagnostics.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{ContractionOptions, DynIndex, IdxTensor, PreparedContraction};
+    ///
+    /// let shared = DynIndex::new_dyn(2);
+    /// let a = IdxTensor::from_dense(vec![shared.clone()], vec![1.0, 2.0])?;
+    /// let b = IdxTensor::from_dense(vec![shared.clone()], vec![3.0, 4.0])?;
+    /// let plan = PreparedContraction::new(&[&a, &b], ContractionOptions::new())?;
+    /// let updated = IdxTensor::from_dense(vec![shared], vec![5.0, 6.0])?;
+    /// assert_eq!(plan.execute(&[&a, &updated])?.to_vec::<f64>()?, vec![17.0]);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn execute(
+        &self,
+        tensors: &[&IdxTensor],
+    ) -> std::result::Result<IdxTensor, IdxTensorError> {
+        self.validate_operands(tensors)?;
+        self.execute_impl(tensors).map_err(IdxTensorError::from)
+    }
+
+    fn validate_operands(&self, tensors: &[&IdxTensor]) -> std::result::Result<(), IdxTensorError> {
+        if tensors.len() != self.expected_indices.len() {
+            return Err(IdxTensorError::ShapeMismatch {
+                operation: "prepared contraction",
+                expected: format!("{} operands", self.expected_indices.len()),
+                actual: format!("{} operands", tensors.len()),
+            });
+        }
+        for (operand, tensor) in tensors.iter().enumerate() {
+            let dims = tensor.dims();
+            if dims != self.expected_dims[operand] {
+                return Err(IdxTensorError::ShapeMismatch {
+                    operation: "prepared contraction",
+                    expected: format!(
+                        "operand {operand} dimensions {:?}",
+                        self.expected_dims[operand]
+                    ),
+                    actual: format!("operand {operand} dimensions {dims:?}"),
+                });
+            }
+            if tensor.indices() != self.expected_indices[operand] {
+                return Err(IdxTensorError::ShapeMismatch {
+                    operation: "prepared contraction",
+                    expected: format!(
+                        "operand {operand} indices {:?}",
+                        self.expected_indices[operand]
+                    ),
+                    actual: format!("operand {operand} indices {:?}", tensor.indices()),
+                });
+            }
+            if tensor.axis_classes() != self.expected_axis_classes[operand] {
+                return Err(IdxTensorError::ShapeMismatch {
+                    operation: "prepared contraction",
+                    expected: format!(
+                        "operand {operand} axis classes {:?}",
+                        self.expected_axis_classes[operand]
+                    ),
+                    actual: format!("operand {operand} axis classes {:?}", tensor.axis_classes()),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn execute_impl(&self, tensors: &[&IdxTensor]) -> Result<IdxTensor> {
+        if tensors.len() == 1 {
+            return Ok((*tensors[0]).clone());
+        }
+        if tensors.len() == 2 && !self.has_retained_indices {
+            return tensors[0].try_contract_pairwise_default_with_options(
+                tensors[1],
+                PairwiseContractionOptions::new(),
+            );
+        }
+        let has_structured_storage = tensors
+            .iter()
+            .map(|tensor| has_dense_axis_classes(tensor).map(|dense| !dense))
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .any(|structured| structured);
+        let has_grad = tensors.iter().any(|tensor| tensor.tracks_grad());
+        if has_structured_storage || has_grad {
+            return IdxTensor::contract_structured_payloads_nary(
+                tensors,
+                self.plan.result_indices.clone(),
+                self.plan.input_ids.clone(),
+                self.plan.output_ids.clone(),
+            );
+        }
+        execute_contraction_plan(tensors, &self.plan, self.has_retained_indices)
     }
 }
 
@@ -547,6 +770,13 @@ fn contract_with_options_impl(
                     "Disconnected tensor network: {} components found",
                     components.len()
                 ));
+            }
+
+            if tensors.len() == 2 && options.retain_indices.is_empty() {
+                return tensors[0].try_contract_pairwise_default_with_options(
+                    tensors[1],
+                    PairwiseContractionOptions::new(),
+                );
             }
 
             let has_structured_storage = tensors

--- a/crates/tensor4all-core/src/defaults/contract.rs
+++ b/crates/tensor4all-core/src/defaults/contract.rs
@@ -10,7 +10,7 @@
 //!
 //! - [`contract`]: Contracts one connected tensor network
 //! - [`contract_with_options`]: Contracts one connected tensor network with retained indices
-//! - [`PreparedContraction`]: Reuses index matching and labels for compatible repeated calls
+//! - [`PreparedContraction`]: Reuses N-ary or retained-call labels for compatible repeated calls
 //!
 //! # Structured Tensor Handling
 //!
@@ -178,7 +178,10 @@ impl Default for ContractionOptions<'_> {
 ///
 /// Prepare this once when repeated operands keep the same ordered indices,
 /// dimensions, and axis classes but their values, dtypes, or gradient state may
-/// change. Fresh index identities require a fresh plan.
+/// change. Planning reuse applies to N-ary or retained-index execution. A binary
+/// call without retained indices preserves the faster pairwise path and does not
+/// consume the stored N-ary labels; use [`contract_pair`] directly for that case.
+/// Fresh index identities require a fresh plan.
 ///
 /// # Examples
 ///
@@ -241,11 +244,16 @@ impl PreparedContraction {
     /// ```
     /// use tensor4all_core::{ContractionOptions, DynIndex, IdxTensor, PreparedContraction};
     ///
-    /// let shared = DynIndex::new_dyn(2);
-    /// let a = IdxTensor::from_dense(vec![shared.clone()], vec![1.0, 2.0])?;
-    /// let b = IdxTensor::from_dense(vec![shared], vec![3.0, 4.0])?;
-    /// let plan = PreparedContraction::new(&[&a, &b], ContractionOptions::new())?;
-    /// assert_eq!(plan.execute(&[&a, &b])?.to_vec::<f64>()?, vec![11.0]);
+    /// let left = DynIndex::new_dyn(2);
+    /// let right = DynIndex::new_dyn(2);
+    /// let a = IdxTensor::from_dense(vec![left.clone()], vec![1.0, 2.0])?;
+    /// let b = IdxTensor::from_dense(
+    ///     vec![left, right.clone()],
+    ///     vec![3.0, 0.0, 0.0, 4.0],
+    /// )?;
+    /// let c = IdxTensor::from_dense(vec![right], vec![5.0, 6.0])?;
+    /// let plan = PreparedContraction::new(&[&a, &b, &c], ContractionOptions::new())?;
+    /// assert_eq!(plan.execute(&[&a, &b, &c])?.to_vec::<f64>()?, vec![63.0]);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn new(
@@ -307,12 +315,17 @@ impl PreparedContraction {
     /// ```
     /// use tensor4all_core::{ContractionOptions, DynIndex, IdxTensor, PreparedContraction};
     ///
-    /// let shared = DynIndex::new_dyn(2);
-    /// let a = IdxTensor::from_dense(vec![shared.clone()], vec![1.0, 2.0])?;
-    /// let b = IdxTensor::from_dense(vec![shared.clone()], vec![3.0, 4.0])?;
-    /// let plan = PreparedContraction::new(&[&a, &b], ContractionOptions::new())?;
-    /// let updated = IdxTensor::from_dense(vec![shared], vec![5.0, 6.0])?;
-    /// assert_eq!(plan.execute(&[&a, &updated])?.to_vec::<f64>()?, vec![17.0]);
+    /// let left = DynIndex::new_dyn(2);
+    /// let right = DynIndex::new_dyn(2);
+    /// let a = IdxTensor::from_dense(vec![left.clone()], vec![1.0, 2.0])?;
+    /// let b = IdxTensor::from_dense(
+    ///     vec![left, right.clone()],
+    ///     vec![3.0, 0.0, 0.0, 4.0],
+    /// )?;
+    /// let c = IdxTensor::from_dense(vec![right.clone()], vec![5.0, 6.0])?;
+    /// let plan = PreparedContraction::new(&[&a, &b, &c], ContractionOptions::new())?;
+    /// let updated = IdxTensor::from_dense(vec![right], vec![1.0, 1.0])?;
+    /// assert_eq!(plan.execute(&[&a, &b, &updated])?.to_vec::<f64>()?, vec![11.0]);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn execute(
@@ -500,8 +513,8 @@ impl PairwiseContractionOptions {
 /// # Errors
 ///
 /// Returns an error when the network is disconnected (a disconnected-network
-/// /// failure), when indices are incompatible (a shape or index mismatch), or
-/// /// when the contraction reports a failure (a backend failure).
+/// failure), when indices are incompatible (a shape or index mismatch), or
+/// when the contraction reports a failure (a backend failure).
 ///
 pub fn contract(tensors: &[&IdxTensor]) -> std::result::Result<IdxTensor, IdxTensorError> {
     contract_with_options(tensors, ContractionOptions::new())
@@ -511,8 +524,8 @@ pub fn contract(tensors: &[&IdxTensor]) -> std::result::Result<IdxTensor, IdxTen
 /// # Errors
 ///
 /// Returns an error when the network is disconnected (a disconnected-network
-/// /// failure), when indices are incompatible (a shape or index mismatch), or
-/// /// when the contraction reports a failure (a backend failure).
+/// failure), when indices are incompatible (a shape or index mismatch), or
+/// when the contraction reports a failure (a backend failure).
 ///
 pub fn contract_with_options(
     tensors: &[&IdxTensor],
@@ -525,8 +538,8 @@ pub fn contract_with_options(
 /// # Errors
 ///
 /// Returns an error when the network is disconnected (a disconnected-network
-/// /// failure), when indices are incompatible (a shape or index mismatch), or
-/// /// when the contraction reports a failure (a backend failure).
+/// failure), when indices are incompatible (a shape or index mismatch), or
+/// when the contraction reports a failure (a backend failure).
 ///
 pub fn contract_owned(tensors: Vec<IdxTensor>) -> std::result::Result<IdxTensor, IdxTensorError> {
     contract_owned_with_options(tensors, ContractionOptions::new())
@@ -536,8 +549,8 @@ pub fn contract_owned(tensors: Vec<IdxTensor>) -> std::result::Result<IdxTensor,
 /// # Errors
 ///
 /// Returns an error when the network is disconnected (a disconnected-network
-/// /// failure), when indices are incompatible (a shape or index mismatch), or
-/// /// when the contraction reports a failure (a backend failure).
+/// failure), when indices are incompatible (a shape or index mismatch), or
+/// when the contraction reports a failure (a backend failure).
 ///
 pub fn contract_owned_with_options(
     tensors: Vec<IdxTensor>,
@@ -563,8 +576,8 @@ pub fn contract_owned_with_options(
 /// # Errors
 ///
 /// Returns an error when the pair is disconnected or has incompatible indices
-/// /// (a shape or index mismatch), or when the contraction reports a failure (a
-/// /// backend failure).
+/// (a shape or index mismatch), or when the contraction reports a failure (a
+/// backend failure).
 ///
 pub fn contract_pair(
     lhs: &IdxTensor,
@@ -584,8 +597,8 @@ pub fn contract_pair(
 /// # Errors
 ///
 /// Returns an error when the pair is disconnected or has incompatible indices
-/// /// (a shape or index mismatch), or when the contraction reports a failure (a
-/// /// backend failure).
+/// (a shape or index mismatch), or when the contraction reports a failure (a
+/// backend failure).
 ///
 /// # Examples
 ///
@@ -628,8 +641,8 @@ pub fn contract_pair_with_operand_options(
 /// # Errors
 ///
 /// Returns an error when the pair is disconnected or has incompatible indices
-/// /// (a shape or index mismatch), or when the contraction reports a failure (a
-/// /// backend failure).
+/// (a shape or index mismatch), or when the contraction reports a failure (a
+/// backend failure).
 ///
 pub fn contract_pair_with_options(
     lhs: &IdxTensor,
@@ -643,7 +656,7 @@ pub fn contract_pair_with_options(
 /// # Errors
 ///
 /// Returns an error when the contracted indices are incompatible (a shape or
-/// /// index mismatch) or the contraction reports a failure (a backend failure).
+/// index mismatch) or the contraction reports a failure (a backend failure).
 ///
 pub fn tensordot(
     lhs: &IdxTensor,
@@ -661,8 +674,8 @@ pub fn tensordot(
 /// # Errors
 ///
 /// Returns an error when the two tensors share contractable indices (a
-/// /// shared-index mismatch) or the construction reports a failure (a backend
-/// /// failure).
+/// shared-index mismatch) or the construction reports a failure (a backend
+/// failure).
 ///
 pub fn outer_product(
     lhs: &IdxTensor,

--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -135,7 +135,7 @@ pub use defaults::contract::{
     contract, contract_owned, contract_owned_with_options, contract_pair,
     contract_pair_with_operand_options, contract_pair_with_options, contract_with_options,
     outer_product, print_and_reset_contract_profile, reset_contract_profile, tensordot,
-    ContractionOptions, PairwiseContractionOptions,
+    ContractionOptions, PairwiseContractionOptions, PreparedContraction,
 };
 pub use defaults::idx_tensor::{
     print_and_reset_pairwise_contract_profile, reset_pairwise_contract_profile,

--- a/crates/tensor4all-core/tests/bench_contract_fit_patterns.rs
+++ b/crates/tensor4all-core/tests/bench_contract_fit_patterns.rs
@@ -1,7 +1,9 @@
 use std::hint::black_box;
 use std::time::{Duration, Instant};
 
-use tensor4all_core::{DynIndex, IdxTensor, TensorContractionLike};
+use tensor4all_core::{
+    ContractionOptions, DynIndex, IdxTensor, PreparedContraction, TensorContractionLike,
+};
 use tensor4all_tensorbackend::{dense_native_tensor_from_col_major, einsum_native_tensors};
 
 fn make_data(dims: &[usize], offset: usize) -> Vec<f64> {
@@ -216,8 +218,19 @@ fn bench_contract_fit_patterns_vs_native() {
     let env6_f_native = dense_native_tensor_from_col_major(&env6_f_data, &env6_f_dims).unwrap();
 
     eprintln!("\n=== IdxTensor contract vs native einsum ===");
+    let env3_plan =
+        PreparedContraction::new(&[&env3_a, &env3_b, &env3_c], ContractionOptions::new()).unwrap();
+    let env3_expected =
+        <IdxTensor as TensorContractionLike>::contract(&[&env3_a, &env3_b, &env3_c]).unwrap();
+    let env3_prepared_result = env3_plan.execute(&[&env3_a, &env3_b, &env3_c]).unwrap();
+    assert!(env3_prepared_result
+        .isapprox(&env3_expected, 1.0e-12, 0.0)
+        .unwrap());
     let env3_contract = time_best_of("env3 IdxTensor::contract", 2_000, || {
         <IdxTensor as TensorContractionLike>::contract(&[&env3_a, &env3_b, &env3_c]).unwrap()
+    });
+    let env3_prepared = time_best_of("env3 PreparedContraction", 2_000, || {
+        env3_plan.execute(&[&env3_a, &env3_b, &env3_c]).unwrap()
     });
     let env3_native = time_best_of("env3 native einsum", 2_000, || {
         einsum_native_tensors(
@@ -268,6 +281,10 @@ fn bench_contract_fit_patterns_vs_native() {
         .unwrap()
     });
 
+    eprintln!(
+        "  ratio env3 IdxTensor/prepared     = {:.2}x",
+        env3_contract.as_secs_f64() / env3_prepared.as_secs_f64()
+    );
     eprintln!(
         "  ratio env3 IdxTensor/native       = {:.2}x",
         env3_contract.as_secs_f64() / env3_native.as_secs_f64()

--- a/crates/tensor4all-core/tests/prepared_contraction.rs
+++ b/crates/tensor4all-core/tests/prepared_contraction.rs
@@ -1,0 +1,241 @@
+use tensor4all_core::{
+    contract, ContractionOptions, DynId, DynIndex, IdxTensor, IdxTensorError, Index,
+    PreparedContraction, TagSet,
+};
+use tensor4all_tensorbackend::StorageKind;
+
+fn dense(indices: Vec<DynIndex>, values: Vec<f64>) -> IdxTensor {
+    IdxTensor::from_dense(indices, values).unwrap()
+}
+
+fn three_operand_fixture() -> (Vec<DynIndex>, Vec<IdxTensor>) {
+    let i = DynIndex::new_dyn(2);
+    let j = DynIndex::new_dyn(2);
+    let k = DynIndex::new_dyn(2);
+    let a = dense(vec![i.clone(), k.clone()], vec![1.0, 2.0, 3.0, 4.0]);
+    let b = dense(vec![k.clone(), j.clone()], vec![5.0, 6.0, 7.0, 8.0]);
+    let c = dense(vec![j.clone()], vec![1.0, 2.0]);
+    (vec![i, j, k], vec![a, b, c])
+}
+
+#[test]
+fn prepared_dense_nary_matches_ordinary_for_new_values_and_mixed_dtype() {
+    let (indices, tensors) = three_operand_fixture();
+    let plan = PreparedContraction::new(
+        &[&tensors[0], &tensors[1], &tensors[2]],
+        ContractionOptions::new(),
+    )
+    .unwrap();
+    let a = IdxTensor::from_dense(
+        vec![indices[0].clone(), indices[2].clone()],
+        vec![1.0_f32, 3.0, 2.0, 4.0],
+    )
+    .unwrap();
+    let b = dense(
+        vec![indices[2].clone(), indices[1].clone()],
+        vec![2.0, 0.0, 1.0, 3.0],
+    );
+    let c = dense(vec![indices[1].clone()], vec![4.0, 5.0]);
+
+    let prepared = plan.execute(&[&a, &b, &c]).unwrap();
+    let ordinary = contract(&[&a, &b, &c]).unwrap();
+    assert!(prepared.isapprox(&ordinary, 1.0e-12, 0.0).unwrap());
+}
+
+#[test]
+fn prepared_retained_contraction_preserves_output_order_and_values() {
+    let batch = DynIndex::new_dyn(2);
+    let left = DynIndex::new_dyn(2);
+    let contracted = DynIndex::new_dyn(3);
+    let right = DynIndex::new_dyn(2);
+    let a = dense(
+        vec![batch.clone(), left.clone(), contracted.clone()],
+        (1..=12).map(f64::from).collect(),
+    );
+    let b = dense(
+        vec![batch.clone(), contracted, right.clone()],
+        (1..=12).map(|value| f64::from(value) / 2.0).collect(),
+    );
+    let retained = [batch.clone()];
+    let options = ContractionOptions::new().with_retain_indices(&retained);
+    let plan = PreparedContraction::new(&[&a, &b], options).unwrap();
+
+    let prepared = plan.execute(&[&a, &b]).unwrap();
+    let ordinary = tensor4all_core::contract_with_options(&[&a, &b], options).unwrap();
+    assert_eq!(prepared.indices(), &[batch, left, right]);
+    assert_eq!(
+        prepared.to_vec::<f64>().unwrap(),
+        ordinary.to_vec::<f64>().unwrap()
+    );
+}
+
+#[test]
+fn prepared_structured_contraction_stays_compact() {
+    let i = DynIndex::new_dyn(3);
+    let j = DynIndex::new_dyn(3);
+    let k = DynIndex::new_dyn(3);
+    let output = DynIndex::new_dyn(3);
+    let a = IdxTensor::from_diag(vec![i.clone(), k.clone()], vec![1.0, 2.0, 3.0]).unwrap();
+    let b = IdxTensor::from_diag(vec![k, j.clone()], vec![4.0, 5.0, 6.0]).unwrap();
+    let c = IdxTensor::from_diag(vec![j, output.clone()], vec![1.0; 3]).unwrap();
+    let plan = PreparedContraction::new(&[&a, &b, &c], ContractionOptions::new()).unwrap();
+
+    let result = plan.execute(&[&a, &b, &c]).unwrap();
+    assert_eq!(result.indices(), &[i, output]);
+    assert_eq!(
+        result.storage().unwrap().storage_kind(),
+        StorageKind::Diagonal
+    );
+    assert_eq!(
+        result.to_vec::<f64>().unwrap(),
+        vec![4.0, 0.0, 0.0, 0.0, 10.0, 0.0, 0.0, 0.0, 18.0]
+    );
+}
+
+#[test]
+fn prepared_structured_contraction_supports_mixed_dtype() {
+    let i = DynIndex::new_dyn(2);
+    let k = DynIndex::new_dyn(2);
+    let j = DynIndex::new_dyn(2);
+    let prototype_a = IdxTensor::from_diag(vec![i.clone(), k.clone()], vec![0.0_f64; 2]).unwrap();
+    let b = IdxTensor::from_diag(vec![k.clone(), j.clone()], vec![3.0_f64, 4.0]).unwrap();
+    let plan = PreparedContraction::new(&[&prototype_a, &b], ContractionOptions::new()).unwrap();
+    let a = IdxTensor::from_diag(vec![i, k], vec![1.0_f32, 2.0]).unwrap();
+
+    let result = plan.execute(&[&a, &b]).unwrap();
+    assert_eq!(
+        result.storage().unwrap().storage_kind(),
+        StorageKind::Diagonal
+    );
+    assert_eq!(result.to_vec::<f64>().unwrap(), vec![3.0, 0.0, 0.0, 8.0]);
+}
+
+#[test]
+fn prepared_execution_preserves_gradients() {
+    let i = DynIndex::new_dyn(2);
+    let k = DynIndex::new_dyn(2);
+    let j = DynIndex::new_dyn(2);
+    let prototype_a = dense(vec![i.clone(), k.clone()], vec![0.0; 4]);
+    let prototype_b = dense(vec![k.clone(), j.clone()], vec![0.0; 4]);
+    let prototype_c = dense(vec![j.clone()], vec![0.0; 2]);
+    let plan = PreparedContraction::new(
+        &[&prototype_a, &prototype_b, &prototype_c],
+        ContractionOptions::new(),
+    )
+    .unwrap();
+    let a = dense(vec![i, k.clone()], vec![1.0, 2.0, 3.0, 4.0])
+        .enable_grad()
+        .unwrap();
+    let b = dense(vec![k, j.clone()], vec![1.0; 4]);
+    let c = dense(vec![j], vec![1.0; 2]);
+
+    plan.execute(&[&a, &b, &c])
+        .unwrap()
+        .sum()
+        .unwrap()
+        .backward()
+        .unwrap();
+    assert_eq!(
+        a.grad().unwrap().unwrap().to_vec::<f64>().unwrap(),
+        vec![2.0; 4]
+    );
+}
+
+#[test]
+fn prepared_structured_contraction_preserves_gradients() {
+    let i = DynIndex::new_dyn(2);
+    let k = DynIndex::new_dyn(2);
+    let j = DynIndex::new_dyn(2);
+    let output = DynIndex::new_dyn(2);
+    let prototype_a = IdxTensor::from_diag(vec![i.clone(), k.clone()], vec![0.0_f64; 2]).unwrap();
+    let b = IdxTensor::from_diag(vec![k.clone(), j.clone()], vec![3.0_f64, 4.0]).unwrap();
+    let c = IdxTensor::from_diag(vec![j, output], vec![5.0_f64, 6.0]).unwrap();
+    let plan =
+        PreparedContraction::new(&[&prototype_a, &b, &c], ContractionOptions::new()).unwrap();
+    let a = IdxTensor::from_diag(vec![i, k], vec![1.0_f64, 2.0])
+        .unwrap()
+        .enable_grad()
+        .unwrap();
+
+    plan.execute(&[&a, &b, &c])
+        .unwrap()
+        .sum()
+        .unwrap()
+        .backward()
+        .unwrap();
+    let gradient = a.grad().unwrap().unwrap();
+    assert_eq!(
+        gradient.storage().unwrap().storage_kind(),
+        StorageKind::Diagonal
+    );
+    assert_eq!(
+        gradient.to_vec::<f64>().unwrap(),
+        vec![15.0, 0.0, 0.0, 24.0]
+    );
+}
+
+#[test]
+fn prepared_execution_rejects_count_dimension_index_and_layout_mismatches() {
+    let shared = Index::new(DynId(700), 2);
+    let left = dense(vec![shared.clone()], vec![1.0, 2.0]);
+    let right = dense(vec![shared.clone()], vec![3.0, 4.0]);
+    let plan = PreparedContraction::new(&[&left, &right], ContractionOptions::new()).unwrap();
+
+    assert!(matches!(
+        plan.execute(&[&left]),
+        Err(IdxTensorError::ShapeMismatch { .. })
+    ));
+    assert!(matches!(
+        plan.execute(&[]),
+        Err(IdxTensorError::ShapeMismatch { .. })
+    ));
+
+    let different_dim = Index::new(DynId(700), 3);
+    let dimension_mismatch = dense(vec![different_dim], vec![1.0, 2.0, 3.0]);
+    assert!(matches!(
+        plan.execute(&[&dimension_mismatch, &right]),
+        Err(IdxTensorError::ShapeMismatch { .. })
+    ));
+
+    let primed = dense(vec![shared.prime()], vec![1.0, 2.0]);
+    assert!(matches!(
+        plan.execute(&[&primed, &right]),
+        Err(IdxTensorError::ShapeMismatch { .. })
+    ));
+
+    let tagged_index = Index::new_with_tags(
+        DynId(700),
+        2,
+        TagSet::from_str("prepared-mismatch").unwrap(),
+    );
+    let tagged = dense(vec![tagged_index], vec![1.0, 2.0]);
+    assert!(matches!(
+        plan.execute(&[&tagged, &right]),
+        Err(IdxTensorError::ShapeMismatch { .. })
+    ));
+
+    let diagonal =
+        IdxTensor::from_diag(vec![shared.clone(), shared.prime()], vec![1.0, 2.0]).unwrap();
+    let dense_layout = dense(diagonal.indices().to_vec(), vec![1.0, 0.0, 0.0, 2.0]);
+    let layout_plan = PreparedContraction::new(&[&diagonal], ContractionOptions::new()).unwrap();
+    assert!(matches!(
+        layout_plan.execute(&[&dense_layout]),
+        Err(IdxTensorError::ShapeMismatch { .. })
+    ));
+}
+
+#[test]
+fn prepared_contraction_rejects_empty_disconnected_and_missing_retained_inputs() {
+    assert!(PreparedContraction::new(&[], ContractionOptions::new()).is_err());
+
+    let a = dense(vec![DynIndex::new_dyn(2)], vec![1.0, 2.0]);
+    let b = dense(vec![DynIndex::new_dyn(2)], vec![3.0, 4.0]);
+    assert!(PreparedContraction::new(&[&a, &b], ContractionOptions::new()).is_err());
+
+    let missing = [DynIndex::new_dyn(2)];
+    assert!(PreparedContraction::new(
+        &[&a],
+        ContractionOptions::new().with_retain_indices(&missing),
+    )
+    .is_err());
+}

--- a/crates/tensor4all-itensorlike/src/options.rs
+++ b/crates/tensor4all-itensorlike/src/options.rs
@@ -205,7 +205,10 @@ impl ContractOptions {
         }
     }
 
-    /// Set the maximum retained bond dimension.
+    /// Set the upper bound on retained bond dimensions.
+    ///
+    /// Fixed-rank SRC may realize smaller bonds when a cut has less row-space
+    /// or opposite-side support than this bound.
     pub fn with_max_bond_dim(mut self, max_bond_dim: usize) -> Self {
         self.max_bond_dim = Some(max_bond_dim);
         self
@@ -280,7 +283,7 @@ impl ContractOptions {
         self.method
     }
 
-    /// Get the maximum retained bond dimension.
+    /// Get the upper bound on retained bond dimensions.
     #[inline]
     pub fn max_bond_dim(&self) -> Option<usize> {
         self.max_bond_dim

--- a/crates/tensor4all-treetn/examples/benchmark_src.rs
+++ b/crates/tensor4all-treetn/examples/benchmark_src.rs
@@ -6,6 +6,7 @@
 //! bond-dimension argument controls the MPO bond dimension and
 //! `T4A_BENCH_MPS_BOND_DIM` optionally sets a different MPS bond dimension.
 
+use std::mem::size_of;
 use std::time::Instant;
 
 use rand::rngs::StdRng;
@@ -16,8 +17,170 @@ use tensor4all_treetn::TreeTN;
 
 type Network = TreeTN<IdxTensor, String>;
 
+const DEFAULT_MAX_INPUT_BYTES: usize = 512 << 20;
+const DEFAULT_MAX_DENSE_BYTES: usize = 256 << 20;
+const BUILD_GIT_COMMIT: &str = match option_env!("T4A_BENCH_GIT_COMMIT") {
+    Some(commit) => commit,
+    None => "unknown",
+};
+
+#[derive(Debug, Clone, Copy)]
+struct MemoryEstimate {
+    total_input_bytes: usize,
+    largest_input_tensor_bytes: usize,
+    dense_output_bytes: usize,
+    max_degree: usize,
+}
+
+fn checked_mul(lhs: usize, rhs: usize, label: &str) -> usize {
+    lhs.checked_mul(rhs)
+        .unwrap_or_else(|| panic!("{label} overflow"))
+}
+
+fn checked_pow(mut base: usize, mut exponent: usize, label: &str) -> usize {
+    let mut result = 1usize;
+    while exponent > 0 {
+        if exponent % 2 == 1 {
+            result = checked_mul(result, base, label);
+        }
+        exponent /= 2;
+        if exponent > 0 {
+            base = checked_mul(base, base, label);
+        }
+    }
+    result
+}
+
+fn bytes(elements: usize, label: &str) -> usize {
+    checked_mul(elements, size_of::<f64>(), label)
+}
+
+fn env_bytes(name: &str, default: usize) -> usize {
+    std::env::var(name).map_or(default, |value| {
+        let parsed = value
+            .parse()
+            .unwrap_or_else(|_| panic!("{name} must be a positive byte count"));
+        assert!(parsed > 0, "{name} must be a positive byte count");
+        parsed
+    })
+}
+
+fn chain_elements(n_sites: usize, local_dim: usize, bond_dim: usize) -> (usize, usize) {
+    let endpoint = checked_mul(local_dim, bond_dim, "chain endpoint elements");
+    let interior = checked_mul(endpoint, bond_dim, "chain interior elements");
+    let total = checked_mul(2, endpoint, "chain endpoint total")
+        .checked_add(checked_mul(
+            n_sites.saturating_sub(2),
+            interior,
+            "chain interior total",
+        ))
+        .expect("chain input element count overflow");
+    (total, endpoint.max(interior))
+}
+
+fn binary_tree_degrees(n_nodes: usize) -> Vec<usize> {
+    let mut degrees = vec![0usize; n_nodes];
+    for child in 1..n_nodes {
+        let parent = (child - 1) / 2;
+        degrees[parent] += 1;
+        degrees[child] += 1;
+    }
+    degrees
+}
+
+fn estimate_memory(
+    mode: &str,
+    n_sites: usize,
+    physical_dim: usize,
+    bond_dim: usize,
+    mps_bond_dim: usize,
+) -> MemoryEstimate {
+    let physical_squared = checked_mul(physical_dim, physical_dim, "physical dimension");
+    let (input_elements, largest_input_elements, output_local_dim, max_degree) = match mode {
+        "mpo-mps" => {
+            let (mpo_total, mpo_largest) = chain_elements(n_sites, physical_squared, bond_dim);
+            let (mps_total, mps_largest) = chain_elements(n_sites, physical_dim, mps_bond_dim);
+            (
+                mpo_total
+                    .checked_add(mps_total)
+                    .expect("MPO-MPS input element count overflow"),
+                mpo_largest.max(mps_largest),
+                physical_dim,
+                2,
+            )
+        }
+        "mpo-mpo" => {
+            let (one_total, one_largest) = chain_elements(n_sites, physical_squared, bond_dim);
+            (
+                checked_mul(2, one_total, "MPO-MPO input elements"),
+                one_largest,
+                physical_squared,
+                2,
+            )
+        }
+        "tree" => {
+            let degrees = binary_tree_degrees(n_sites);
+            let mut one_total = 0usize;
+            let mut one_largest = 0usize;
+            for degree in degrees.iter().copied() {
+                let elements = checked_mul(
+                    physical_squared,
+                    checked_pow(bond_dim, degree, "tree bond product"),
+                    "tree tensor elements",
+                );
+                one_total = one_total
+                    .checked_add(elements)
+                    .expect("tree input element count overflow");
+                one_largest = one_largest.max(elements);
+            }
+            (
+                checked_mul(2, one_total, "tree pair input elements"),
+                one_largest,
+                physical_squared,
+                degrees.into_iter().max().unwrap_or(0),
+            )
+        }
+        _ => panic!("mode must be mpo-mps, mpo-mpo, both, or tree"),
+    };
+    MemoryEstimate {
+        total_input_bytes: bytes(input_elements, "total input bytes"),
+        largest_input_tensor_bytes: bytes(largest_input_elements, "largest input tensor bytes"),
+        dense_output_bytes: bytes(
+            checked_pow(output_local_dim, n_sites, "dense output elements"),
+            "dense output bytes",
+        ),
+        max_degree,
+    }
+}
+
+fn validate_memory(mode: &str, estimate: MemoryEstimate, exact: bool, network_seed: u64) {
+    let max_input_bytes = env_bytes("T4A_BENCH_MAX_INPUT_BYTES", DEFAULT_MAX_INPUT_BYTES);
+    let max_dense_bytes = env_bytes("T4A_BENCH_MAX_DENSE_BYTES", DEFAULT_MAX_DENSE_BYTES);
+    assert!(
+        estimate.total_input_bytes <= max_input_bytes,
+        "estimated input {} bytes exceeds T4A_BENCH_MAX_INPUT_BYTES={max_input_bytes}",
+        estimate.total_input_bytes
+    );
+    assert!(
+        !exact || estimate.dense_output_bytes <= max_dense_bytes,
+        "estimated dense oracle {} bytes exceeds T4A_BENCH_MAX_DENSE_BYTES={max_dense_bytes}",
+        estimate.dense_output_bytes
+    );
+    println!(
+        "record=preflight mode={mode} network_seed={network_seed} total_input_bytes={} largest_input_tensor_bytes={} dense_output_bytes={} max_degree={} max_input_bytes={max_input_bytes} max_dense_bytes={max_dense_bytes}",
+        estimate.total_input_bytes,
+        estimate.largest_input_tensor_bytes,
+        estimate.dense_output_bytes,
+        estimate.max_degree,
+    );
+}
+
 fn random_tensor(indices: Vec<DynIndex>, rng: &mut StdRng) -> IdxTensor {
-    let elements = indices.iter().map(IndexLike::dim).product();
+    let elements = indices
+        .iter()
+        .map(IndexLike::dim)
+        .try_fold(1usize, |size, dim| size.checked_mul(dim))
+        .expect("tensor element count was checked by benchmark preflight");
     let data = (0..elements)
         .map(|_| rng.random_range(-1.0_f64..1.0_f64))
         .collect();
@@ -134,60 +297,54 @@ fn make_mpo_mpo(
     )
 }
 
-fn make_star_pair(
-    n_leaves: usize,
+fn make_binary_tree_pair(
+    n_nodes: usize,
     physical_dim: usize,
     bond_dim: usize,
     seed: u64,
 ) -> (Network, Network) {
-    assert!(n_leaves >= 2);
+    assert!(n_nodes >= 3);
     let mut rng = StdRng::seed_from_u64(seed);
-    let shared = (0..n_leaves + 1)
+    let shared = (0..n_nodes)
         .map(|_| DynIndex::new_dyn(physical_dim))
         .collect::<Vec<_>>();
-    let outputs_a = (0..n_leaves + 1)
+    let outputs_a = (0..n_nodes)
         .map(|_| DynIndex::new_dyn(physical_dim))
         .collect::<Vec<_>>();
-    let outputs_b = (0..n_leaves + 1)
+    let outputs_b = (0..n_nodes)
         .map(|_| DynIndex::new_dyn(physical_dim))
         .collect::<Vec<_>>();
-    let bonds_a = (0..n_leaves)
+    let bonds_a = (1..n_nodes)
         .map(|_| DynIndex::new_dyn(bond_dim))
         .collect::<Vec<_>>();
-    let bonds_b = (0..n_leaves)
+    let bonds_b = (1..n_nodes)
         .map(|_| DynIndex::new_dyn(bond_dim))
         .collect::<Vec<_>>();
-    let names = std::iter::once("C".to_string())
-        .chain((0..n_leaves).map(|leaf| format!("L{leaf}")))
+    let names = (0..n_nodes)
+        .map(|node| format!("N{node:04}"))
         .collect::<Vec<_>>();
 
-    let mut center_a = vec![shared[0].clone(), outputs_a[0].clone()];
-    center_a.extend(bonds_a.iter().cloned());
-    let mut center_b = vec![shared[0].clone(), outputs_b[0].clone()];
-    center_b.extend(bonds_b.iter().cloned());
-    let mut tensors_a = vec![random_tensor(center_a, &mut rng)];
-    let mut tensors_b = vec![random_tensor(center_b, &mut rng)];
-    for leaf in 0..n_leaves {
-        tensors_a.push(random_tensor(
-            vec![
-                shared[leaf + 1].clone(),
-                outputs_a[leaf + 1].clone(),
-                bonds_a[leaf].clone(),
-            ],
-            &mut rng,
-        ));
-        tensors_b.push(random_tensor(
-            vec![
-                shared[leaf + 1].clone(),
-                outputs_b[leaf + 1].clone(),
-                bonds_b[leaf].clone(),
-            ],
-            &mut rng,
-        ));
-    }
+    let build_indices = |node: usize, outputs: &[DynIndex], bonds: &[DynIndex]| {
+        let mut indices = vec![shared[node].clone(), outputs[node].clone()];
+        if node > 0 {
+            indices.push(bonds[node - 1].clone());
+        }
+        for child in [2 * node + 1, 2 * node + 2] {
+            if child < n_nodes {
+                indices.push(bonds[child - 1].clone());
+            }
+        }
+        indices
+    };
+    let tensors_a = (0..n_nodes)
+        .map(|node| random_tensor(build_indices(node, &outputs_a, &bonds_a), &mut rng))
+        .collect();
+    let tensors_b = (0..n_nodes)
+        .map(|node| random_tensor(build_indices(node, &outputs_b, &bonds_b), &mut rng))
+        .collect();
     (
-        Network::from_tensors(tensors_a, names.clone()).expect("first star topology"),
-        Network::from_tensors(tensors_b, names).expect("second star topology"),
+        Network::from_tensors(tensors_a, names.clone()).expect("first binary-tree topology"),
+        Network::from_tensors(tensors_b, names).expect("second binary-tree topology"),
     )
 }
 
@@ -206,6 +363,7 @@ fn run_case(
     left: &Network,
     right: &Network,
     options: ContractionOptions,
+    requested_max_rank: usize,
     reps: usize,
     exact: Option<&IdxTensor>,
 ) {
@@ -218,6 +376,8 @@ fn run_case(
             .min()
             .expect("non-empty benchmark network")
     });
+    let warmup = contract(left, right, &center, options.clone()).expect("benchmark warm-up");
+    std::hint::black_box(warmup);
     let start = Instant::now();
     let mut result = None;
     for _ in 0..reps {
@@ -237,17 +397,33 @@ fn run_case(
         }
     });
     println!(
-        "case={label} reps={reps} elapsed={:.6}s per_run={:.6}s nodes={} edges={} max_bond={} relative_error={}",
+        "record=case name={label} reps={reps} elapsed_seconds={:.6} per_run_seconds={:.6} nodes={} edges={} requested_max_rank={requested_max_rank} effective_max_bond={} src_seed={} relative_error={}",
         elapsed.as_secs_f64(),
         elapsed.as_secs_f64() / reps as f64,
         result.node_count(),
         result.edge_count(),
         max_bond(&result),
+        options.src_options.seed,
         rel_error.map_or_else(|| "n/a".to_string(), |e| format!("{e:.3e}")),
     );
     tensor4all_core::print_and_reset_contract_profile();
     tensor4all_core::print_and_reset_native_einsum_profile();
     tensor4all_core::print_and_reset_pairwise_contract_profile();
+}
+
+fn enabled_features() -> String {
+    [
+        ("tenferro-cpu-faer", cfg!(feature = "tenferro-cpu-faer")),
+        (
+            "tenferro-provider-inject",
+            cfg!(feature = "tenferro-provider-inject"),
+        ),
+        ("tenferro-cuda", cfg!(feature = "tenferro-cuda")),
+    ]
+    .into_iter()
+    .filter_map(|(name, enabled)| enabled.then_some(name))
+    .collect::<Vec<_>>()
+    .join(",")
 }
 
 fn main() {
@@ -284,6 +460,16 @@ fn main() {
         value.parse().expect("target_rank")
     });
     let algorithm = std::env::var("T4A_BENCH_ALGORITHM").unwrap_or_else(|_| "all".to_string());
+    assert!(n_sites >= 2, "n_sites must be at least 2");
+    assert!(reps >= 1, "reps must be at least 1");
+    assert!(
+        mode != "tree" || n_sites >= 3,
+        "tree mode requires at least 3 nodes"
+    );
+    assert!(
+        matches!(mode.as_str(), "mpo-mps" | "mpo-mpo" | "both" | "tree"),
+        "mode must be mpo-mps, mpo-mpo, both, or tree"
+    );
     assert!(
         matches!(
             algorithm.as_str(),
@@ -292,11 +478,19 @@ fn main() {
         "T4A_BENCH_ALGORITHM must be all, zipup, src-fixed, or src-adaptive"
     );
 
-    println!(
-        "config=n_sites:{n_sites} physical_dim:{physical_dim} mpo_bond:{bond_dim} mps_bond:{mps_bond_dim} max_rank:{max_rank} reps:{reps} mode:{mode} algorithm:{algorithm} rank_increment:{rank_increment} final_svd:{final_svd}"
-    );
-
     let skip_exact = std::env::var("T4A_BENCH_SKIP_EXACT").is_ok();
+    let profile = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
+    println!(
+        "record=build git_commit={BUILD_GIT_COMMIT} profile={profile} backend=tenferro features={}",
+        enabled_features()
+    );
+    println!(
+        "record=config n_sites={n_sites} physical_dim={physical_dim} mpo_bond={bond_dim} mps_bond={mps_bond_dim} requested_max_rank={max_rank} reps={reps} mode={mode} algorithm={algorithm} rank_increment={rank_increment} final_svd={final_svd} src_seed=1234 adaptive_rtol=1e-4 adaptive_atol=0 adaptive_min_rank=2"
+    );
     let run = |label: &str, left: Network, right: Network| {
         let exact = if skip_exact {
             None
@@ -306,7 +500,7 @@ fn main() {
                 .contract_naive(&right)
                 .expect("benchmark naive exact contraction");
             println!(
-                "case={label}/naive-exact elapsed={:.6}s (reference only)",
+                "record=reference name={label}/naive-exact elapsed_seconds={:.6}",
                 start.elapsed().as_secs_f64()
             );
             Some(dense)
@@ -318,6 +512,7 @@ fn main() {
                 &left,
                 &right,
                 ContractionOptions::zipup().with_max_bond_dim(max_rank),
+                max_rank,
                 reps,
                 exact_ref,
             );
@@ -334,6 +529,7 @@ fn main() {
                             .with_seed(1234)
                             .with_final_svd(final_svd),
                     ),
+                max_rank,
                 reps,
                 exact_ref,
             );
@@ -352,6 +548,7 @@ fn main() {
                             .with_seed(1234)
                             .with_final_svd(final_svd),
                     ),
+                max_rank,
                 reps,
                 exact_ref,
             );
@@ -359,15 +556,63 @@ fn main() {
     };
 
     if mode == "mpo-mps" || mode == "both" {
+        validate_memory(
+            "mpo-mps",
+            estimate_memory("mpo-mps", n_sites, physical_dim, bond_dim, mps_bond_dim),
+            !skip_exact,
+            7,
+        );
         let (operator, state) = make_mpo_mps(n_sites, physical_dim, bond_dim, mps_bond_dim, 7);
         run("mpo-mps", operator, state);
     }
     if mode == "mpo-mpo" || mode == "both" {
+        validate_memory(
+            "mpo-mpo",
+            estimate_memory("mpo-mpo", n_sites, physical_dim, bond_dim, mps_bond_dim),
+            !skip_exact,
+            11,
+        );
         let (left, right) = make_mpo_mpo(n_sites, physical_dim, bond_dim, 11);
         run("mpo-mpo", left, right);
     }
     if mode == "tree" {
-        let (left, right) = make_star_pair(n_sites - 1, physical_dim, bond_dim, 13);
+        validate_memory(
+            "tree",
+            estimate_memory("tree", n_sites, physical_dim, bond_dim, mps_bond_dim),
+            !skip_exact,
+            13,
+        );
+        let (left, right) = make_binary_tree_pair(n_sites, physical_dim, bond_dim, 13);
         run("tree-mpo-mpo", left, right);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chain_memory_estimate_is_checked_and_exact() {
+        let estimate = estimate_memory("mpo-mps", 3, 2, 2, 2);
+        assert_eq!(estimate.total_input_bytes, 384);
+        assert_eq!(estimate.largest_input_tensor_bytes, 128);
+        assert_eq!(estimate.dense_output_bytes, 64);
+        assert_eq!(estimate.max_degree, 2);
+    }
+
+    #[test]
+    fn binary_tree_estimate_has_bounded_degree_and_core_size() {
+        let estimate = estimate_memory("tree", 7, 2, 4, 4);
+        assert_eq!(estimate.total_input_bytes, 10_240);
+        assert_eq!(estimate.largest_input_tensor_bytes, 2_048);
+        assert_eq!(estimate.dense_output_bytes, 131_072);
+        assert_eq!(estimate.max_degree, 3);
+        assert_eq!(binary_tree_degrees(15).into_iter().max(), Some(3));
+    }
+
+    #[test]
+    #[should_panic(expected = "dense output elements overflow")]
+    fn memory_estimate_rejects_dense_output_overflow() {
+        let _ = estimate_memory("mpo-mpo", usize::BITS as usize, 2, 2, 2);
     }
 }

--- a/crates/tensor4all-treetn/examples/benchmark_src.rs
+++ b/crates/tensor4all-treetn/examples/benchmark_src.rs
@@ -78,14 +78,14 @@ fn chain_elements(n_sites: usize, local_dim: usize, bond_dim: usize) -> (usize, 
     (total, endpoint.max(interior))
 }
 
-fn binary_tree_degrees(n_nodes: usize) -> Vec<usize> {
-    let mut degrees = vec![0usize; n_nodes];
-    for child in 1..n_nodes {
-        let parent = (child - 1) / 2;
-        degrees[parent] += 1;
-        degrees[child] += 1;
-    }
-    degrees
+fn binary_tree_shape_counts(n_nodes: usize) -> (usize, usize, usize, usize) {
+    assert!(n_nodes >= 3, "binary tree requires at least three nodes");
+    let two_child_nodes = (n_nodes - 1) / 2;
+    let nonroot_two_child_nodes = two_child_nodes - 1;
+    let one_child_nodes = usize::from(n_nodes.is_multiple_of(2));
+    let leaves = n_nodes - n_nodes / 2;
+    let max_degree = if nonroot_two_child_nodes > 0 { 3 } else { 2 };
+    (leaves, one_child_nodes, nonroot_two_child_nodes, max_degree)
 }
 
 fn estimate_memory(
@@ -119,25 +119,43 @@ fn estimate_memory(
             )
         }
         "tree" => {
-            let degrees = binary_tree_degrees(n_sites);
-            let mut one_total = 0usize;
-            let mut one_largest = 0usize;
-            for degree in degrees.iter().copied() {
-                let elements = checked_mul(
-                    physical_squared,
-                    checked_pow(bond_dim, degree, "tree bond product"),
-                    "tree tensor elements",
-                );
-                one_total = one_total
-                    .checked_add(elements)
-                    .expect("tree input element count overflow");
-                one_largest = one_largest.max(elements);
-            }
+            let (leaves, one_child, nonroot_two_child, max_degree) =
+                binary_tree_shape_counts(n_sites);
+            let degree_one = checked_mul(physical_squared, bond_dim, "tree leaf elements");
+            let degree_two = checked_mul(
+                physical_squared,
+                checked_pow(bond_dim, 2, "tree degree-two bond product"),
+                "tree degree-two elements",
+            );
+            let degree_three = checked_mul(
+                physical_squared,
+                checked_pow(bond_dim, 3, "tree degree-three bond product"),
+                "tree degree-three elements",
+            );
+            let one_total = checked_mul(leaves, degree_one, "tree leaf total")
+                .checked_add(checked_mul(
+                    one_child + 1,
+                    degree_two,
+                    "tree degree-two total",
+                ))
+                .and_then(|total| {
+                    total.checked_add(checked_mul(
+                        nonroot_two_child,
+                        degree_three,
+                        "tree degree-three total",
+                    ))
+                })
+                .expect("tree input element count overflow");
+            let one_largest = if max_degree == 3 {
+                degree_three
+            } else {
+                degree_two
+            };
             (
                 checked_mul(2, one_total, "tree pair input elements"),
                 one_largest,
                 physical_squared,
-                degrees.into_iter().max().unwrap_or(0),
+                max_degree,
             )
         }
         _ => panic!("mode must be mpo-mps, mpo-mpo, both, or tree"),
@@ -397,7 +415,7 @@ fn run_case(
         }
     });
     println!(
-        "record=case name={label} reps={reps} elapsed_seconds={:.6} per_run_seconds={:.6} nodes={} edges={} requested_max_rank={requested_max_rank} effective_max_bond={} src_seed={} relative_error={}",
+        "record=case name={label} reps={reps} elapsed_seconds={:.6} per_run_seconds={:.6} nodes={} edges={} requested_max_rank={requested_max_rank} effective_max_bond={} src_seed={} center={center} relative_error={}",
         elapsed.as_secs_f64(),
         elapsed.as_secs_f64() / reps as f64,
         result.node_count(),
@@ -607,7 +625,7 @@ mod tests {
         assert_eq!(estimate.largest_input_tensor_bytes, 2_048);
         assert_eq!(estimate.dense_output_bytes, 131_072);
         assert_eq!(estimate.max_degree, 3);
-        assert_eq!(binary_tree_degrees(15).into_iter().max(), Some(3));
+        assert_eq!(binary_tree_shape_counts(15).3, 3);
     }
 
     #[test]

--- a/crates/tensor4all-treetn/src/treetn/contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction.rs
@@ -148,7 +148,7 @@ where
     /// # Errors
     ///
     /// Returns an error when the dense contraction fails (a shape or index
-    /// /// mismatch, or a backend failure).
+    /// mismatch, or a backend failure).
     ///
     /// # Examples
     ///
@@ -311,7 +311,7 @@ where
     /// # Errors
     ///
     /// Returns an error when the zip-up contraction fails (a shape or index
-    /// /// mismatch, or a backend failure).
+    /// mismatch, or a backend failure).
     ///
     pub fn contract_zipup(
         &self,
@@ -354,7 +354,7 @@ where
     /// # Errors
     ///
     /// Returns an error when the zip-up contraction fails (a shape or index
-    /// /// mismatch, or a backend failure).
+    /// mismatch, or a backend failure).
     ///
     pub fn contract_zipup_with(
         &self,
@@ -1194,7 +1194,7 @@ where
     /// # Errors
     ///
     /// Returns an error when the naive contraction fails (a shape or index
-    /// /// mismatch, or a backend failure).
+    /// mismatch, or a backend failure).
     ///
     pub fn contract_naive(&self, other: &Self) -> std::result::Result<T, TreeTNOperationError>
     where
@@ -1242,7 +1242,7 @@ where
     /// # Errors
     ///
     /// Returns an error when the orthogonality structure is inconsistent (an
-    /// /// graph consistency failure).
+    /// graph consistency failure).
     ///
     pub fn validate_ortho_consistency(&self) -> std::result::Result<(), TreeTNOperationError> {
         // If not canonicalized, require no ortho_towards at all

--- a/crates/tensor4all-treetn/src/treetn/contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction.rs
@@ -1423,9 +1423,11 @@ pub enum ContractionMethod {
 /// Options specific to successive randomized compression (SRC).
 ///
 /// `rtol = None` selects fixed-rank mode; fixed-rank SRC requires
-/// [`ContractionOptions::with_max_bond_dim`] to provide the requested output
-/// rank. `rtol = Some(_)` selects adaptive mode and requires a finite maximum
-/// rank, supplied either by [`Self::max_rank`] or by the contraction's
+/// [`ContractionOptions::with_max_bond_dim`] to provide an upper bound for the
+/// output rank. Each cut clamps that bound to its local row dimension and
+/// opposite-side support, so a realized bond may be smaller than requested.
+/// `rtol = Some(_)` selects adaptive mode and requires a finite maximum rank,
+/// supplied either by [`Self::max_rank`] or by the contraction's
 /// `max_bond_dim`.
 ///
 /// # Examples
@@ -1714,7 +1716,8 @@ impl SrcOptions {
 pub struct ContractionOptions {
     /// Contraction method to use.
     pub method: ContractionMethod,
-    /// Maximum bond dimension (optional).
+    /// Upper bound on the bond dimension. SRC additionally clamps this bound
+    /// at each cut to the local row dimension and opposite-side support.
     pub max_bond_dim: Option<usize>,
     /// Explicit SVD truncation policy (optional).
     pub svd_policy: Option<SvdTruncationPolicy>,
@@ -1814,7 +1817,10 @@ impl ContractionOptions {
         self
     }
 
-    /// Set maximum bond dimension.
+    /// Set the upper bound on bond dimensions.
+    ///
+    /// Fixed-rank SRC may realize smaller bonds when a cut has less row-space
+    /// or opposite-side support than this bound.
     pub fn with_max_bond_dim(mut self, max_bond_dim: usize) -> Self {
         self.max_bond_dim = Some(max_bond_dim);
         self

--- a/crates/tensor4all-treetn/src/treetn/contraction/src_chain.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction/src_chain.rs
@@ -372,8 +372,7 @@ where
         .map_err(|error| {
             anyhow::anyhow!("contract_src: site {site} prefix contraction failed: {error}")
         })?;
-        let sketch = prefix_local
-            .contract_pair(&right_environment)
+        let sketch = T::contract(&[&prefix_local, &right_environment])
             .map_err(|error| anyhow::anyhow!("contract_src: site {site} sketch failed: {error}"))?;
         let (factor, cap) = factorize_fixed_batch(&sketch, &left_indices, &format!("site {site}"))?;
         let factor_conj = factor.conj();

--- a/crates/tensor4all-treetn/src/treetn/contraction/src_probe.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction/src_probe.rs
@@ -253,7 +253,7 @@ where
     let (a_probes, b_probes) = partition_probes(tensor_a, tensor_b, outputs, &probe_tensors)?;
     let probed_a = contract_operand_with_probes(tensor_a, &a_probes, None)?;
     let probed_b = contract_operand_with_probes(tensor_b, &b_probes, None)?;
-    probed_a.contract_pair(&probed_b).map_err(|error| {
+    T::contract(&[&probed_a, &probed_b]).map_err(|error| {
         anyhow::anyhow!("contract_src: factorized probe contraction failed: {error}")
     })
 }
@@ -280,7 +280,7 @@ where
         );
     }
     if outputs.is_empty() {
-        let local = tensor_a.contract_pair(tensor_b).map_err(|error| {
+        let local = T::contract(&[tensor_a, tensor_b]).map_err(|error| {
             anyhow::anyhow!("contract_src: scalar local pair contraction failed: {error}")
         })?;
         let batch_values = T::ones(std::slice::from_ref(batch)).map_err(|error| {
@@ -308,11 +308,9 @@ pub(super) fn contract_prefix_with_site_pair<T>(prefix: &T, tensor_a: &T, tensor
 where
     T: TensorLike,
 {
-    let after_a = prefix
-        .contract_pair(tensor_a)
+    let after_a = T::contract(&[prefix, tensor_a])
         .map_err(|error| anyhow::anyhow!("contract_src: prefix-A contraction failed: {error}"))?;
-    after_a
-        .contract_pair(tensor_b)
+    T::contract(&[&after_a, tensor_b])
         .map_err(|error| anyhow::anyhow!("contract_src: prefix-B contraction failed: {error}"))
 }
 
@@ -338,12 +336,10 @@ where
         .map(|index| single_probe::<T, R>(index, probes, column))
         .collect::<Result<Vec<_>>>()?;
     let (a_probes, b_probes) = partition_probes(tensor_a, tensor_b, outputs, &probe_tensors)?;
-    let mut result = prefix
-        .contract_pair(tensor_a)
+    let mut result = T::contract(&[prefix, tensor_a])
         .map_err(|error| anyhow::anyhow!("contract_src: prefix-A contraction failed: {error}"))?;
     result = contract_operand_with_probes(&result, &a_probes, None)?;
-    result = result
-        .contract_pair(tensor_b)
+    result = T::contract(&[&result, tensor_b])
         .map_err(|error| anyhow::anyhow!("contract_src: prefix-B contraction failed: {error}"))?;
     contract_operand_with_probes(&result, &b_probes, None)
 }
@@ -1082,9 +1078,14 @@ mod tests {
     }
 
     #[test]
-    fn maximum_probe_width_respects_the_exact_product_cut_dimension() {
+    fn maximum_probe_width_respects_rank_row_and_cut_bounds() {
         let fixed = SrcOptions::fixed();
-        assert_eq!(maximum_site_width(4096, 1024, 256, &fixed), 256);
+        assert_eq!(maximum_site_width(8, 16, 12, &fixed), 8);
+        assert_eq!(maximum_site_width(12, 16, 12, &fixed), 12);
+        assert_eq!(maximum_site_width(32, 16, 12, &fixed), 12);
+
+        let oversampled = SrcOptions::fixed().with_final_svd(true);
+        assert_eq!(maximum_site_width(8, 16, 12, &oversampled), 12);
 
         let adaptive = SrcOptions::adaptive(1.0e-6, 4096);
         assert_eq!(maximum_site_width(4096, 1024, 256, &adaptive), 256);

--- a/crates/tensor4all-treetn/src/treetn/contraction/src_tree.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction/src_tree.rs
@@ -408,7 +408,14 @@ where
     /// per-edge environment tensors, without ever materializing a
     /// per-column (`width == 1`) representation.
     fn grow_segment(&mut self, start: usize, width: usize) -> Result<()> {
-        self.probes.extend_to(start + width)?;
+        let end = start
+            .checked_add(width)
+            .ok_or_else(|| anyhow::anyhow!("contract_src: tree segment range overflows"))?;
+        self.probes.extend_to(end)?;
+        let next_total_width = self
+            .segment_total_width
+            .checked_add(width)
+            .ok_or_else(|| anyhow::anyhow!("contract_src: tree cached width overflows"))?;
         let batch = T::Index::new_link(width)?;
         let probe_batches = self
             .nodes
@@ -437,7 +444,7 @@ where
             &batch,
         )?;
         self.segments.push((start, width, batch, directed));
-        self.segment_total_width += width;
+        self.segment_total_width = next_total_width;
         Ok(())
     }
 
@@ -446,19 +453,12 @@ where
     ///
     /// `EnvironmentCache` is shared across every edge in the tree -- unlike
     /// `PrefixCache` (one instance per site), one `EnvironmentCache` serves
-    /// every edge's own `site_max_width`. Segments therefore grow on a fixed
-    /// `batch_size`-wide grid regardless of which edge's request triggers
-    /// growth first, so a later edge's request can still land on an earlier
-    /// edge's segment boundaries. The common case (the request aligns
-    /// exactly with one already-grown or newly-grown segment's boundaries)
-    /// returns that segment's environment directly, no
-    /// `select_indices`/`stack_along_new_index` at all. A request that only
-    /// partially overlaps a segment boundary (possible when an edge's own
-    /// `site_max_width` caps a segment at a width narrower than
-    /// `batch_size`) falls back to splitting and re-stacking the covering
-    /// segments' environments -- mirrors `PrefixCache::request`
-    /// (`src_chain.rs`) exactly, adapted for one `(parent, child)` map per
-    /// segment instead of one tensor per segment.
+    /// every edge's own `site_max_width`. Only the initial segment may be
+    /// narrower than `batch_size`; later growth computes a full segment so
+    /// requests remain aligned even when one edge caps an earlier request.
+    /// The common case returns one segment directly. A genuinely partial
+    /// overlap falls back to splitting and re-stacking the covering segments'
+    /// environments.
     fn request(
         &mut self,
         parent: &V,
@@ -466,10 +466,19 @@ where
         start: usize,
         width: usize,
     ) -> Result<(T, T::Index)> {
-        self.probes.extend_to(start + width)?;
-        while self.segment_total_width < start + width {
+        if width == 0 {
+            anyhow::bail!("contract_src: tree environment request must be non-empty");
+        }
+        let requested_end = start
+            .checked_add(width)
+            .ok_or_else(|| anyhow::anyhow!("contract_src: requested tree probe range overflows"))?;
+        while self.segment_total_width < requested_end {
             let next_start = self.segment_total_width;
-            let next_width = self.batch_size.min(start + width - next_start);
+            let next_width = if next_start == 0 {
+                self.batch_size.min(requested_end)
+            } else {
+                self.batch_size
+            };
             self.grow_segment(next_start, next_width)?;
         }
 
@@ -498,9 +507,11 @@ where
         let mut collected = Vec::with_capacity(width);
         for (segment_start, segment_width, batch_index, environments) in &self.segments {
             let segment_start = *segment_start;
-            let segment_end = segment_start + *segment_width;
+            let segment_end = segment_start
+                .checked_add(*segment_width)
+                .ok_or_else(|| anyhow::anyhow!("contract_src: cached tree segment overflows"))?;
             let overlap_start = segment_start.max(start);
-            let overlap_end = segment_end.min(start + width);
+            let overlap_end = segment_end.min(requested_end);
             if overlap_start >= overlap_end {
                 continue;
             }
@@ -529,10 +540,9 @@ where
         }
         anyhow::ensure!(
             collected.len() == width,
-            "contract_src: {:?}->{:?} misaligned segment request [{start}, {}) only found {} of {} columns",
+            "contract_src: {:?}->{:?} misaligned segment request [{start}, {requested_end}) only found {} of {} columns",
             parent,
             child,
-            start + width,
             collected.len(),
             width
         );
@@ -541,10 +551,9 @@ where
         let stacked = T::stack_along_new_index(&collected_refs, batch_index.clone(), -1)
             .map_err(|error| {
                 anyhow::anyhow!(
-                    "contract_src: {:?}->{:?} misaligned segment request [{start}, {}) failed: {error}",
+                    "contract_src: {:?}->{:?} misaligned segment request [{start}, {requested_end}) failed: {error}",
                     parent,
-                    child,
-                    start + width
+                    child
                 )
             })?;
         Ok((stacked, batch_index))
@@ -898,11 +907,13 @@ mod tests {
             .flat_map(|node| outputs[node].iter().cloned())
             .collect::<Vec<_>>();
         let mut probes = ProbeBank::from_seed(std::mem::take(&mut probe_indices), 1, 99).unwrap();
-        // batch_size 3 matches the request width exactly, so this exercises
-        // the aligned single-segment path only -- see the misaligned/
-        // multi-edge test below for the fixed-grid growth and fallback.
+        // The first width-3 request is narrower than batch_size 5, so this
+        // exercises the permitted short initial segment and its direct replay.
         let mut cache =
-            EnvironmentCache::new(&tn_a, &edges, &nodes, &local, &outputs, &mut probes, 3);
+            EnvironmentCache::new(&tn_a, &edges, &nodes, &local, &outputs, &mut probes, 5);
+        assert!(cache
+            .request(&"B".to_string(), &"A".to_string(), 0, 0)
+            .is_err());
 
         let (first, first_batch) = cache
             .request(&"B".to_string(), &"A".to_string(), 0, 3)
@@ -929,12 +940,12 @@ mod tests {
     fn request_shared_across_edges_replays_a_misaligned_range_exactly() {
         // `EnvironmentCache` is shared across every edge in the tree, and
         // different edges generally need different widths (different ranks).
-        // This reproduces exactly that: edge (B, A) grows the cache to width
-        // 5 on a batch_size-2 grid (segments [0,2), [2,2), [4,1)), then edge
-        // (B, C) requests [0,3) -- a width that lands on none of those
-        // segment boundaries -- forcing the misaligned split/re-stack
-        // fallback. Re-reading the same range must reproduce the cached
-        // columns bit-for-bit without growing or recomputing environments.
+        // This reproduces exactly that: edge (B, A) requests width 5 on a
+        // batch_size-2 grid. Later segments stay full, producing [0,2),
+        // [2,2), [4,2), so future rank increments remain aligned. Edge (B, C)
+        // then requests [0,3), which still genuinely spans segment boundaries
+        // and exercises the split/re-stack fallback. Re-reading the same range
+        // must reproduce the cached columns bit-for-bit.
         let tn_a = three_node_path(1.0);
         let tn_b = three_node_path(2.0);
         let mut nodes = tn_a.node_names();
@@ -971,11 +982,18 @@ mod tests {
             .request(&"B".to_string(), &"A".to_string(), 0, 5)
             .unwrap();
         assert_eq!(wide_batch.dim(), 5);
+        assert_eq!(cache.segments.len(), 3);
         assert_eq!(
-            cache.segments.len(),
-            3,
-            "batch_size 2 growing to width 5 should produce segments [0,2), [2,2), [4,1)"
+            cache
+                .segments
+                .iter()
+                .map(|(_, width, _, _)| *width)
+                .collect::<Vec<_>>(),
+            vec![2, 2, 2],
+            "later tree segments must keep the rank-increment grid aligned"
         );
+        assert_eq!(cache.segment_total_width - 5, 1);
+        assert!(cache.segment_total_width - 5 < cache.batch_size);
 
         let (narrow, narrow_batch) = cache
             .request(&"B".to_string(), &"C".to_string(), 0, 3)
@@ -997,6 +1015,11 @@ mod tests {
             replayed.to_vec::<f64>().unwrap(),
             "misaligned fallback must replay cached columns exactly"
         );
+
+        let (_aligned, aligned_batch) = cache
+            .request(&"B".to_string(), &"C".to_string(), 4, 2)
+            .unwrap();
+        assert_eq!(aligned_batch, cache.segments[2].2);
     }
 
     #[test]

--- a/crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs
@@ -517,25 +517,57 @@ fn zipup_chain_matches_naive_without_truncation() {
     assert!(error < 1e-9, "exact zip-up residual is {error}");
 }
 
-#[test]
-fn src_fixed_matches_exact_contraction_when_probe_cap_is_full() {
-    let (tn_a, tn_b) = make_three_node_chain_pair();
-    let expected = tn_a.contract_naive(&tn_b).unwrap();
-    let options = ContractionOptions::src()
-        .with_max_bond_dim(4)
-        .with_src_options(SrcOptions::fixed().with_seed(123).with_final_svd(false));
-    let actual = contract(&tn_a, &tn_b, &"C".to_string(), options)
-        .unwrap()
-        .to_dense()
-        .unwrap();
+fn max_internal_bond(network: &TreeTN<IdxTensor, String>) -> usize {
+    network
+        .graph
+        .graph()
+        .edge_indices()
+        .map(|edge| network.bond_index(edge).unwrap().dim())
+        .max()
+        .unwrap_or(1)
+}
 
-    let error = actual.sub(&expected).unwrap().maxabs().unwrap();
-    assert!(error < 1.0e-8, "full-probe SRC residual is {error}");
-    assert!(actual
-        .clone()
-        .external_indices()
-        .iter()
-        .all(|index| index.dim() == 2));
+fn assert_fixed_src_rank_cap_semantics(
+    tn_a: &TreeTN<IdxTensor, String>,
+    tn_b: &TreeTN<IdxTensor, String>,
+    center: &str,
+    support: usize,
+) {
+    let expected = tn_a.contract_naive(tn_b).unwrap();
+    for (requested, final_svd, should_be_exact) in [
+        (support - 1, false, false),
+        (support, false, true),
+        (support * 4, false, true),
+        (support * 4, true, true),
+    ] {
+        let actual = contract(
+            tn_a,
+            tn_b,
+            &center.to_string(),
+            ContractionOptions::src()
+                .with_max_bond_dim(requested)
+                .with_src_options(SrcOptions::fixed().with_seed(123).with_final_svd(final_svd)),
+        )
+        .unwrap();
+        assert!(
+            max_internal_bond(&actual) <= requested.min(support),
+            "requested={requested}, support={support}, final_svd={final_svd}"
+        );
+        if should_be_exact {
+            let dense = actual.to_dense().unwrap();
+            let error = dense.sub(&expected).unwrap().maxabs().unwrap();
+            assert!(
+                error < 1.0e-8,
+                "fixed SRC residual is {error} for requested={requested}, support={support}, final_svd={final_svd}"
+            );
+        }
+    }
+}
+
+#[test]
+fn src_fixed_chain_clamps_requested_rank_to_cut_support() {
+    let (tn_a, tn_b) = make_three_node_chain_pair();
+    assert_fixed_src_rank_cap_semantics(&tn_a, &tn_b, "C", 4);
 }
 
 #[test]
@@ -1077,28 +1109,9 @@ fn src_adaptive_traverses_a_branched_tree_and_matches_dense_reference() {
 }
 
 #[test]
-fn src_fixed_matches_naive_on_a_branched_tree_when_probe_cap_is_full() {
+fn src_fixed_tree_clamps_requested_rank_to_cut_support() {
     let (tn_a, tn_b) = make_branched_pair();
-    let expected = tn_a.contract_naive(&tn_b).unwrap();
-    let actual = contract(
-        &tn_a,
-        &tn_b,
-        &"C".to_string(),
-        ContractionOptions::src()
-            .with_max_bond_dim(4)
-            .with_src_options(SrcOptions::fixed().with_seed(77).with_final_svd(false)),
-    )
-    .unwrap();
-
-    let error = actual
-        .to_dense()
-        .unwrap()
-        .sub(&expected)
-        .unwrap()
-        .maxabs()
-        .unwrap();
-    assert!(error < 1.0e-8, "branched SRC residual is {error}");
-    actual.validate_ortho_consistency().unwrap();
+    assert_fixed_src_rank_cap_semantics(&tn_a, &tn_b, "C", 4);
 }
 
 #[test]
@@ -1133,7 +1146,7 @@ fn src_adaptive_contracts_a_branched_tree_with_a_rank_cap() {
 #[test]
 fn src_adaptive_matches_naive_on_a_branched_tree_when_probe_cap_is_full() {
     // Same fixture and interior center ("C", the degree-3 hub) as
-    // `src_fixed_matches_naive_on_a_branched_tree_when_probe_cap_is_full`,
+    // `src_fixed_tree_clamps_requested_rank_to_cut_support`,
     // but with `SrcOptions::adaptive` so this exercises the `rtol.is_some()`
     // dispatch branch (`EnvironmentCache::request`/`grow_segment`, the
     // batch-native probe path) with a numeric dense-oracle comparison,

--- a/docs/book/src/guides/tensor-basics.md
+++ b/docs/book/src/guides/tensor-basics.md
@@ -164,6 +164,35 @@ let product = outer_product(&a, &c).unwrap();
 assert_eq!(product.dims().iter().product::<usize>(), 2 * 3 * 4 * 5);
 ```
 
+### Repeated contraction with a prepared plan
+
+When repeated operands keep exactly the same ordered indices, dimensions, and
+axis classes, prepare the index matching and label assignment once. Values,
+dtypes, and gradient-tracking state may change; fresh index identities require a
+new plan.
+
+```rust
+use tensor4all_core::{ContractionOptions, IdxTensor, Index, PreparedContraction};
+
+let i = Index::new_dyn(2);
+let j = Index::new_dyn(2);
+let k = Index::new_dyn(2);
+let a = IdxTensor::from_dense(
+    vec![i.clone(), k.clone()],
+    vec![1.0, 2.0, 3.0, 4.0],
+).unwrap();
+let b = IdxTensor::from_dense(
+    vec![k, j.clone()],
+    vec![5.0, 6.0, 7.0, 8.0],
+).unwrap();
+let c = IdxTensor::from_dense(vec![j], vec![1.0, 2.0]).unwrap();
+
+let plan = PreparedContraction::new(&[&a, &b, &c], ContractionOptions::new()).unwrap();
+let result = plan.execute(&[&a, &b, &c]).unwrap();
+assert_eq!(result.indices(), &[i]);
+assert_eq!(result.to_vec::<f64>().unwrap(), vec![85.0, 126.0]);
+```
+
 ## Factorization
 
 The unified `factorize()` function dispatches to SVD, QR, LU, or CI based on

--- a/docs/plans/2026-09-03-fixed-rank-src-semantics-design.md
+++ b/docs/plans/2026-09-03-fixed-rank-src-semantics-design.md
@@ -1,0 +1,53 @@
+# Fixed-rank SRC rank semantics design (#705)
+
+## Decision
+
+Treat `ContractionOptions::max_bond_dim` as an upper bound, not a promise that
+every output bond has that exact dimension. Fixed-rank SRC uses, at each cut,
+
+```text
+effective_sketch_width = min(requested_max_bond_dim,
+                             local_row_dimension,
+                             opposite_cut_support)
+```
+
+In fixed mode only, enabling `final_svd` first oversamples the requested width
+and then applies the same local-row and cut-support bounds. Adaptive mode keeps
+its separate `SrcOptions::max_rank` cap and is unchanged by this decision. The
+realized output bond may be smaller than the requested maximum.
+
+## Alternatives
+
+- **Reject above-support requests:** rejected because `max_bond_dim` is a global
+  cap while support varies by cut; callers should not need to precompute every
+  internal cut merely to provide a safe cap.
+- **Honor the exact request:** impossible without adding zero/redundant columns
+  beyond mathematical support and would preserve the benchmark's avoidable work.
+- **Clamp to support:** selected; it matches maximum-rank vocabulary, existing
+  `maximum_site_width` behavior, and other truncation APIs.
+
+## Contract owner and implementation
+
+- `maximum_site_width` remains the single owner of per-cut clamping.
+- `chain_cut_dimensions` and the corresponding rooted-tree edge dimensions
+  compute opposite-side support with checked multiplication.
+- Public `SrcOptions`/`ContractionOptions` docs state cap semantics explicitly.
+- `benchmark_src` reports both `requested_max_rank` and the realized
+  `effective_max_bond`, avoiding oversized-request ambiguity.
+- No compatibility shim or new public API is needed.
+
+## Tests
+
+Use deterministic small fixed-SRC chains and branched trees whose support is
+known. For each topology cover:
+
+1. requested rank below support: realized bonds do not exceed the request;
+2. requested rank equal to support: exact fixed contraction is recovered;
+3. requested rank above support: result matches the support-sized request and
+   does not create larger bonds;
+4. fixed mode with `final_svd` still cannot exceed local or cut support;
+5. existing zero/overflow validation remains unchanged.
+
+Compare small results through one dense materialization and a whole-result
+residual. Do not relax tolerances. Adaptive semantics and tests are not changed
+by #705.

--- a/docs/plans/2026-09-03-issue-698-follow-ups.md
+++ b/docs/plans/2026-09-03-issue-698-follow-ups.md
@@ -1,0 +1,136 @@
+# Issue #698 follow-up execution plan
+
+## Objective
+
+Close the low-bond SRC performance umbrella through small, independently
+mergeable changes. Every optimization is measurement-gated; a failed need or
+promotion gate closes the corresponding experiment without production code.
+
+## Order and dependencies
+
+```text
+Item 1 binary dispatch (current branch)
+  -> #705 fixed-rank semantics
+  -> #706 valid benchmark gates
+  -> #700 caller-owned prepared plan
+  -> rebaseline
+     -> #702 directed-message experiment
+     -> #703 tree-cache alignment experiment
+     -> #701 residual fixed-overhead profile/fix
+          -> #704 flattened-batch primitive, only if still justified
+  -> final cross-item audit
+  -> close #698
+```
+
+`#702` and `#703` may be measured in parallel after the rebaseline, but their
+implementations remain separate changes. No Cargo jobs share one target
+directory concurrently.
+
+## Phase 0: land item 1
+
+**Scope:** current `fix/issue-698-small-bond` diff.
+
+- Keep the connected binary/no-retain fast-path scope approved by the maintainer.
+- Preserve generic connectivity and retained-index validation before dispatch.
+- Keep SRC call sites generic and verify generic-vs-explicit timing.
+- Run formatting, focused core/TreeTN tests, clippy, repository-rules review,
+  and the recorded bond-32 A/B gate.
+
+**Exit:** item 1 is merged; #698 links the merged PR and marks item 1 complete.
+
+## Phase 1: settle semantics and measurement infrastructure
+
+### #705 — fixed-rank SRC semantics
+
+Decide clamp versus typed error versus exact-request behavior before benchmark
+cases encode the current ambiguity. Record the mathematical support bound,
+checked-arithmetic implementation point, public diagnostics, and boundary tests.
+
+**Exit:** one documented canonical rank rule is merged and benchmark output can
+report requested and effective ranks unambiguously.
+
+### #706 — valid benchmark gates
+
+Replace the invalid large-star case with bounded-center chain/tree cases. Define
+hardware/provider lanes, memory formulas and guards, seeds, warm-up, repetitions,
+statistics, host-noise rejection, correctness oracle, and promotion thresholds.
+Keep the default local gate short; archive heavy studies outside the source tree.
+
+**Exit:** every later issue has a reproducible current-main baseline and a
+predeclared promotion/non-regression gate.
+
+## Phase 2: remove reusable planning cost
+
+### #700 — caller-owned prepared contraction plan
+
+1. Profile current-main core/backend planning shares on #706 gates.
+2. Write and review the public API design before implementation.
+3. Implement explicit caller-owned preparation/execution; do not add an identity-
+   keyed, thread-local, or global cache.
+4. Test compatibility rejection/fallback for indices, shapes, dtype, layout,
+   retained labels, structured storage, and AD.
+5. Integrate with SRC only if its separate end-to-end gate passes.
+
+**Exit:** repeated compatible calls demonstrably reuse core and backend planning,
+public docs/doctests pass, and SRC either adopts the API with a passing gate or
+records why it does not.
+
+## Phase 3: rebaseline and run bounded experiments
+
+After #700, rerun #706 and refresh the contraction section profile. Old shares
+must not be used to justify new code.
+
+### #702 — directed messages
+
+Measure cost versus tree degree and bond size. If the path is material, compare
+prefix/suffix partial contractions with the existing message reference. Promote
+only with bounded memory, numerical parity, and a passing tree gate; otherwise
+close with measurements.
+
+### #703 — tree segment alignment
+
+Measure runtime, cache reuse, over-generated columns/messages, and peak memory
+for aligned versus ragged growth. Promote only if the primary tree gate passes
+without a memory or other-topology regression; otherwise remove the candidate.
+
+### #701 — residual fixed overhead
+
+Profile first and select one ownership-level subpath. Preserve validation,
+structured storage, AD, dtype promotion, layout, and source errors. Do not repeat
+the four rejected experiments from #698 without new evidence.
+
+**Exit:** each issue contains a PASS/FAIL/INCONCLUSIVE result and either one
+independently mergeable fix or no production diff.
+
+## Phase 4: last-resort batching
+
+### #704 — flattened-batch primitive
+
+Start only if the post-#701 profile still shows many small retained contractions
+or QR appends as a material end-to-end cost. Review ownership and API design
+before implementation. Prefer an existing core/backend batch seam; add no
+application-specific C API and no per-column tensor construction.
+
+**Exit:** a paired low-bond improvement passes with no high-bond, memory,
+correctness, layout, or AD regression. Otherwise close as unnecessary.
+
+## Per-change gates
+
+- Branch from current `origin/main`; one issue and one independently mergeable
+  diff per task.
+- Record baseline/candidate commits and the full measurement protocol before
+  candidate results are known.
+- Do not relax numerical or coverage thresholds.
+- Run focused release tests first, then formatting, clippy, doctests/docs when
+  public APIs change, and repository-rules review.
+- Any delegated implementation requires the repository's pre-design and
+  post-diff cross-model review gate.
+- Update the issue and its worklog with negative and inconclusive results, not
+  only successful candidates.
+
+## Final audit and closure
+
+Re-run all #706 gates on one exact candidate commit. Audit specification,
+correctness/AD/structured paths, performance, public API/docs, and available
+CPU-provider/CUDA lanes. Close #698 only after every child issue is closed,
+merged, or explicitly deferred with evidence and an owner.

--- a/docs/plans/2026-09-03-prepared-contraction-design.md
+++ b/docs/plans/2026-09-03-prepared-contraction-design.md
@@ -1,0 +1,76 @@
+# Caller-owned prepared contraction design (#700)
+
+## Decision
+
+Add `tensor4all_core::PreparedContraction`, an explicitly caller-owned immutable
+plan for repeatedly contracting `IdxTensor` operands with the same index and
+axis-layout contract. It owns core label assignment and result ordering; no
+thread-local/global core cache is added.
+
+```rust
+let plan = PreparedContraction::new(&[&a, &b, &c], options)?;
+let result = plan.execute(&[&a2, &b2, &c2])?;
+```
+
+## Compatibility contract
+
+Preparation records, per operand, the ordered full `DynIndex` values, explicit
+dimensions, and axis classes. Execution requires:
+
+- the same operand count;
+- the same full indices in the same order (including ID, prime level, tags, and
+  direction);
+- the same explicit dimensions (dimension is validated separately because index
+  equality alone is not the dimension contract);
+- the same axis classes.
+
+Values, dtype, storage payload, and gradient-tracking state may change. Full
+index equality makes validation linear in total rank and prevents a later tensor
+from introducing an unplanned contraction. Fresh SRC-generated index identities
+are intentionally incompatible; the caller prepares a new plan when identity or
+layout changes.
+
+A mismatch returns the existing typed `IdxTensorError::ShapeMismatch` with
+operation `prepared contraction`. Backend/materialization failures preserve their
+existing source chain.
+
+## Execution
+
+- Zero operands fail during preparation; disconnected inputs retain generic
+  contraction's rejection.
+- One operand returns a clone.
+- Connected binary/no-retain execution keeps the existing pairwise fast path.
+- N-ary and retained dense execution reuses stored input/output labels and the
+  backend's existing shape/dtype-aware `ConcreteEinsumPlan` cache/session.
+- Structured and AD execution uses the same structured/AD-preserving path as the
+  ordinary borrowed entry with stored labels and result metadata.
+- Retained indices are resolved only during preparation; exact input identity
+  validation proves they remain present during execution.
+
+The type exposes no mutable plan internals, cache capacity, or compatibility
+shim. `Debug` is metadata-only and `Clone` shares no hidden global state.
+
+## SRC integration decision
+
+Current SRC is generic over `TensorLike` and creates fresh batch/cap/link indices
+as rank segments grow and on every top-level repetition. Exact caller-owned
+plans therefore do not survive those boundaries, while a normalized plan would
+have to revalidate the same contractability graph it is meant to avoid. Add no
+SRC-specific reach-through. Measure the core repeated-contract benchmark and the
+SRC #706 gates separately; adopt in SRC only if a future owner keeps exact index
+identities stable and a fresh end-to-end gate passes.
+
+## Tests and evidence
+
+- Dense N-ary prepared execution matches ordinary contraction for repeated
+  values and mixed dtype.
+- Retained-index output order and values match.
+- Diagonal/structured storage remains compact; tracked inputs preserve backward
+  gradients.
+- Operand count, dimension, full-index identity (including same-ID prime/tag
+  variants), and axis-class mismatches return `ShapeMismatch` before backend
+  execution.
+- Existing binary, disconnected, and empty semantics remain covered.
+- The ignored repeated-contraction benchmark compares ordinary versus prepared
+  core calls after warm-up; promote only with a predeclared paired improvement
+  and no correctness regression.

--- a/docs/plans/2026-09-03-prepared-contraction-design.md
+++ b/docs/plans/2026-09-03-prepared-contraction-design.md
@@ -3,8 +3,8 @@
 ## Decision
 
 Add `tensor4all_core::PreparedContraction`, an explicitly caller-owned immutable
-plan for repeatedly contracting `IdxTensor` operands with the same index and
-axis-layout contract. It owns core label assignment and result ordering; no
+plan for repeatedly contracting N-ary or retained-index `IdxTensor` operands
+with the same index and axis-layout contract. It owns core label assignment and result ordering; no
 thread-local/global core cache is added.
 
 ```rust
@@ -39,7 +39,8 @@ existing source chain.
 - Zero operands fail during preparation; disconnected inputs retain generic
   contraction's rejection.
 - One operand returns a clone.
-- Connected binary/no-retain execution keeps the existing pairwise fast path.
+- Connected binary/no-retain execution keeps the existing pairwise fast path;
+  it provides semantic parity but does not reuse the stored N-ary labels.
 - N-ary and retained dense execution reuses stored input/output labels and the
   backend's existing shape/dtype-aware `ConcreteEinsumPlan` cache/session.
 - Structured and AD execution uses the same structured/AD-preserving path as the

--- a/docs/plans/2026-09-03-src-benchmark-gates-design.md
+++ b/docs/plans/2026-09-03-src-benchmark-gates-design.md
@@ -1,0 +1,110 @@
+# SRC benchmark gates design (#706)
+
+## Goals
+
+Provide one reproducible CPU gate runner for current-main/candidate comparisons,
+replace the unbounded-degree star fixture, refuse oversized inputs/oracles before
+allocation, and make unavailable backend lanes explicit.
+
+## Benchmark fixture changes
+
+- Keep deterministic 10-site MPO--MPS chains for low/high bond behavior.
+- Replace `tree` mode's star with a rooted binary tree. Its maximum degree is 3,
+  so each input core is bounded by `physical_dim^2 * bond_dim^3` rather than
+  `physical_dim^2 * bond_dim^n` at the star center.
+- Compute checked estimates before construction:
+  - every chain/tree input core and total input bytes;
+  - dense oracle output bytes (`2^n` values for MPO--MPS and `4^n` for
+    MPO--MPO/tree);
+  - maximum topology degree.
+- Refuse runs above `T4A_BENCH_MAX_INPUT_BYTES` or
+  `T4A_BENCH_MAX_DENSE_BYTES`; defaults are 512 MiB and 256 MiB.
+- Warm each selected algorithm once before timed repetitions. Keep setup and
+  dense-oracle time outside the measured section.
+- Print machine-parseable requested/effective ranks, estimates, topology, seed,
+  relative error, compile-time git commit, release/debug profile, enabled
+  backend features, and backend selection. The runner rejects an expected
+  commit/profile/feature mismatch and records each binary's SHA-256.
+
+## Gate runner
+
+Add a Python-stdlib runner under `scripts/` that accepts prebuilt baseline and
+candidate binaries, alternates their order for each pair, fixes Rayon/BLAS
+threads to one, applies a child-process address-space ceiling, captures host load
+and every raw result, and writes JSON. GNU `time` records each child's peak RSS;
+`RLIMIT_AS` is reported separately as virtual-memory enforcement, never as an
+RSS measurement.
+
+Each invocation declares before execution:
+
+- suite and exact cases;
+- pair/repetition counts;
+- correctness tolerance;
+- required improvement and allowed non-regression percentages;
+- maximum paired-ratio and per-binary dispersion, peak RSS, and virtual memory;
+- binary paths, expected embedded commit identifiers, SHA-256 digests, profile,
+  enabled features, and backend.
+
+For each case use paired ratios `r_i = candidate_ms / baseline_ms`. The point
+estimate is `median(r_i)`; dispersion gates use
+`MAD(r_i) / median(r_i)` and each binary's `MAD(time) / median(time)`. A
+fixed-seed 10,000-resample paired bootstrap gives a percentile 95% confidence
+interval for the median ratio. A promotion case passes only when the interval's
+upper bound is at or below `1 - required_improvement`; a non-regression case
+passes only when it is at or below `1 + allowed_regression`. Quick checks use at
+least 5 pairs and full promotion studies at least 10.
+
+Classification is `PASS`, `FAIL`, or `INCONCLUSIVE`, with no selective retries.
+A baseline/shared timeout, memory failure, malformed output, identity mismatch,
+or excessive baseline dispersion is `INCONCLUSIVE`. A candidate-only timeout,
+RSS/address-space excess, malformed output, identity mismatch, correctness
+failure, or excessive candidate dispersion after a valid baseline is `FAIL`.
+Any numerical correctness failure is `FAIL` and takes precedence over an
+unrelated `INCONCLUSIVE` case in the aggregate result.
+
+## Suites
+
+Every case uses physical dimension 2, SRC seed 1234, `final_svd=false`, and
+requested max rank 32. Network-generation seeds are independently fixed and
+reported: 7 for MPO--MPS chains, 11 for MPO--MPO chains, and 13 for binary
+trees. Adaptive cases additionally fix `rtol=1e-4`, `atol=0`, `min_rank=2`, and
+`rank_increment=3`.
+
+Quick local suite:
+
+1. chain MPO--MPS, 10 sites, MPO/MPS bond 32, fixed SRC;
+2. chain MPO--MPS, 10 sites, MPO/MPS bond 32, adaptive SRC;
+3. binary tree MPO--MPO, 7 nodes, bond 4, fixed SRC;
+4. the same tree, adaptive SRC.
+
+The full chain suite uses 10 sites, MPO/MPS bonds 4/8/16/32/64/128, and both
+fixed/adaptive modes. The full tree suite is the Cartesian product of node
+counts 3/7/10, bonds 2/4/8, and fixed/adaptive modes. Ten nodes keep the exact
+`4^n` dense oracle below the default 256 MiB ceiling while still exercising
+increasing tree size. All use the fixed settings
+above and remain subject to preflight/process limits. Heavy raw records belong
+in `tensor4all-benchmark`; the repository stores the protocol and curated
+worklog only.
+
+## Backend lanes
+
+- Canonical required lane: default one-thread tenferro/faer CPU.
+- Provider-injection lane: compile/run when the caller-configured TreeTN
+  contraction surface can own an injected context; until then classify
+  `UNSUPPORTED` with the missing seam, not as a CPU-faer pass.
+- CUDA lane: compile the existing CUDA feature and run CUDA TreeTN smoke checks.
+  SRC itself currently constructs CPU probes through `TensorLike` and has no
+  device/context-owning API, so CUDA SRC is `UNSUPPORTED` rather than silently
+  inferred from dense CUDA contraction. Record GPU/runtime diagnostics and the
+  exact command needed once an SRC device-context seam exists.
+
+Adding provider/device execution to SRC is not part of a benchmark-only change;
+it requires its own reviewed public-API design.
+
+## Tests
+
+- Unit-test checked memory estimates, overflow, and binary-tree degree bounds.
+- Unit-test runner parsing/statistics/classification with synthetic output.
+- Smoke-run every quick topology with an exact oracle.
+- Verify CUDA feature compilation and the existing CUDA smoke test on available
+  hardware, while reporting SRC CUDA support separately.

--- a/docs/plans/2026-09-03-src-benchmark-gates-design.md
+++ b/docs/plans/2026-09-03-src-benchmark-gates-design.md
@@ -22,16 +22,17 @@ allocation, and make unavailable backend lanes explicit.
 - Warm each selected algorithm once before timed repetitions. Keep setup and
   dense-oracle time outside the measured section.
 - Print machine-parseable requested/effective ranks, estimates, topology, seed,
-  relative error, compile-time git commit, release/debug profile, enabled
-  backend features, and backend selection. The runner rejects an expected
+  relative error, selected center, compile-time git commit, release/debug
+  profile, enabled backend features, and backend selection. The runner rejects an expected
   commit/profile/feature mismatch and records each binary's SHA-256.
 
 ## Gate runner
 
 Add a Python-stdlib runner under `scripts/` that accepts prebuilt baseline and
-candidate binaries, alternates their order for each pair, fixes Rayon/BLAS
-threads to one, applies a child-process address-space ceiling, captures host load
-and every raw result, and writes JSON. GNU `time` records each child's peak RSS;
+candidate binaries, alternates their order for each pair, removes ambient
+`T4A_BENCH_*`/`T4A_PROFILE_*` overrides, fixes Rayon/BLAS threads to one, applies
+a child-process address-space ceiling, kills the complete benchmark process
+group on timeout, captures host load and every raw result, and writes JSON. GNU `time` records each child's peak RSS;
 `RLIMIT_AS` is reported separately as virtual-memory enforcement, never as an
 RSS measurement.
 

--- a/docs/worklogs/2026-09-03-binary-contraction-dispatch.md
+++ b/docs/worklogs/2026-09-03-binary-contraction-dispatch.md
@@ -1,0 +1,54 @@
+# Binary contraction dispatch for issue #698
+
+## Summary
+
+The generic borrowed contraction entry now routes connected two-tensor calls
+without retained indices through the existing pairwise implementation. SRC's
+statically binary call sites were returned to `TensorLike::contract`, so new
+generic algorithm code receives the fast path automatically.
+
+This closes item 1 of [issue #698](https://github.com/tensor4all/tensor4all-rs/issues/698).
+The prepared-plan API and the other independent umbrella items remain deferred.
+
+## Sources and decision
+
+- Baseline: `origin/main` at `b9636123`.
+- Read `docs/worklogs/2026-08-31-src-performance-remediation.md`, the issue,
+  `contract_with_options_impl`, the pairwise implementation, SRC binary call
+  sites, and the existing N-ary/pairwise equivalence tests.
+- Connectivity and retained-index validation remain before dispatch, preserving
+  the generic entry's rejection of disconnected networks and retained-label
+  semantics.
+- Restricting dispatch to tensors with trivial axis classes did not recover the
+  SRC path because some dense SRC intermediates retain structured axis metadata.
+  The pairwise implementation already owns structured and AD-preserving paths,
+  so every connected binary no-retain call uses that canonical seam.
+
+## Performance gate
+
+Predeclared gate: 10-site MPO--MPS, input bond and maximum rank 32,
+`rank_increment=3`, release profile, 20 repetitions, fixed
+`RAYON_NUM_THREADS=1`, `OPENBLAS_NUM_THREADS=1`, `OMP_NUM_THREADS=1`, and
+`MKL_NUM_THREADS=1`; generic dispatch must be within 5% of explicit
+`contract_pair`.
+
+Five alternating process pairs used binaries built from the same candidate,
+with only the SRC call sites differing:
+
+| Method | Explicit median ms/run | Generic median ms/run | Ratio-of-medians change | Median paired change |
+|---|---:|---:|---:|---:|
+| SRC fixed | 31.284 | 31.684 | +1.28% | +0.62% |
+| SRC adaptive | 30.627 | 30.298 | -1.07% | +0.06% |
+
+Both cases pass the 5% gate. A one-repetition dense-oracle run of adaptive SRC
+reported relative error `1.755e-23`.
+
+## Verification
+
+- `cargo test --release -p tensor4all-core --lib`: 442 passed, 1 ignored.
+- `cargo test --release -p tensor4all-core --test tensor_contract_nary_pair_equivalence`: 4 passed.
+- `cargo test --release -p tensor4all-core --test ad_integration`: 6 passed.
+- `cargo test --release -p tensor4all-core --test tensor_contraction`: 28 passed.
+- `cargo test --release -p tensor4all-core --test tensor_diag`: 25 passed.
+- `cargo test --release -p tensor4all-treetn 'treetn::contraction::' --lib`: 75 passed.
+- No tolerance was changed.

--- a/docs/worklogs/2026-09-03-fixed-rank-src-semantics.md
+++ b/docs/worklogs/2026-09-03-fixed-rank-src-semantics.md
@@ -1,0 +1,31 @@
+# Fixed-rank SRC rank semantics (#705)
+
+## Decision and implementation
+
+`max_bond_dim` is documented as an upper bound. Fixed SRC continues to clamp
+each requested sketch width to the local row dimension and exact opposite-cut
+support in `maximum_site_width`; no redundant rank-padding or new public API was
+added. Adaptive `SrcOptions::max_rank` semantics are unchanged.
+
+The reviewed design is
+`docs/plans/2026-09-03-fixed-rank-src-semantics-design.md`. After adding explicit
+chain/tree and fixed/adaptive distinctions, the independent reviewer verdict was
+`Correct-to-merge`.
+
+`benchmark_src` now prints `requested_max_rank` and `effective_max_bond`, so an
+oversized benchmark request cannot be mistaken for realized work.
+
+## Coverage
+
+A shared deterministic test exercises both a chain and branched tree with a
+requested rank below, equal to, and above cut support, plus the oversampled
+`final_svd` fixed path. Full-support cases are compared to one dense oracle and
+all realized bonds are checked against both request and support. The private
+width-selection test separately pins row and cut clamping.
+
+## Verification
+
+- `cargo test --release -p tensor4all-treetn src_fixed_ --lib`: 4 passed.
+- `cargo test --release -p tensor4all-treetn maximum_probe_width_respects_rank_row_and_cut_bounds --lib`: 1 passed.
+- `cargo run --release -p tensor4all-treetn --example benchmark_src -- 3 2 1 mpo-mps 1 false 16`: passed; reported requested rank 16 and effective SRC bond 4 with relative error `6.525e-16`.
+- No tolerance changed.

--- a/docs/worklogs/2026-09-03-issue-698-final-audit.md
+++ b/docs/worklogs/2026-09-03-issue-698-final-audit.md
@@ -1,0 +1,104 @@
+# Issue #698 final integration audit
+
+## Candidate
+
+Audited implementation commit:
+`a0ae762ccb147fb7e8b91d3c185b705d022b674b`.
+Base: `origin/main` at `b9636123b239ba3426511311e43f4ac66577b60b`.
+A fresh fetch, empty `git status --short`, and merge-base ancestor check confirmed
+the candidate contains current `origin/main`.
+
+This file is the only post-audit documentation addition. The final PR-head
+refresh must treat it as report-only and reconfirm clean status/base ancestry.
+
+## Lane reports
+
+### Specification and architecture
+
+**PASS.** Item 1, #700, #703, #705, and #706 have implemented deliverables.
+#701, #702, and #704 have explicit measured need-gate closures rather than
+unowned deferrals. Review findings on benchmark identity/config verification and
+mandatory candidate commit provenance were fixed and re-reviewed.
+
+### Safety and resource lifecycle
+
+**PASS.** `PreparedContraction` validates count, explicit dimensions, ordered
+full indices, and axis classes before execution and preserves structured/AD
+paths. Benchmark timeout kills and reaps the complete process group. Tree memory
+preflight uses O(1) checked shape counts; non-finite controls/results are
+rejected. Tree cache growth is bounded and checked. No hidden dense/device
+transfer or new global cache was introduced.
+
+### Performance and parallelism
+
+**PASS.** The runner sanitizes ambient benchmark/profile variables, validates
+selected center/config/build identity, records effective pair count, enforces
+5/10-pair minima, fixes all compute-library thread counts to one, and preserves
+failure precedence. All negative and initially failed measurements remain in the
+worklogs. Prepared-plan claims are limited to N-ary/retained calls; #701's
+conclusion is limited to measured fixed N-ary sections.
+
+### Public API and documentation
+
+**PASS.** `PreparedContraction` is exported, documented, and covered by runnable
+asserted examples and typed error behavior. The mdBook guide is synchronized.
+Malformed literal `/// ///` text in changed public rustdoc was removed. Fixed-rank
+and benchmark documentation match implementation and CLI behavior.
+
+### Backend and hardware
+
+**PASS.** Default faer CPU is the required SRC lane. Provider-injection compile
+passes but is not misrepresented as a provider-specific SRC run. Nine CUDA
+TreeTN tests pass on NVIDIA A100 80GB; CUDA SRC remains accurately marked
+unsupported because SRC has no device/context-owning seam. Later changes did not
+touch backend/device execution, so this evidence carried forward after explicit
+diff-impact review.
+
+### Integration
+
+The first integration verdict was `INCONCLUSIVE` solely because the read-only
+auditor could not prove worktree cleanliness or remote freshness. The parent
+then fetched origin and supplied exact command evidence: clean status, candidate
+HEAD above, current origin/main above, and successful ancestor check. The
+independent integration recheck returned **PASS** with no Critical, Important,
+or Minor findings.
+
+## Verification evidence
+
+- `cargo fmt --all -- --check`: passed.
+- Workspace clippy with `-D warnings`, `missing_errors_doc`, and
+  `missing_panics_doc`: passed on the exact implementation tree.
+- Non-HDF5 nextest: 3,250 tests passed before the 60-second command ceiling;
+  the only two interrupted long tests were rerun with the same workspace feature
+  set and both passed, covering all 3,252 tests.
+- HDF5: 1 unit passed (4 ignored hardware/library annotations), 46 integration
+  tests passed, and 10 doctests passed.
+- Workspace doctests: passed; `PreparedContraction`'s three doctests were rerun
+  after final review fixes and passed.
+- `TENSOR4ALL_CARGO_PROFILE=ci ./scripts/test-mdbook.sh`: passed.
+- `cargo doc --workspace --no-deps`: completed; warnings were pre-existing and
+  no changed public link remained broken.
+- `cargo run -p xtask --release -- api-dump`: complete public inventory passed
+  and included `PreparedContraction`.
+- `python3 scripts/test-run-src-benchmark-gates.py`: 11 passed.
+- Benchmark example estimator tests: 3 passed.
+- Changed public error-doc audit, repository-rules dry run, crate-boundary tests,
+  and C API header check: passed.
+- Provider-injection check: passed.
+- CUDA TreeTN test: 9 passed on A100.
+- Final exact-candidate quick SRC smoke: PASS, including stale ambient variable
+  sanitization.
+- Coverage impact attestation: every new branch is covered by focused tests;
+  no tolerance or threshold was relaxed. Hosted CI remains authoritative for
+  percentage coverage.
+
+## Performance closure
+
+- Automatic binary dispatch is within noise of explicit pairwise calls.
+- Prepared N-ary execution improves the representative repeated core contraction
+  by 14–17% across five fresh processes.
+- Tree segment alignment improves the primary bounded-tree case by 5.46%; the
+  final complete quick gate and bond-8 diagnostics pass.
+- Fixed N-ary sections (#701), directed-message planning (#702), and flattened
+  submission overhead (#704) remain below their predeclared 10% need gates, so
+  no speculative machinery was added.

--- a/docs/worklogs/2026-09-03-prepared-contraction.md
+++ b/docs/worklogs/2026-09-03-prepared-contraction.md
@@ -3,14 +3,16 @@
 ## Summary
 
 Added public `PreparedContraction`, which owns core index matching, internal
-labels, retained-label output order, and result axis metadata for repeated
-`IdxTensor` contractions. Execution requires the same operand count, ordered
+labels, retained-label output order, and result axis metadata for repeated N-ary
+or retained-index `IdxTensor` contractions. Execution requires the same operand count, ordered
 full indices, explicit dimensions, and axis classes; values, dtype, payload, and
 gradient state may change. Compatibility failures return
 `IdxTensorError::ShapeMismatch` before backend execution.
 
 The implementation preserves ordinary single clone, binary pairwise, N-ary
-native, retained, structured, and AD dispatch. Backend shape/dtype/label plans
+native, retained, structured, and AD dispatch. Binary calls without retained
+indices deliberately keep the faster pairwise path and do not reuse the stored
+N-ary labels; their support is semantic parity, not a reuse claim. Backend shape/dtype/label plans
 continue through the existing backend-owned cache/session. No new global or
 thread-local core cache was added.
 
@@ -47,7 +49,7 @@ rerun used 10 pairs and 30 repetitions with the unchanged 5% threshold and
 ## Verification
 
 - `cargo test --release -p tensor4all-core --test prepared_contraction`: 8 passed.
-- `cargo test --doc --release -p tensor4all-core PreparedContraction`: 3 passed before the review additions; rerun in final integration verification.
+- `cargo test --doc --release -p tensor4all-core PreparedContraction`: 3 passed after final review fixes.
 - Ignored repeated-contraction benchmark: 5/5 performance pairs passed.
 - #706 quick SRC non-regression: final 10-pair/30-repetition run passed.
 - No tolerance changed.

--- a/docs/worklogs/2026-09-03-prepared-contraction.md
+++ b/docs/worklogs/2026-09-03-prepared-contraction.md
@@ -1,0 +1,53 @@
+# Caller-owned prepared contraction (#700)
+
+## Summary
+
+Added public `PreparedContraction`, which owns core index matching, internal
+labels, retained-label output order, and result axis metadata for repeated
+`IdxTensor` contractions. Execution requires the same operand count, ordered
+full indices, explicit dimensions, and axis classes; values, dtype, payload, and
+gradient state may change. Compatibility failures return
+`IdxTensorError::ShapeMismatch` before backend execution.
+
+The implementation preserves ordinary single clone, binary pairwise, N-ary
+native, retained, structured, and AD dispatch. Backend shape/dtype/label plans
+continue through the existing backend-owned cache/session. No new global or
+thread-local core cache was added.
+
+SRC was not wired to the concrete API: SRC is generic over `TensorLike` and
+creates fresh batch/cap/link identities across growth and top-level runs. An
+exact caller-owned plan therefore cannot survive those boundaries, while a
+normalized validator would repeat the planner's contractability work. The SRC
+non-regression gate was measured separately.
+
+The design and final implementation received independent `Correct-to-merge`
+verdicts. All review findings were fixed, including explicit dimension
+validation, structured mixed-dtype/AD coverage, missing-retain and zero-execute
+coverage, precise error docs, and metadata-summary `Debug`.
+
+## Performance
+
+Predeclared repeated-core gate: release, one thread, five fresh processes; each
+process compares 2,000 calls, best of three, and requires at least 5% paired
+median improvement. Generic/prepared ratios were `1.17x`, `1.15x`, `1.14x`,
+`1.16x`, and `1.14x`; correctness was asserted before timing.
+
+The first #706 SRC quick non-regression run (5 pairs, 3 repetitions) failed
+because one very short tree-fixed baseline sample was 8.2% below its median.
+A complete 10-pair/10-repetition rerun still had a within-limit +3.05% point
+estimate but a 6.20% CI upper bound. The final predeclared stronger complete
+rerun used 10 pairs and 30 repetitions with the unchanged 5% threshold and
+10% dispersion limit; all four cases passed:
+
+- chain fixed ratio `1.0126`, CI `[0.9715, 1.0368]`;
+- chain adaptive `0.9747`, CI `[0.9680, 0.9997]`;
+- tree fixed `0.9854`, CI `[0.9709, 1.0203]`;
+- tree adaptive `0.9885`, CI `[0.9725, 1.0177]`.
+
+## Verification
+
+- `cargo test --release -p tensor4all-core --test prepared_contraction`: 8 passed.
+- `cargo test --doc --release -p tensor4all-core PreparedContraction`: 3 passed before the review additions; rerun in final integration verification.
+- Ignored repeated-contraction benchmark: 5/5 performance pairs passed.
+- #706 quick SRC non-regression: final 10-pair/30-repetition run passed.
+- No tolerance changed.

--- a/docs/worklogs/2026-09-03-src-benchmark-gates.md
+++ b/docs/worklogs/2026-09-03-src-benchmark-gates.md
@@ -28,7 +28,9 @@ PASS/FAIL/INCONCLUSIVE classification. Its design and final diff received
 
 ## Verification
 
-- `python3 scripts/test-run-src-benchmark-gates.py`: 7 passed.
+- `python3 scripts/test-run-src-benchmark-gates.py`: 11 passed, including
+  process-group timeout cleanup, strict config/provenance checks, minimum paired
+  samples, non-finite rejection, and classification precedence.
 - `cargo test --release -p tensor4all-treetn --example benchmark_src`: 3 passed.
 - Quick candidate smoke (4 exact cases, one warm-up + one timed run each): PASS.
   - chain bond-32 fixed: relative error `6.562e-26`;

--- a/docs/worklogs/2026-09-03-src-benchmark-gates.md
+++ b/docs/worklogs/2026-09-03-src-benchmark-gates.md
@@ -1,0 +1,41 @@
+# SRC benchmark gates (#706)
+
+## Summary
+
+The invalid unbounded-degree star fixture was replaced by a deterministic
+maximum-degree-3 binary tree. `benchmark_src` now performs checked input/oracle
+memory preflight before allocation, warms each selected algorithm once, and
+emits machine-readable build, configuration, memory, timing, rank, seed, and
+correctness records.
+
+`scripts/run-src-benchmark-gates.py` provides candidate smoke and paired
+baseline/candidate modes with fixed one-thread settings, binary identity checks,
+SHA-256 records, separate RLIMIT_AS/peak-RSS controls, alternating order,
+median/MAD statistics, deterministic bootstrap intervals, and explicit
+PASS/FAIL/INCONCLUSIVE classification. Its design and final diff received
+`Correct-to-merge` verdicts after all review findings were fixed.
+
+## Backend lanes
+
+- Default tenferro/faer CPU is the required SRC lane.
+- Provider-injection compiles, but SRC has no caller-owned execution-context
+  seam; provider-specific SRC timing is recorded as unsupported rather than
+  inferred from a feature build.
+- CUDA hardware was available (NVIDIA A100 80GB). Existing resident TreeTN CUDA
+  tests pass, but SRC itself remains unsupported on CUDA because generic probe
+  construction and factorization are CPU/context-free. The command and missing
+  seam are documented in `benchmarks/README.md`.
+
+## Verification
+
+- `python3 scripts/test-run-src-benchmark-gates.py`: 7 passed.
+- `cargo test --release -p tensor4all-treetn --example benchmark_src`: 3 passed.
+- Quick candidate smoke (4 exact cases, one warm-up + one timed run each): PASS.
+  - chain bond-32 fixed: relative error `6.562e-26`;
+  - chain bond-32 adaptive: `1.698e-23`;
+  - binary-tree n=7 bond-4 fixed: `3.719e-18`;
+  - binary-tree n=7 bond-4 adaptive: `3.845e-18`.
+- One-byte input limit rejected the tree fixture before allocation (exit 101,
+  estimated 10,240 bytes).
+- `cargo check -p tensor4all-treetn --no-default-features --features simplett-bridge,tenferro-provider-inject`: passed.
+- `cargo test --release -p tensor4all-treetn --features tenferro-cuda --test cuda_tree_contraction -- --nocapture`: 9 passed on A100.

--- a/docs/worklogs/2026-09-03-src-remaining-performance-items.md
+++ b/docs/worklogs/2026-09-03-src-remaining-performance-items.md
@@ -21,9 +21,12 @@ and submitted 254 N-ary contractions. Totals were:
 | result wrapping | 0.747 | 1.96% |
 | backend execution | 17.237 | 45.26% |
 
-No non-backend fixed section reached the 10% need gate; together they were about
-7.7%. The remaining dominant time is required backend contraction work, not one
-owner-level fixed-cost defect. No optimization was added. Previously rejected
+No measured non-backend fixed N-ary contraction section reached the 10% need
+gate; together they were about 7.7%. These section totals intentionally do not
+account for the complete SRC runtime: the remainder includes QR, probe/cache
+work, pairwise contractions, and other algorithm stages and is not classified
+here as backend work. #701 concerns the named fixed per-N-ary sections above;
+none justified another production optimization. Previously rejected
 planner-map, linear cache, label-grouping, and fusion candidates were not
 repeated.
 

--- a/docs/worklogs/2026-09-03-src-remaining-performance-items.md
+++ b/docs/worklogs/2026-09-03-src-remaining-performance-items.md
@@ -1,0 +1,93 @@
+# Remaining SRC performance items (#701–#704)
+
+## Protocol
+
+All measurements used the #706 deterministic release harness on the AMD EPYC
+7713P host with Rayon, BLAS, OpenBLAS, OMP, and MKL thread counts fixed to one.
+Temporary section instrumentation was enabled only for one timed run after the
+harness's untimed warm-up and was removed afterward. A candidate subpath needed
+at least 10% end-to-end share before new production machinery was allowed.
+
+## #701 — remaining fixed contraction overhead
+
+A fresh bond-32 adaptive chain run took 38.084 ms under section instrumentation
+and submitted 254 N-ary contractions. Totals were:
+
+| Section | ms | share |
+|---|---:|---:|
+| core plan | 1.372 | 3.60% |
+| size validation | 0.115 | 0.30% |
+| native operand preparation | 0.683 | 1.79% |
+| result wrapping | 0.747 | 1.96% |
+| backend execution | 17.237 | 45.26% |
+
+No non-backend fixed section reached the 10% need gate; together they were about
+7.7%. The remaining dominant time is required backend contraction work, not one
+owner-level fixed-cost defect. No optimization was added. Previously rejected
+planner-map, linear cache, label-grouping, and fusion candidates were not
+repeated.
+
+## #702 — directed-message planner repetition
+
+The complete directed-message routine occupied 39–60% of timed adaptive tree
+runs for binary trees with 3/7/10 nodes and bonds 4/8, establishing that message
+execution is important. That first measurement includes required contraction
+kernels, however, while the proposed prefix/suffix change targets repeated
+*planning*.
+
+A second profile isolated all core planning on bond-8 trees:
+
+| Nodes | plan calls | plan ms | run ms | share |
+|---:|---:|---:|---:|---:|
+| 3 | 15 | 0.123 | 2.455 | 5.00% |
+| 7 | 169 | 1.546 | 31.231 | 4.95% |
+| 10 | 257 | 2.489 | 57.031 | 4.36% |
+
+The targeted overhead is below the 10% need gate. Prefix/suffix products would
+also materialize products of leave-one-out branch spaces and risk replacing a
+small planner cost with payload growth. No production change was made.
+
+## #703 — aligned tree environment segments
+
+Temporary cache instrumentation found misaligned split/restack fallback calls in
+bounded binary-tree gates: 4 calls per two runs at n=7 bond 4/8, 8 at n=10 bond
+4, and 10 at n=10 bond 8; n=3 and bond-2 cases had none.
+
+The promoted change permits only the first segment to be narrow and grows later
+segments by the full rank increment, with at most `rank_increment - 1` extra
+columns. Range and accumulated-width arithmetic is checked. Tests cover a narrow
+initial segment, bounded overgeneration, aligned direct reuse, true misaligned
+fallback, exact replay, and zero-width rejection.
+
+Predeclared primary gate: #706 quick, tree n=7 bond=4 adaptive, at least 3%
+improvement; other cases at most 5% regression. The first 10-pair/30-repetition
+run had a passing primary ratio `0.9454` (5.46% improvement, CI upper `0.9589`)
+but failed overall because the unchanged 4.6-ms tree-fixed case had a noisy CI
+upper of `1.0695` despite an improving median. The complete stronger rerun used
+10 pairs and 60 repetitions with unchanged thresholds and passed all cases.
+Additional 10-pair/20-repetition bond-8 diagnostics improved by 3.89% at n=7
+and 4.88% at n=10.
+
+The final independent review verdict was `Correct-to-merge`; all four Minor
+findings were also fixed.
+
+## #704 — flattened adaptive batch primitive
+
+A fresh bond-32 adaptive chain profile separated backend cached-plan lookup,
+session execution, and session shell over 254 calls. The 36.116-ms run spent
+0.233 ms in plan lookup and 0.470 ms in the session shell: 1.95% combined.
+Required kernel execution was 16.856 ms. The candidate boundary therefore fails
+the 10% need gate. The earlier experiment that fused 57 of 230 boundaries was
+also neutral. Adding a new flattened-batch API would not be justified; no code
+was added.
+
+## Verification
+
+- Temporary instrumentation strings were removed from core, tensorbackend,
+  TreeTN, and benchmark sources.
+- `cargo test --release -p tensor4all-treetn 'treetn::contraction::' --lib`:
+  75 passed before final Minor fixes; rerun in integration verification.
+- #703 focused request/replay test passed.
+- #706 paired/raw JSON records are retained in `/tmp` for the active session;
+  curated results are recorded above.
+- No tolerance was changed.

--- a/scripts/run-src-benchmark-gates.py
+++ b/scripts/run-src-benchmark-gates.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Run reproducible SRC correctness and paired performance gates."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import random
+import resource
+import statistics
+import subprocess
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    n_sites: int
+    bond: int
+    mode: str
+    algorithm: str
+    max_rank: int = 32
+    rank_increment: int = 3
+
+
+def cases(suite: str) -> list[Case]:
+    quick = [
+        Case("chain-b32-fixed", 10, 32, "mpo-mps", "src-fixed"),
+        Case("chain-b32-adaptive", 10, 32, "mpo-mps", "src-adaptive"),
+        Case("tree-n7-b4-fixed", 7, 4, "tree", "src-fixed"),
+        Case("tree-n7-b4-adaptive", 7, 4, "tree", "src-adaptive"),
+    ]
+    if suite == "quick":
+        return quick
+    full = [
+        Case(f"chain-b{bond}-{kind}", 10, bond, "mpo-mps", f"src-{kind}")
+        for bond in (4, 8, 16, 32, 64, 128)
+        for kind in ("fixed", "adaptive")
+    ]
+    full.extend(
+        Case(f"tree-n{nodes}-b{bond}-{kind}", nodes, bond, "tree", f"src-{kind}")
+        for nodes in (3, 7, 10)
+        for bond in (2, 4, 8)
+        for kind in ("fixed", "adaptive")
+    )
+    return full
+
+
+def parse_records(output: str) -> dict[str, list[dict[str, str]]]:
+    records: dict[str, list[dict[str, str]]] = {}
+    for line in output.splitlines():
+        fields = dict(token.split("=", 1) for token in line.split() if "=" in token)
+        kind = fields.pop("record", None)
+        if kind is not None:
+            records.setdefault(kind, []).append(fields)
+    return records
+
+
+def relative_mad(values: list[float]) -> float:
+    median = statistics.median(values)
+    if median == 0:
+        return 0.0 if all(value == 0 for value in values) else float("inf")
+    return statistics.median(abs(value - median) for value in values) / median
+
+
+def bootstrap_median_ci(values: list[float], seed: int, samples: int = 10_000) -> tuple[float, float]:
+    rng = random.Random(seed)
+    medians = sorted(
+        statistics.median(rng.choices(values, k=len(values))) for _ in range(samples)
+    )
+    return medians[int(0.025 * samples)], medians[int(0.975 * samples)]
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def run_once(
+    binary: Path,
+    expected_commit: str | None,
+    case: Case,
+    reps: int,
+    timeout: float,
+    max_virtual_bytes: int,
+    max_rss_kib: int,
+    correctness_tol: float,
+    expected_backend: str,
+    expected_features: str,
+) -> dict[str, object]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "RAYON_NUM_THREADS": "1",
+            "BLAS_NUM_THREADS": "1",
+            "OPENBLAS_NUM_THREADS": "1",
+            "OMP_NUM_THREADS": "1",
+            "MKL_NUM_THREADS": "1",
+            "T4A_BENCH_ALGORITHM": case.algorithm,
+        }
+    )
+    command = [
+        str(binary),
+        str(case.n_sites),
+        str(case.bond),
+        str(reps),
+        case.mode,
+        str(case.rank_increment),
+        "false",
+        str(case.max_rank),
+    ]
+
+    def limit_address_space() -> None:
+        resource.setrlimit(resource.RLIMIT_AS, (max_virtual_bytes, max_virtual_bytes))
+
+    gnu_time = Path("/usr/bin/time")
+    if not gnu_time.is_file():
+        raise OSError("GNU /usr/bin/time is required for per-child peak RSS")
+    with tempfile.NamedTemporaryFile() as rss_file:
+        timed = [str(gnu_time), "-f", "%M", "-o", rss_file.name, *command]
+        completed = subprocess.run(
+            timed,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+            preexec_fn=limit_address_space,
+        )
+        rss_file.seek(0)
+        rss_text = rss_file.read().decode().strip()
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"exit={completed.returncode}; stderr={completed.stderr[-2000:]}"
+        )
+    records = parse_records(completed.stdout)
+    if len(records.get("build", [])) != 1 or len(records.get("case", [])) != 1:
+        raise RuntimeError("benchmark output lacks exactly one build and case record")
+    build = records["build"][0]
+    result = records["case"][0]
+    if build.get("profile") != "release":
+        raise RuntimeError(f"expected release profile, got {build.get('profile')}")
+    if expected_commit is not None and build.get("git_commit") != expected_commit:
+        raise RuntimeError(
+            f"expected commit {expected_commit}, got {build.get('git_commit')}"
+        )
+    if build.get("backend") != expected_backend:
+        raise RuntimeError(
+            f"expected backend {expected_backend}, got {build.get('backend')}"
+        )
+    if build.get("features") != expected_features:
+        raise RuntimeError(
+            f"expected features {expected_features}, got {build.get('features')}"
+        )
+    relative_error = float(result["relative_error"])
+    if relative_error > correctness_tol:
+        raise ValueError(
+            f"relative error {relative_error} exceeds {correctness_tol}"
+        )
+    rss_kib = int(rss_text)
+    if rss_kib > max_rss_kib:
+        raise MemoryError(f"peak RSS {rss_kib} KiB exceeds {max_rss_kib} KiB")
+    return {
+        "seconds": float(result["per_run_seconds"]),
+        "relative_error": relative_error,
+        "peak_rss_kib": rss_kib,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+        "build": build,
+        "result": result,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--candidate", type=Path, required=True)
+    parser.add_argument("--candidate-commit")
+    parser.add_argument("--baseline", type=Path)
+    parser.add_argument("--baseline-commit")
+    parser.add_argument("--suite", choices=("quick", "full"), default="quick")
+    parser.add_argument("--pairs", type=int)
+    parser.add_argument("--reps", type=int, default=5)
+    parser.add_argument("--correctness-tol", type=float, default=1.0e-8)
+    parser.add_argument("--expected-backend", default="tenferro")
+    parser.add_argument("--expected-features", default="tenferro-cpu-faer")
+    parser.add_argument("--required-improvement-percent", type=float, default=0.0)
+    parser.add_argument("--allowed-regression-percent", type=float, default=5.0)
+    parser.add_argument("--max-dispersion-percent", type=float, default=10.0)
+    parser.add_argument("--primary", action="append", default=[])
+    parser.add_argument("--timeout-seconds", type=float, default=60.0)
+    parser.add_argument("--max-rss-mib", type=int, default=4096)
+    parser.add_argument("--max-virtual-mib", type=int, default=8192)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    if not args.candidate.is_file():
+        parser.error("--candidate must name an existing prebuilt binary")
+    if args.baseline is not None and not args.baseline.is_file():
+        parser.error("--baseline must name an existing prebuilt binary")
+    if args.baseline is None and args.baseline_commit is not None:
+        parser.error("--baseline-commit requires --baseline")
+    if args.baseline is not None and args.baseline_commit is None:
+        parser.error("paired runs require --baseline-commit")
+    if args.baseline is not None and args.candidate_commit is None:
+        parser.error("paired runs require --candidate-commit")
+    pairs = args.pairs or (10 if args.suite == "full" else 5)
+    if pairs < 1 or args.reps < 1:
+        parser.error("pairs and reps must be positive")
+    if not math.isfinite(args.correctness_tol) or args.correctness_tol < 0:
+        parser.error("--correctness-tol must be finite and non-negative")
+    if not 0 <= args.required_improvement_percent < 100:
+        parser.error("--required-improvement-percent must be in [0, 100)")
+    if (
+        not math.isfinite(args.allowed_regression_percent)
+        or args.allowed_regression_percent < 0
+    ):
+        parser.error("--allowed-regression-percent must be finite and non-negative")
+    if not math.isfinite(args.max_dispersion_percent) or args.max_dispersion_percent <= 0:
+        parser.error("--max-dispersion-percent must be finite and positive")
+    if (
+        not math.isfinite(args.timeout_seconds)
+        or args.timeout_seconds <= 0
+        or args.max_rss_mib <= 0
+        or args.max_virtual_mib <= 0
+    ):
+        parser.error("timeout and memory limits must be positive")
+
+    selected = cases(args.suite)
+    unknown_primary = set(args.primary) - {case.name for case in selected}
+    if unknown_primary:
+        parser.error(f"unknown primary cases: {sorted(unknown_primary)}")
+    report: dict[str, object] = {
+        "protocol": vars(args) | {"candidate": str(args.candidate), "baseline": str(args.baseline) if args.baseline else None, "output": str(args.output)},
+        "loadavg_before": os.getloadavg(),
+        "binaries": {"candidate": {"path": str(args.candidate), "sha256": sha256(args.candidate)}},
+        "cases": {},
+    }
+    if args.baseline:
+        report["binaries"]["baseline"] = {"path": str(args.baseline), "sha256": sha256(args.baseline)}
+
+    baseline_errors: list[str] = []
+    candidate_errors: list[str] = []
+    correctness_errors: list[str] = []
+    shared_errors: list[str] = []
+    for case_index, case in enumerate(selected):
+        case_report: dict[str, object] = {"config": asdict(case), "baseline": [], "candidate": []}
+        report["cases"][case.name] = case_report
+        for pair in range(pairs):
+            order = ["candidate"] if args.baseline is None else (["baseline", "candidate"] if pair % 2 == 0 else ["candidate", "baseline"])
+            for kind in order:
+                binary = args.candidate if kind == "candidate" else args.baseline
+                commit = args.candidate_commit if kind == "candidate" else args.baseline_commit
+                try:
+                    result = run_once(
+                        binary,
+                        commit,
+                        case,
+                        args.reps,
+                        args.timeout_seconds,
+                        args.max_virtual_mib << 20,
+                        args.max_rss_mib << 10,
+                        args.correctness_tol,
+                        args.expected_backend,
+                        args.expected_features,
+                    )
+                    case_report[kind].append(result)
+                except OSError as error:
+                    message = f"{case.name} pair={pair} shared environment: {error}"
+                    shared_errors.append(message)
+                    case_report[kind].append({"error": message})
+                except ValueError as error:
+                    message = f"{case.name} pair={pair} {kind} correctness: {error}"
+                    correctness_errors.append(message)
+                    case_report[kind].append({"error": message})
+                except (subprocess.TimeoutExpired, RuntimeError, MemoryError) as error:
+                    message = f"{case.name} pair={pair} {kind}: {error}"
+                    (baseline_errors if kind == "baseline" else candidate_errors).append(message)
+                    case_report[kind].append({"error": message})
+
+    inconclusive_reasons = [*shared_errors, *baseline_errors]
+    fail_reasons = [*correctness_errors, *candidate_errors]
+    if not inconclusive_reasons and not fail_reasons and args.baseline:
+        max_dispersion = args.max_dispersion_percent / 100.0
+        for case_index, case in enumerate(selected):
+            case_report = report["cases"][case.name]
+            baseline_times = [run["seconds"] for run in case_report["baseline"]]
+            candidate_times = [run["seconds"] for run in case_report["candidate"]]
+            ratios = [
+                candidate / baseline
+                for baseline, candidate in zip(baseline_times, candidate_times)
+            ]
+            ratio_median = statistics.median(ratios)
+            ratio_ci = bootstrap_median_ci(ratios, seed=706_000 + case_index)
+            stats = {
+                "baseline_median_seconds": statistics.median(baseline_times),
+                "candidate_median_seconds": statistics.median(candidate_times),
+                "baseline_relative_mad": relative_mad(baseline_times),
+                "candidate_relative_mad": relative_mad(candidate_times),
+                "paired_ratio_median": ratio_median,
+                "paired_ratio_relative_mad": relative_mad(ratios),
+                "paired_ratio_ci95": ratio_ci,
+            }
+            case_report["statistics"] = stats
+            if stats["baseline_relative_mad"] > max_dispersion:
+                inconclusive_reasons.append(
+                    f"{case.name}: baseline dispersion exceeds limit"
+                )
+                continue
+            if (
+                stats["candidate_relative_mad"] > max_dispersion
+                or stats["paired_ratio_relative_mad"] > max_dispersion
+            ):
+                fail_reasons.append(
+                    f"{case.name}: candidate/paired dispersion exceeds limit"
+                )
+                continue
+            threshold = (
+                1.0 - args.required_improvement_percent / 100.0
+                if case.name in args.primary
+                else 1.0 + args.allowed_regression_percent / 100.0
+            )
+            if ratio_ci[1] > threshold:
+                fail_reasons.append(
+                    f"{case.name}: CI upper {ratio_ci[1]:.6f} exceeds {threshold:.6f}"
+                )
+
+    if fail_reasons:
+        status = "FAIL"
+    elif inconclusive_reasons:
+        status = "INCONCLUSIVE"
+    else:
+        status = "PASS"
+    reasons = [*inconclusive_reasons, *fail_reasons]
+    report["loadavg_after"] = os.getloadavg()
+    report["status"] = status
+    report["reasons"] = reasons
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    print(f"SRC benchmark gate: {status}; report={args.output}")
+    for reason in reasons:
+        print(reason)
+    return {"PASS": 0, "FAIL": 1, "INCONCLUSIVE": 2}[status]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-src-benchmark-gates.py
+++ b/scripts/run-src-benchmark-gates.py
@@ -10,6 +10,7 @@ import math
 import os
 import random
 import resource
+import signal
 import statistics
 import subprocess
 import tempfile
@@ -96,7 +97,11 @@ def run_once(
     expected_backend: str,
     expected_features: str,
 ) -> dict[str, object]:
-    env = os.environ.copy()
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("T4A_BENCH_") and not key.startswith("T4A_PROFILE_")
+    }
     env.update(
         {
             "RAYON_NUM_THREADS": "1",
@@ -126,25 +131,39 @@ def run_once(
         raise OSError("GNU /usr/bin/time is required for per-child peak RSS")
     with tempfile.NamedTemporaryFile() as rss_file:
         timed = [str(gnu_time), "-f", "%M", "-o", rss_file.name, *command]
-        completed = subprocess.run(
+        process = subprocess.Popen(
             timed,
             env=env,
             text=True,
-            capture_output=True,
-            timeout=timeout,
-            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
             preexec_fn=limit_address_space,
         )
+        try:
+            stdout, stderr = process.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired as error:
+            os.killpg(process.pid, signal.SIGKILL)
+            stdout, stderr = process.communicate()
+            raise subprocess.TimeoutExpired(
+                command,
+                timeout,
+                output=stdout,
+                stderr=stderr,
+            ) from error
         rss_file.seek(0)
         rss_text = rss_file.read().decode().strip()
-    if completed.returncode != 0:
+    if process.returncode != 0:
+        raise RuntimeError(f"exit={process.returncode}; stderr={stderr[-2000:]}")
+    records = parse_records(stdout)
+    required_records = ("build", "config", "preflight", "case")
+    if any(len(records.get(kind, [])) != 1 for kind in required_records):
         raise RuntimeError(
-            f"exit={completed.returncode}; stderr={completed.stderr[-2000:]}"
+            "benchmark output lacks exactly one build, config, preflight, and case record"
         )
-    records = parse_records(completed.stdout)
-    if len(records.get("build", [])) != 1 or len(records.get("case", [])) != 1:
-        raise RuntimeError("benchmark output lacks exactly one build and case record")
     build = records["build"][0]
+    config = records["config"][0]
+    preflight = records["preflight"][0]
     result = records["case"][0]
     if build.get("profile") != "release":
         raise RuntimeError(f"expected release profile, got {build.get('profile')}")
@@ -160,20 +179,68 @@ def run_once(
         raise RuntimeError(
             f"expected features {expected_features}, got {build.get('features')}"
         )
+
+    expected_config = {
+        "n_sites": str(case.n_sites),
+        "physical_dim": "2",
+        "mpo_bond": str(case.bond),
+        "mps_bond": str(case.bond),
+        "requested_max_rank": str(case.max_rank),
+        "reps": str(reps),
+        "mode": case.mode,
+        "algorithm": case.algorithm,
+        "rank_increment": str(case.rank_increment),
+        "final_svd": "false",
+        "src_seed": "1234",
+        "adaptive_rtol": "1e-4",
+        "adaptive_atol": "0",
+        "adaptive_min_rank": "2",
+    }
+    if any(config.get(key) != value for key, value in expected_config.items()):
+        raise RuntimeError(f"benchmark config mismatch: expected {expected_config}, got {config}")
+    expected_network_seed = "7" if case.mode == "mpo-mps" else "13"
+    if preflight.get("mode") != case.mode or preflight.get("network_seed") != expected_network_seed:
+        raise RuntimeError("benchmark preflight mode or network seed mismatch")
+    expected_name = (
+        f"mpo-mps/{case.algorithm}"
+        if case.mode == "mpo-mps"
+        else f"tree-mpo-mpo/{case.algorithm}"
+    )
+    expected_result = {
+        "name": expected_name,
+        "reps": str(reps),
+        "requested_max_rank": str(case.max_rank),
+        "src_seed": "1234",
+        "center": "S0" if case.mode == "mpo-mps" else "N0000",
+    }
+    if any(result.get(key) != value for key, value in expected_result.items()):
+        raise RuntimeError(f"benchmark case mismatch: expected {expected_result}, got {result}")
+
+    seconds = float(result["per_run_seconds"])
+    elapsed = float(result["elapsed_seconds"])
     relative_error = float(result["relative_error"])
-    if relative_error > correctness_tol:
+    effective_max_bond = int(result["effective_max_bond"])
+    if not math.isfinite(seconds) or seconds <= 0 or not math.isfinite(elapsed) or elapsed <= 0:
+        raise RuntimeError("benchmark timing must be finite and positive")
+    if (
+        not math.isfinite(relative_error)
+        or relative_error < 0
+        or relative_error > correctness_tol
+    ):
         raise ValueError(
-            f"relative error {relative_error} exceeds {correctness_tol}"
+            f"relative error {relative_error} is outside [0, {correctness_tol}]"
         )
+    if not 1 <= effective_max_bond <= case.max_rank:
+        raise RuntimeError("effective max bond is outside the declared rank cap")
     rss_kib = int(rss_text)
     if rss_kib > max_rss_kib:
         raise MemoryError(f"peak RSS {rss_kib} KiB exceeds {max_rss_kib} KiB")
     return {
-        "seconds": float(result["per_run_seconds"]),
+        "seconds": seconds,
         "relative_error": relative_error,
         "peak_rss_kib": rss_kib,
-        "stdout": completed.stdout,
-        "stderr": completed.stderr,
+        "stdout": stdout,
+        "stderr": stderr,
         "build": build,
         "result": result,
     }
@@ -182,7 +249,7 @@ def run_once(
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--candidate", type=Path, required=True)
-    parser.add_argument("--candidate-commit")
+    parser.add_argument("--candidate-commit", required=True)
     parser.add_argument("--baseline", type=Path)
     parser.add_argument("--baseline-commit")
     parser.add_argument("--suite", choices=("quick", "full"), default="quick")
@@ -209,15 +276,21 @@ def main() -> int:
         parser.error("--baseline-commit requires --baseline")
     if args.baseline is not None and args.baseline_commit is None:
         parser.error("paired runs require --baseline-commit")
-    if args.baseline is not None and args.candidate_commit is None:
-        parser.error("paired runs require --candidate-commit")
-    pairs = args.pairs or (10 if args.suite == "full" else 5)
+    pairs = (10 if args.suite == "full" else 5) if args.pairs is None else args.pairs
     if pairs < 1 or args.reps < 1:
         parser.error("pairs and reps must be positive")
+    minimum_pairs = 10 if args.suite == "full" else 5
+    if args.baseline is not None and pairs < minimum_pairs:
+        parser.error(
+            f"paired {args.suite} runs require at least {minimum_pairs} pairs"
+        )
     if not math.isfinite(args.correctness_tol) or args.correctness_tol < 0:
         parser.error("--correctness-tol must be finite and non-negative")
-    if not 0 <= args.required_improvement_percent < 100:
-        parser.error("--required-improvement-percent must be in [0, 100)")
+    if (
+        not math.isfinite(args.required_improvement_percent)
+        or not 0 <= args.required_improvement_percent < 100
+    ):
+        parser.error("--required-improvement-percent must be finite and in [0, 100)")
     if (
         not math.isfinite(args.allowed_regression_percent)
         or args.allowed_regression_percent < 0
@@ -238,7 +311,13 @@ def main() -> int:
     if unknown_primary:
         parser.error(f"unknown primary cases: {sorted(unknown_primary)}")
     report: dict[str, object] = {
-        "protocol": vars(args) | {"candidate": str(args.candidate), "baseline": str(args.baseline) if args.baseline else None, "output": str(args.output)},
+        "protocol": vars(args)
+        | {
+            "candidate": str(args.candidate),
+            "baseline": str(args.baseline) if args.baseline else None,
+            "output": str(args.output),
+            "pairs": pairs,
+        },
         "loadavg_before": os.getloadavg(),
         "binaries": {"candidate": {"path": str(args.candidate), "sha256": sha256(args.candidate)}},
         "cases": {},
@@ -250,7 +329,9 @@ def main() -> int:
     candidate_errors: list[str] = []
     correctness_errors: list[str] = []
     shared_errors: list[str] = []
-    for case_index, case in enumerate(selected):
+    if not Path("/usr/bin/time").is_file():
+        shared_errors.append("GNU /usr/bin/time is required for per-child peak RSS")
+    for case_index, case in enumerate([] if shared_errors else selected):
         case_report: dict[str, object] = {"config": asdict(case), "baseline": [], "candidate": []}
         report["cases"][case.name] = case_report
         for pair in range(pairs):
@@ -273,8 +354,8 @@ def main() -> int:
                     )
                     case_report[kind].append(result)
                 except OSError as error:
-                    message = f"{case.name} pair={pair} shared environment: {error}"
-                    shared_errors.append(message)
+                    message = f"{case.name} pair={pair} {kind} launch: {error}"
+                    (baseline_errors if kind == "baseline" else candidate_errors).append(message)
                     case_report[kind].append({"error": message})
                 except ValueError as error:
                     message = f"{case.name} pair={pair} {kind} correctness: {error}"

--- a/scripts/test-run-src-benchmark-gates.py
+++ b/scripts/test-run-src-benchmark-gates.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Tests for run-src-benchmark-gates.py."""
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("run-src-benchmark-gates.py")
+SPEC = importlib.util.spec_from_file_location("src_benchmark_gates", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class SrcBenchmarkGateTests(unittest.TestCase):
+    def test_parse_records_and_statistics(self):
+        records = MODULE.parse_records(
+            "record=build git_commit=abc profile=release\n"
+            "record=case name=x per_run_seconds=0.25 relative_error=1e-12\n"
+        )
+        self.assertEqual(records["build"][0]["git_commit"], "abc")
+        self.assertEqual(records["case"][0]["name"], "x")
+        self.assertEqual(MODULE.relative_mad([1.0, 1.0, 1.0]), 0.0)
+        self.assertEqual(
+            MODULE.bootstrap_median_ci([0.9, 1.0, 1.1], 7, 100),
+            MODULE.bootstrap_median_ci([0.9, 1.0, 1.1], 7, 100),
+        )
+
+    def test_suite_shapes_are_fixed(self):
+        quick = MODULE.cases("quick")
+        self.assertEqual(len(quick), 4)
+        self.assertTrue(all(case.max_rank == 32 for case in quick))
+        self.assertTrue(all(case.rank_increment == 3 for case in quick))
+        full = MODULE.cases("full")
+        self.assertEqual(len(full), 30)
+        self.assertNotIn(15, {case.n_sites for case in full if case.mode == "tree"})
+
+    def run_gate(
+        self,
+        baseline_error: str,
+        candidate_error: str,
+        baseline_features: str = "fake",
+        candidate_features: str = "fake",
+    ):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            baseline = self.write_fake(
+                root / "baseline", "base", 1.0, baseline_error, baseline_features
+            )
+            candidate = self.write_fake(
+                root / "candidate", "cand", 0.99, candidate_error, candidate_features
+            )
+            report = root / "report.json"
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--baseline",
+                    str(baseline),
+                    "--baseline-commit",
+                    "base",
+                    "--candidate",
+                    str(candidate),
+                    "--candidate-commit",
+                    "cand",
+                    "--expected-backend",
+                    "fake",
+                    "--expected-features",
+                    "fake",
+                    "--pairs",
+                    "1",
+                    "--reps",
+                    "1",
+                    "--max-dispersion-percent",
+                    "100",
+                    "--output",
+                    str(report),
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            return completed.returncode, json.loads(report.read_text())
+
+    @staticmethod
+    def write_fake(
+        path: Path,
+        commit: str,
+        seconds: float,
+        relative_error: str,
+        features: str = "fake",
+    ) -> Path:
+        path.write_text(
+            "#!/bin/sh\n"
+            f"echo 'record=build git_commit={commit} profile=release backend=fake features={features}'\n"
+            f"echo 'record=case name=fake reps=1 elapsed_seconds={seconds} per_run_seconds={seconds} nodes=1 edges=0 requested_max_rank=32 effective_max_bond=1 src_seed=1234 relative_error={relative_error}'\n"
+        )
+        path.chmod(0o700)
+        return path
+
+    def test_paired_synthetic_gate_passes(self):
+        code, report = self.run_gate("0", "0")
+        self.assertEqual(code, 0)
+        self.assertEqual(report["status"], "PASS")
+
+    def test_candidate_correctness_failure_is_fail(self):
+        code, report = self.run_gate("0", "1")
+        self.assertEqual(code, 1)
+        self.assertEqual(report["status"], "FAIL")
+
+    def test_baseline_identity_failure_is_inconclusive(self):
+        code, report = self.run_gate("0", "0", baseline_features="wrong")
+        self.assertEqual(code, 2)
+        self.assertEqual(report["status"], "INCONCLUSIVE")
+
+    def test_baseline_correctness_failure_is_fail(self):
+        code, report = self.run_gate("1", "0")
+        self.assertEqual(code, 1)
+        self.assertEqual(report["status"], "FAIL")
+
+    def test_candidate_feature_mismatch_is_fail(self):
+        code, report = self.run_gate("0", "0", candidate_features="wrong")
+        self.assertEqual(code, 1)
+        self.assertEqual(report["status"], "FAIL")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-run-src-benchmark-gates.py
+++ b/scripts/test-run-src-benchmark-gates.py
@@ -3,9 +3,11 @@
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -46,6 +48,8 @@ class SrcBenchmarkGateTests(unittest.TestCase):
         candidate_error: str,
         baseline_features: str = "fake",
         candidate_features: str = "fake",
+        pairs: int = 5,
+        required_improvement: str = "0",
     ):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -73,7 +77,9 @@ class SrcBenchmarkGateTests(unittest.TestCase):
                     "--expected-features",
                     "fake",
                     "--pairs",
-                    "1",
+                    str(pairs),
+                    "--required-improvement-percent",
+                    required_improvement,
                     "--reps",
                     "1",
                     "--max-dispersion-percent",
@@ -84,8 +90,14 @@ class SrcBenchmarkGateTests(unittest.TestCase):
                 text=True,
                 capture_output=True,
                 check=False,
+                env=os.environ
+                | {
+                    "T4A_BENCH_CENTER": "stale-center",
+                    "T4A_PROFILE_CONTRACT": "stale-profile",
+                },
             )
-            return completed.returncode, json.loads(report.read_text())
+            report_data = json.loads(report.read_text()) if report.exists() else None
+            return completed.returncode, report_data
 
     @staticmethod
     def write_fake(
@@ -97,8 +109,12 @@ class SrcBenchmarkGateTests(unittest.TestCase):
     ) -> Path:
         path.write_text(
             "#!/bin/sh\n"
+            "n=$1; bond=$2; reps=$3; mode=$4; increment=$5; final_svd=$6; max_rank=$7\n"
+            "if [ \"$mode\" = mpo-mps ]; then seed=7; center=S0; name=mpo-mps/$T4A_BENCH_ALGORITHM; else seed=13; center=N0000; name=tree-mpo-mpo/$T4A_BENCH_ALGORITHM; fi\n"
             f"echo 'record=build git_commit={commit} profile=release backend=fake features={features}'\n"
-            f"echo 'record=case name=fake reps=1 elapsed_seconds={seconds} per_run_seconds={seconds} nodes=1 edges=0 requested_max_rank=32 effective_max_bond=1 src_seed=1234 relative_error={relative_error}'\n"
+            "echo \"record=config n_sites=$n physical_dim=2 mpo_bond=$bond mps_bond=$bond requested_max_rank=$max_rank reps=$reps mode=$mode algorithm=$T4A_BENCH_ALGORITHM rank_increment=$increment final_svd=$final_svd src_seed=1234 adaptive_rtol=1e-4 adaptive_atol=0 adaptive_min_rank=2\"\n"
+            "echo \"record=preflight mode=$mode network_seed=$seed total_input_bytes=8 largest_input_tensor_bytes=8 dense_output_bytes=8 max_degree=2 max_input_bytes=1024 max_dense_bytes=1024\"\n"
+            f"echo \"record=case name=$name reps=$reps elapsed_seconds={seconds} per_run_seconds={seconds} nodes=1 edges=0 requested_max_rank=$max_rank effective_max_bond=1 src_seed=1234 center=$center relative_error={relative_error}\"\n"
         )
         path.chmod(0o700)
         return path
@@ -107,6 +123,7 @@ class SrcBenchmarkGateTests(unittest.TestCase):
         code, report = self.run_gate("0", "0")
         self.assertEqual(code, 0)
         self.assertEqual(report["status"], "PASS")
+        self.assertEqual(report["protocol"]["pairs"], 5)
 
     def test_candidate_correctness_failure_is_fail(self):
         code, report = self.run_gate("0", "1")
@@ -127,6 +144,54 @@ class SrcBenchmarkGateTests(unittest.TestCase):
         code, report = self.run_gate("0", "0", candidate_features="wrong")
         self.assertEqual(code, 1)
         self.assertEqual(report["status"], "FAIL")
+
+    def test_non_finite_error_is_fail(self):
+        code, report = self.run_gate("0", "nan")
+        self.assertEqual(code, 1)
+        self.assertEqual(report["status"], "FAIL")
+
+    def test_paired_quick_gate_rejects_fewer_than_five_pairs(self):
+        code, report = self.run_gate("0", "0", pairs=1)
+        self.assertEqual(code, 2)
+        self.assertIsNone(report)
+
+    def test_non_finite_improvement_is_rejected(self):
+        code, report = self.run_gate("0", "0", required_improvement="nan")
+        self.assertEqual(code, 2)
+        self.assertIsNone(report)
+
+    def test_timeout_kills_the_benchmark_process_group(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            child_pid = root / "child.pid"
+            binary = root / "hang"
+            binary.write_text(
+                "#!/bin/sh\n"
+                f"sleep 30 & echo $! > {child_pid}\n"
+                "wait\n"
+            )
+            binary.chmod(0o700)
+            with self.assertRaises(subprocess.TimeoutExpired):
+                MODULE.run_once(
+                    binary,
+                    None,
+                    MODULE.cases("quick")[0],
+                    1,
+                    0.1,
+                    1 << 30,
+                    1 << 20,
+                    1.0e-8,
+                    "fake",
+                    "fake",
+                )
+            pid = int(child_pid.read_text())
+            time.sleep(0.1)
+            self.assertNotEqual(
+                subprocess.run(
+                    ["ps", "-p", str(pid)], capture_output=True, check=False
+                ).returncode,
+                0,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- route connected binary/no-retain generic contractions through the canonical pairwise fast path and return SRC call sites to the generic seam
- add caller-owned `PreparedContraction` for repeated compatible N-ary/retained contractions, including structured, mixed-dtype, and AD coverage
- define fixed-rank SRC `max_bond_dim` as a per-cut upper bound and report requested/effective ranks separately
- replace the invalid unbounded star benchmark with checked bounded binary-tree gates and add a reproducible paired runner
- align adaptive tree environment-cache segments after measured restack overhead
- close the remaining fixed-overhead, directed-planner, and flattened-batch candidates with fresh failed need-gate evidence rather than speculative APIs

## Design and evidence

- [Execution plan](docs/plans/2026-09-03-issue-698-follow-ups.md)
- [Prepared contraction design](docs/plans/2026-09-03-prepared-contraction-design.md)
- [Fixed-rank semantics design](docs/plans/2026-09-03-fixed-rank-src-semantics-design.md)
- [Benchmark gate design](docs/plans/2026-09-03-src-benchmark-gates-design.md)
- [Final multi-lane audit](docs/worklogs/2026-09-03-issue-698-final-audit.md)

All design/task reviews and the five final audit lanes ended `Correct-to-merge`/`PASS`; the final integration audit passed on `d29ffd92195f70cf17f85c3cfaea2c38c4d1fba6` with no findings.

## Performance

- binary generic entry: within noise of explicit pairwise (fixed +0.62%, adaptive +0.06% paired medians)
- prepared 3-operand contraction: 14–17% faster in five fresh processes
- tree cache alignment: primary n=7/bond-4 adaptive case improved 5.46%; final complete quick gate passed; bond-8 n=7/n=10 diagnostics improved 3.89%/4.88%
- no-code need gates: fixed N-ary sections 7.7% combined, directed-message planning 4.36–5.00%, plan lookup + session shell 1.95% (all below the predeclared 10% threshold)

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc`
- all 3,252 non-HDF5 nextest tests (3,250 complete-run passes + the two timeout-interrupted long tests rerun and passed)
- HDF5: 1 unit + 46 integration + 10 doctests passed (4 annotated ignores)
- workspace doctests and `TENSOR4ALL_CARGO_PROFILE=ci ./scripts/test-mdbook.sh`
- `cargo doc --workspace --no-deps`
- public API dump, public-error docs, crate boundaries, C API header, repository-rules review
- benchmark runner: 11 tests; Rust estimator: 3 tests; final quick exact smoke: PASS
- provider-injection compile: PASS
- CUDA TreeTN: 9 tests PASS on NVIDIA A100 80GB

Coverage impact attestation: removed/redirected paths and every new branch were reviewed; focused replacement coverage covers binary dispatch, prepared compatibility/error/structured/AD paths, rank boundaries, cache alignment/fallback, memory overflow, runner classification/provenance/non-finite inputs, and process cleanup. No tolerance or coverage threshold changed. Hosted CI remains authoritative for percentage coverage.

Closes #698
Closes #700
Closes #701
Closes #702
Closes #703
Closes #704
Closes #705
Closes #706