### PR TITLE
Add caller-owned context-scoped tensor construction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,10 +86,10 @@ ndarray = "0.17"
 quanticsgrids = { git = "https://github.com/tensor4all/quanticsgrids-rs", rev = "8214b72" }
 hdf5-rt = { git = "https://github.com/tensor4all/hdf5-rt", default-features = false }
 hataori = { git = "https://github.com/shinaoka/hataori-rs.git", rev = "59d0ccd6b403e285b7e716a8ae6d12d851da13b1", default-features = false }
-tenferro = { package = "tenferro-runtime", git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45", default-features = false }
-tenferro-ad = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45", default-features = false }
-tenferro-cpu = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45", default-features = false }
-tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45", default-features = false }
-tenferro-linalg = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45", default-features = false }
-tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45", default-features = false }
-tenferro-gpu = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45", default-features = false }
+tenferro = { package = "tenferro-runtime", git = "https://github.com/tensor4all/tenferro-rs.git", rev = "007e3bb6c1187a2569d237b2bc6e6ad486f2b4f4", default-features = false }
+tenferro-ad = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "007e3bb6c1187a2569d237b2bc6e6ad486f2b4f4", default-features = false }
+tenferro-cpu = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "007e3bb6c1187a2569d237b2bc6e6ad486f2b4f4", default-features = false }
+tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "007e3bb6c1187a2569d237b2bc6e6ad486f2b4f4", default-features = false }
+tenferro-linalg = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "007e3bb6c1187a2569d237b2bc6e6ad486f2b4f4", default-features = false }
+tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "007e3bb6c1187a2569d237b2bc6e6ad486f2b4f4", default-features = false }
+tenferro-gpu = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "007e3bb6c1187a2569d237b2bc6e6ad486f2b4f4", default-features = false }

--- a/crates/tensor4all-core/Cargo.toml
+++ b/crates/tensor4all-core/Cargo.toml
@@ -69,6 +69,7 @@ tenferro-tensor.workspace = true
 [dev-dependencies]
 rand_chacha.workspace = true
 tenferro-tensor.workspace = true
+tenferro-cpu.workspace = true
 approx.workspace = true
 criterion.workspace = true
 

--- a/crates/tensor4all-core/src/defaults/idx_tensor.rs
+++ b/crates/tensor4all-core/src/defaults/idx_tensor.rs
@@ -23,8 +23,8 @@ use tenferro_linalg::EagerTensorLinalgExt;
 use tensor4all_tensorbackend::{
     contract_native_tensor, default_eager_ctx, dense_native_tensor_from_col_major,
     diag_native_tensor_from_col_major, native_tensor_primal_to_diag,
-    storage_payload_native_read_input, storage_to_native_tensor, NativeTensorReadInput,
-    TensorElement,
+    storage_payload_native_read_input, storage_to_native_tensor, ExecutionContext,
+    NativeTensorReadInput, TensorElement,
 };
 use tensor4all_tensorbackend::{src_error_estimate as backend_src_error_estimate, Matrix};
 use tensor4all_tensorbackend::{IncrementalQr, IncrementalQrScalar};
@@ -7138,6 +7138,171 @@ impl IdxTensor {
     /// ```
     pub fn is_complex(&self) -> bool {
         self.storage.is_complex()
+    }
+    /// Create a dense tensor in a caller-owned execution context.
+    ///
+    /// Host data is explicitly uploaded when `context` is CUDA-resident; no
+    /// global default context is consulted.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tensor4all_core::{DynIndex, ExecutionContext, IdxTensor};
+    /// use tensor4all_tensorbackend::CpuExecutionContext;
+    /// use tenferro_cpu::CpuBackend;
+    ///
+    /// let context = ExecutionContext::Cpu(Arc::new(
+    ///     CpuExecutionContext::from_backend(CpuBackend::new()),
+    /// ));
+    /// let index = DynIndex::new_dyn(2);
+    /// let tensor = IdxTensor::from_dense_in(&context, vec![index], vec![1.0_f64, 2.0])?;
+    /// assert_eq!(tensor.to_vec::<f64>()?, vec![1.0, 2.0]);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdxTensorError`] when the indices, payload, context, or
+    /// explicit transfer is invalid.
+    pub fn from_dense_in<T: TensorElement>(
+        context: &ExecutionContext,
+        indices: Vec<DynIndex>,
+        data: Vec<T>,
+    ) -> std::result::Result<Self, IdxTensorError> {
+        let dims = Self::expected_dims_from_indices(&indices);
+        Self::validate_indices(&indices)?;
+        Self::validate_dense_payload_len(data.len(), &dims)?;
+        let native = dense_native_tensor_from_col_major(&data, &dims)
+            .map_err(|error| IdxTensorError::operation("context-scoped construction", error))?;
+        let inner = match context {
+            ExecutionContext::Cpu(context) => {
+                let runtime = context.eager_runtime().map_err(|error| {
+                    IdxTensorError::operation("CPU context construction", anyhow::Error::new(error))
+                })?;
+                EagerTensor::from_tensor_in(native, runtime).map_err(|error| {
+                    IdxTensorError::operation(
+                        "CPU context eager wrapping",
+                        anyhow::Error::new(error),
+                    )
+                })?
+            }
+            #[cfg(feature = "tenferro-cuda")]
+            ExecutionContext::Cuda(context) => {
+                let uploaded = context.upload_cuda(&native).map_err(|error| {
+                    IdxTensorError::operation(
+                        "CUDA context construction",
+                        anyhow::Error::new(error),
+                    )
+                })?;
+                EagerTensor::from_tensor_in(
+                    uploaded,
+                    context.eager_runtime().map_err(|error| {
+                        IdxTensorError::operation(
+                            "CUDA context eager runtime",
+                            anyhow::Error::new(error),
+                        )
+                    })?,
+                )
+                .map_err(|error| {
+                    IdxTensorError::operation(
+                        "CUDA context eager wrapping",
+                        anyhow::Error::new(error),
+                    )
+                })?
+            }
+        };
+        Self::from_inner(indices, inner).map_err(IdxTensorError::from)
+    }
+
+    /// Create an all-ones tensor in a caller-owned execution context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tensor4all_core::{DynIndex, ExecutionContext, IdxTensor};
+    /// use tensor4all_tensorbackend::CpuExecutionContext;
+    /// use tenferro_cpu::CpuBackend;
+    ///
+    /// let context = ExecutionContext::Cpu(Arc::new(
+    ///     CpuExecutionContext::from_backend(CpuBackend::new()),
+    /// ));
+    /// let index = DynIndex::new_dyn(2);
+    /// let tensor = IdxTensor::ones_in(&context, &[index])?;
+    /// assert_eq!(tensor.to_vec::<f64>()?, vec![1.0, 1.0]);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdxTensorError`] when the index dimensions or context
+    /// construction is invalid.
+    pub fn ones_in(
+        context: &ExecutionContext,
+        indices: &[DynIndex],
+    ) -> std::result::Result<Self, IdxTensorError> {
+        let dims = Self::expected_dims_from_indices(indices);
+        let total_size = checked_total_size(&dims)?;
+        Self::from_dense_in(context, indices.to_vec(), vec![1.0_f64; total_size])
+    }
+
+    /// Validate that this tensor belongs to the supplied execution context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tensor4all_core::{DynIndex, ExecutionContext, IdxTensor};
+    /// use tensor4all_tensorbackend::CpuExecutionContext;
+    /// use tenferro_cpu::CpuBackend;
+    ///
+    /// let context = ExecutionContext::Cpu(Arc::new(
+    ///     CpuExecutionContext::from_backend(CpuBackend::new()),
+    /// ));
+    /// let index = DynIndex::new_dyn(2);
+    /// let tensor = IdxTensor::from_dense_in(&context, vec![index], vec![1.0_f64, 2.0])?;
+    /// tensor.validate_context(&context)?;
+    /// assert_eq!(tensor.dims(), vec![2]);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdxTensorError`] when the tensor does not belong to `context`.
+    pub fn validate_context(
+        &self,
+        context: &ExecutionContext,
+    ) -> std::result::Result<(), IdxTensorError> {
+        let Some(inner) = self.storage.eager() else {
+            if matches!(context, ExecutionContext::Cpu(_)) {
+                return Ok(());
+            }
+            return Err(IdxTensorError::operation(
+                "context validation",
+                anyhow::anyhow!("tensor has no CUDA eager runtime"),
+            ));
+        };
+        match context {
+            ExecutionContext::Cpu(context) => {
+                let expected = context.eager_runtime().map_err(|error| {
+                    IdxTensorError::operation("CPU context validation", anyhow::Error::new(error))
+                })?;
+                if inner.ctx_id() != expected.id() {
+                    return Err(IdxTensorError::operation(
+                        "context validation",
+                        anyhow::anyhow!("tensor belongs to a different CPU eager context"),
+                    ));
+                }
+            }
+            #[cfg(feature = "tenferro-cuda")]
+            ExecutionContext::Cuda(context) => {
+                self.validate_cuda_residency(context).map_err(|error| {
+                    IdxTensorError::operation("CUDA context validation", anyhow::Error::new(error))
+                })?;
+            }
+        }
+        Ok(())
     }
 }
 

--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -119,6 +119,8 @@ pub use defaults::idx_tensor::{
 };
 #[cfg(feature = "tenferro-cuda")]
 pub use defaults::IdxTensorCudaError;
+#[cfg(feature = "backend-tenferro")]
+pub use tensor4all_tensorbackend::ExecutionContext;
 pub use tensor4all_tensorbackend::TensorElement;
 pub use tensor4all_tensorbackend::{
     print_and_reset_native_einsum_profile, reset_native_einsum_profile,

--- a/crates/tensor4all-core/tests/context_foundation.rs
+++ b/crates/tensor4all-core/tests/context_foundation.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+
+use tenferro_cpu::CpuBackend;
+use tensor4all_core::{DynIndex, ExecutionContext, IdxTensor};
+use tensor4all_tensorbackend::CpuExecutionContext;
+
+fn cpu_context() -> ExecutionContext {
+    ExecutionContext::Cpu(Arc::new(CpuExecutionContext::from_backend(
+        CpuBackend::new(),
+    )))
+}
+
+#[test]
+fn context_scoped_construction_uses_the_supplied_cpu_runtime() {
+    let context = cpu_context();
+    let index = DynIndex::new_dyn(2);
+    let tensor = IdxTensor::from_dense_in(&context, vec![index], vec![1.0_f64, 2.0]).unwrap();
+
+    tensor.validate_context(&context).unwrap();
+    assert_eq!(tensor.to_vec::<f64>().unwrap(), vec![1.0, 2.0]);
+
+    let ones = IdxTensor::ones_in(&context, tensor.indices()).unwrap();
+    assert_eq!(ones.to_vec::<f64>().unwrap(), vec![1.0, 1.0]);
+}
+
+#[test]
+fn context_validation_rejects_a_different_cpu_runtime() {
+    let first = cpu_context();
+    let second = cpu_context();
+    let tensor =
+        IdxTensor::from_dense_in(&first, vec![DynIndex::new_dyn(1)], vec![3.0_f64]).unwrap();
+
+    assert!(tensor.validate_context(&second).is_err());
+}
+
+#[cfg(feature = "tenferro-cuda")]
+#[test]
+#[ignore]
+fn context_scoped_cuda_construction_stays_in_the_selected_runtime() {
+    let cuda = tensor4all_tensorbackend::CudaExecutionContext::new().unwrap();
+    let context = ExecutionContext::Cuda(Arc::new(cuda));
+    let tensor =
+        IdxTensor::from_dense_in(&context, vec![DynIndex::new_dyn(2)], vec![1.0_f64, 2.0]).unwrap();
+
+    tensor.validate_context(&context).unwrap();
+}

--- a/crates/tensor4all-tensorbackend/src/context.rs
+++ b/crates/tensor4all-tensorbackend/src/context.rs
@@ -8,6 +8,19 @@ use tenferro_ad::{AdContext, EagerRuntime};
 use tenferro_cpu::{BufferPoolStats, CpuBackend};
 use tenferro_tensor::{BackendSession, BackendSessionHost};
 
+/// Caller-owned execution domain used by context-aware tensor algorithms.
+///
+/// Values are validated against the exact runtime represented by the selected
+/// context; no implicit host/device transfer is performed by this enum.
+#[derive(Clone, Debug)]
+pub enum ExecutionContext {
+    /// Host execution through one caller-owned CPU context.
+    Cpu(Arc<CpuExecutionContext>),
+    /// CUDA execution through one caller-owned CUDA context.
+    #[cfg(feature = "tenferro-cuda")]
+    Cuda(Arc<crate::cuda::CudaExecutionContext>),
+}
+
 /// Error returned by explicit CPU context graph or eager-runtime operations.
 ///
 /// The original tenferro diagnostic is retained as the error source.

--- a/crates/tensor4all-tensorbackend/src/lib.rs
+++ b/crates/tensor4all-tensorbackend/src/lib.rs
@@ -56,7 +56,7 @@ pub use backend::{
 #[cfg(feature = "global-defaults")]
 pub use context::{default_eager_ctx, with_default_backend, EagerContextError};
 #[cfg(feature = "explicit-context")]
-pub use context::{CpuExecutionContext, CpuExecutionContextError};
+pub use context::{CpuExecutionContext, CpuExecutionContextError, ExecutionContext};
 #[cfg(feature = "tenferro-cuda")]
 pub use cuda::{CudaExecutionContext, CudaExecutionContextError, CUDA_ORDINAL};
 #[cfg(feature = "global-defaults")]

--- a/docs/design/context-scoped-src-contraction.md
+++ b/docs/design/context-scoped-src-contraction.md
@@ -1,0 +1,267 @@
+# Context-scoped SRC contraction
+
+**Status:** Reviewed and approved for tensor4all-rs #720 and the first #623 Stage-2 migration
+
+## Problem and baseline
+
+`TreeTN` SRC currently creates Gaussian probes with `T::from_dense` and scalar
+caps with `T::ones`. For `IdxTensor`, those context-free constructors enter the
+process-global CPU eager runtime. Combining the resulting tensors with inputs
+uploaded into a caller-selected `CudaExecutionContext` therefore crosses both
+placement and eager-runtime identities.
+
+On an NVIDIA A100, same-context CUDA pairwise contraction succeeds, while the
+first general SRC contraction reaches a CPU extension and fails because its
+operand is device-resident. CUDA eager QR/SVD also fail on the current pin even
+though current tenferro direct CUDA-session QR/SVD kernels pass. The upstream
+prerequisite is the separately reviewed placement-aware eager extension
+dispatch design in tenferro.
+
+## Invariants
+
+- One caller-supplied execution context is the sole construction and validation
+  authority for an SRC call.
+- Both input trees, all probes/caps, every contraction/factorization/truncation
+  output, and the returned tree belong to that exact context.
+- Placement remains metadata on the underlying tenferro tensor; tensor4all
+  adds no second device tag.
+- There is no automatic host/device migration, CPU numerical fallback, backend
+  construction, or process-global context lookup in the explicit path.
+- Host-originated constructor data and bounded decision metadata readbacks are
+  explicit context operations. They are documented and measured; they are not
+  arithmetic fallbacks.
+- Full `Index` identity, direction, prime level, tags, order, column-major
+  payload semantics, dtype, storage class, eager AD identity, numerical
+  policies, and source errors are preserved.
+
+## Dependency-ordered PRs
+
+### PR 1: tenferro eager extension target dispatch
+
+Make eager general/N-ary einsum and linalg extension registration select the
+validated owning runtime target. This is an upstream tenferro PR with its own
+design and review gates.
+
+### PR 2: tensor4all context foundation and tenferro pin
+
+After PR 1 merges, update all seven tensor4all tenferro pins together. A
+compatibility probe from tensor4all `origin/main` to tenferro `0190e43b` passed
+both targeted CPU `--all-targets` and CUDA feature checks without source
+changes, so a separate mechanical pin-only PR is unnecessary.
+
+Add a reusable `TensorExecutionContext<T>` trait in `tensor4all-core`. It is
+not SRC-specific. Its initial required operations are:
+
+```text
+validate_tensor(&self, operation, &T)
+from_dense(&self, ordered_indices, column_major_host_data)
+ones(&self, ordered_indices)
+read_decision_data(&self, operation, &T)
+```
+
+The construction methods return `T` in the supplied context. The decision-read
+method is an explicit, typed synchronization/readback boundary for small
+algorithm-control payloads; it cannot be called by ordinary tensor arithmetic.
+The interface remains generic and statically dispatched rather than storing a
+trait object or execution context inside each tensor.
+
+Implement the trait for `IdxTensor` with both `CpuExecutionContext` and
+`CudaExecutionContext`. The implementations:
+
+- validate eager runtime identity, placement, allocation domain, supported
+  dtype, untracked status where required, dense axis classes, and storage kind;
+- create a host native tensor from column-major data, then either adopt it into
+  the supplied CPU eager runtime or explicitly upload it through the supplied
+  CUDA context before eager wrapping;
+- preserve the original ordered full indices;
+- retain original tensorbackend/tenferro errors as typed sources.
+
+No constructor derives a fresh tensor's home from another tensor. Inputs are
+only checked against the caller's chosen context.
+
+Extend `CudaExecutionContext` with `new_on(visible_ordinal)` and retain `new()`
+as ordinal-0 construction only if it remains a documented convenience rather
+than the canonical API. Context state and diagnostics record the selected
+ordinal. No operation relies on thread-local current-device state. Allocation
+and eager-runtime identity, not ordinal text alone, decide compatibility.
+
+The explicit CPU implementation never consults the default context. Existing
+CPU-global convenience APIs may remain at their current compatibility boundary,
+but the new trait implementation and every explicit-context test are built and
+checked without using them.
+
+### PR 3: context-aware factorization and SRC decision primitives
+
+Make the factorization operations required by SRC context-aware before changing
+SRC itself:
+
+- QR, including incremental probe QR;
+- SVD and device-resident slicing/truncation;
+- the Appendix-C adaptive SRC error estimate;
+- final-SVD factor absorption.
+
+Eager QR/SVD/triangular-solve and elementwise/reduction operations execute in
+the operand's owning runtime after the upstream dispatch fix. Identity/one
+values are constructed through `TensorExecutionContext`.
+
+Current `svd_truncated_inner` calls `EagerTensor::value()` and reads the full
+singular-value vector on host to choose rank. Current
+`IdxTensor::src_error_estimate` materializes the full QR factor into host
+`Matrix` and performs the estimator on the CPU. Neither path is acceptable for
+CUDA SRC.
+
+Replace the adaptive estimator's CPU fallback with eager operations in the
+same runtime: form `R†`, solve the triangular system there, compute norm terms
+there, and read back only the bounded scalar/vector decision payload needed by
+Rust control flow. SVD factors and slicing remain resident; only singular
+values needed for rank selection/public diagnostics cross the explicit
+`read_decision_data` boundary. Validate results after each factorization and
+slice.
+
+Record synchronization count and transferred decision bytes. This is the
+unavoidable scalar/rank-selection readback anticipated by #623; it is not an
+implicit tensor download and must never reconstruct an arithmetic operand on
+CPU.
+
+### PR 4: SRC API and algorithm migration
+
+Make the canonical Rust SRC entry accept `&impl TensorExecutionContext<T>`.
+Thread it through chain/tree scheduling, probe batches, caps, fixed/adaptive
+factorization, optional final SVD, and result assembly. Validate both complete
+input trees before RNG advancement or contraction. Mixed host/CUDA inputs and
+foreign CUDA contexts fail at this boundary.
+
+The API migration must leave no public CUDA-capable SRC route that omits a
+context. Existing CPU convenience layers may explicitly pass their existing CPU
+context, but generic SRC implementation code cannot call a global helper.
+Context-free `T::from_dense`, `T::ones`, `T::scalar_one`, direct host matrix
+conversion, and unscoped factorization are forbidden in production SRC files.
+
+Fixed/adaptive semantics, deterministic seed prefixes, cap normalization,
+chain/tree topology handling, final-SVD behavior, and existing CPU results stay
+unchanged.
+
+## Error model
+
+Add non-exhaustive public errors with explicit variants for:
+
+- host/device mismatch;
+- foreign eager context or CUDA allocation domain;
+- selected-device mismatch;
+- unsupported dtype, storage, tracked value, or operation;
+- context construction/transfer/synchronization failure;
+- bounded decision readback failure;
+- factorization and contraction failures.
+
+Each wrapper stores the original lower-level error as `#[source]`. Validation
+errors identify the operation and offending tree/node. No panic, string-only
+flattening, or `anyhow` erasure may occur at the public boundary.
+
+## Construction and transfer semantics
+
+`from_dense` accepts host-originated column-major values. With a CUDA context,
+its contract explicitly includes one host-to-device construction transfer. SRC
+probe/cap construction therefore remains visible to instrumentation and is
+reported separately from caller input upload and steady-state arithmetic.
+There is no device-to-host conversion of probes, caps, intermediates, factors,
+or results.
+
+Decision readbacks are a separate category and are limited to:
+
+- singular values needed to choose/return retained rank;
+- final scalar estimates required by adaptive stopping.
+
+A test counter rejects any other transfer during the algorithm.
+
+## Tests
+
+### CPU and hardware-independent
+
+- Explicit CPU construction uses exactly the supplied eager runtime.
+- Different CPU contexts are rejected.
+- Column-major F64/C64 probe and cap values plus complete indices round-trip.
+- CUDA features remain optional and CPU-only/explicit-only builds compile.
+- Mixed placement, foreign context, unsupported dtype/storage/tracked inputs,
+  and invalid options fail before RNG or arithmetic.
+- A recording context proves every SRC constructor and validation hook is
+  scoped; source-contract tests reject global-default calls in production SRC.
+- Existing CPU fixed/adaptive and chain/tree result tests remain numerically
+  unchanged.
+- Runnable doctests demonstrate explicit CPU and feature-gated CUDA use with
+  assertions.
+
+### Real CUDA
+
+For F64 and C64 where all required kernels are supported, cover the matrix:
+
+- fixed and adaptive mode;
+- chain and branched tree;
+- `final_svd` false and true.
+
+For every case:
+
+- upload both inputs into one caller-owned context;
+- validate every observed intermediate and the output against its exact eager
+  runtime/allocation domain;
+- compare the explicitly downloaded result with CPU using complete index order
+  and a dense whole-result `maxabs` residual;
+- assert no CPU arithmetic fallback and no unclassified transfer;
+- verify mixed host/CUDA and two-context inputs return typed source chains before
+  work begins.
+
+Unsupported dtype/operation cases fail at entry and do not partially execute.
+
+## Benchmark evidence
+
+The release benchmark reports independently:
+
+1. host fixture setup;
+2. CPU/CUDA context setup;
+3. explicit input upload;
+4. probe/cap construction transfer;
+5. warm-up/JIT;
+6. synchronized steady-state SRC;
+7. decision-readback synchronization/count/bytes;
+8. explicit result download;
+9. CPU steady-state reference.
+
+Correctness and residency assertions are outside timed loops. Warm-up is never
+included in the steady-state statistic.
+
+## Sibling audit
+
+Audit all touched construction/factorization helpers and all uses of
+`T::from_dense`, `from_dense_any`, `ones`, `scalar_one`, host `Matrix`
+materialization, `EagerTensor::value`, and `to_vec` reachable from SRC. Fix
+shared seams needed by SRC in PRs 2-3. Record non-SRC callers in #623 rather
+than adding local compatibility shims.
+
+## Non-goals
+
+- Distributed or partitioned execution of one contraction.
+- Automatic device choice, sharding, or transfer.
+- CUDA LU/CI or unsupported linalg emulation.
+- Storing execution contexts inside `IdxTensor`.
+- A process-global CUDA registry or thread-local current device.
+- Migrating every tensor4all algorithm to explicit contexts in #720; the seam
+  is reusable and #623 owns subsequent entry-point migrations.
+- Changing tolerances, AD rules, structured-storage semantics, or index
+  equality.
+
+## Review and verification gates
+
+Pre-implementation design review:
+
+- Reviewer: `reviewer-flash` (DeepSeek family, read-only)
+- Verdict: **Correct-to-implement**
+- Evidence: the reviewer verified the current context-free probes/caps, full
+  singular-value host read, host-Matrix adaptive estimator, proposed reusable
+  trait and PR split, and found no blocking issue.
+
+Each PR requires a recorded pre-implementation design verdict and a post-diff
+verdict from a different model family, with fixes re-reviewed. Run repository
+format/clippy, changed-crate release tests, CUDA-gated tests, workspace nextest
+and HDF5, workspace doctests, rustdoc, mdBook, API inventory,
+repository-rules review, coverage-impact audit, and clean diff/status checks.
+Before merge, fetch `origin/main`, update the branch, rerun affected gates and
+CI, verify exact head/check state, then squash-merge in dependency order.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -9,6 +9,7 @@
 | [explicit-cpu-execution-context.md](./explicit-cpu-execution-context.md) | Issue #663 explicit plain, graph, eager-AD, and logical reconstruction context |
 | [tensorbackend-session-entry.md](./tensorbackend-session-entry.md) | Issue #623 slice: centralize concrete CPU sessions on explicit contexts before CUDA dispatch |
 | [cuda-tree-contraction.md](./cuda-tree-contraction.md) | Issues #623/#553 single-CUDA explicit transfer and TreeTN contraction vertical slice |
+| [context-scoped-src-contraction.md](./context-scoped-src-contraction.md) | Issue #720 caller-owned context construction, factorization, adaptive decisions, and CUDA-resident SRC |
 | [torch_backend.md](./torch_backend.md) | PyTorch backend design exploration |
 | [tenferro_ad_scalar_operator_extension_note.md](./tenferro_ad_scalar_operator_extension_note.md) | Tenferro AD scalar operator extension notes |
 | [build-profiles.md](./build-profiles.md) | Debug-free ordinary Cargo profiles and the opt-in full-debug release profile |


### PR DESCRIPTION
Part of #720; follows tensor4all/tenferro-rs#1753 (merged as 007e3bb6).

Adds the reusable ExecutionContext seam and IdxTensor::from_dense_in, ones_in, and validate_context. CPU construction uses the supplied CpuExecutionContext eager runtime; CUDA construction explicitly uploads through the supplied CudaExecutionContext. All seven tenferro pins update together to the merged upstream dispatch fix.

Validation:
- cargo check -j 8 -p tensor4all-tensorbackend -p tensor4all-core --all-targets
- cargo test -j 8 -p tensor4all-core --test context_foundation (2 passed)
- cargo test --doc -p tensor4all-core (308 passed)
- CUDA feature compile and ignored A100 context construction test pass
- repository design review: reviewer-flash, Correct-to-implement
- post-diff review: reviewer-flash, Correct-to-merge

Design: docs/design/context-scoped-src-contraction.md
This PR does not yet migrate SRC; that is the next dependent slice.