### PR TITLE
Add context-aware factorization for CUDA SRC (#720 PR3)

### DIFF
--- a/crates/tensor4all-core/src/defaults/idx_tensor.rs
+++ b/crates/tensor4all-core/src/defaults/idx_tensor.rs
@@ -3112,6 +3112,27 @@ impl IdxTensor {
             .or_else(|| self.eager_cache.get().map(AsRef::as_ref))
     }
 
+    /// Check whether this tensor's eager value is device-resident.
+    ///
+    /// Metadata-only: inspects placement without reading data, transferring,
+    /// or consulting any execution context. Used to route factorization to the
+    /// context-scoped path and to reject context-free calls on resident inputs
+    /// before algorithm work begins.
+    #[cfg(feature = "tenferro-cuda")]
+    pub(crate) fn is_cuda_resident(&self) -> bool {
+        self.cuda_eager_inner().is_some_and(|inner| {
+            inner.tensor_read().placement().memory_kind == tenferro_tensor::MemoryKind::Device
+        })
+    }
+
+    /// Check whether this tensor's eager value is device-resident.
+    ///
+    /// Without the CUDA feature no tensor can be device-resident.
+    #[cfg(not(feature = "tenferro-cuda"))]
+    pub(crate) fn is_cuda_resident(&self) -> bool {
+        false
+    }
+
     #[cfg(feature = "tenferro-cuda")]
     pub(crate) fn cuda_duplicate_native(&self) -> Result<NativeTensor> {
         Ok(self.try_materialized_inner()?.duplicate_value()?)
@@ -5704,9 +5725,43 @@ impl TensorFactorizationLike for IdxTensor {
         factorize_probe_batch_incremental_impl(previous, batch_tensor, batch_index, left_inds)
     }
 
+    fn factorize_probe_batch_incremental_in(
+        previous: Option<&FactorizeResult<IdxTensor>>,
+        batch_tensor: &IdxTensor,
+        batch_index: &DynIndex,
+        left_inds: &[DynIndex],
+        context: &ExecutionContext,
+    ) -> std::result::Result<FactorizeResult<IdxTensor>, FactorizeError> {
+        if let Some(previous) = previous {
+            previous
+                .left
+                .validate_context(context)
+                .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+            previous
+                .right
+                .validate_context(context)
+                .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+        }
+        batch_tensor
+            .validate_context(context)
+            .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+        #[cfg(feature = "tenferro-cuda")]
+        if matches!(context, ExecutionContext::Cuda(_)) {
+            return Self::resident_probe_batch_qr(previous, batch_tensor, batch_index, left_inds);
+        }
+        #[cfg(not(feature = "tenferro-cuda"))]
+        let _ = context;
+        factorize_probe_batch_incremental_impl(previous, batch_tensor, batch_index, left_inds)
+    }
+
     fn src_error_estimate(
         &self,
     ) -> std::result::Result<tensor4all_tensorbackend::SrcErrorEstimate, FactorizeError> {
+        if self.is_cuda_resident() {
+            return Err(FactorizeError::ComputationError(anyhow::anyhow!(
+                "CUDA-resident QR factor requires src_error_estimate_in with the owning execution context"
+            )));
+        }
         let indices = self.indices();
         if indices.len() != 2 {
             return Err(FactorizeError::ComputationError(anyhow::anyhow!(
@@ -5738,6 +5793,326 @@ impl TensorFactorizationLike for IdxTensor {
             ));
         };
         result.map_err(|error| FactorizeError::ComputationError(anyhow::anyhow!(error)))
+    }
+
+    fn src_error_estimate_in(
+        &self,
+        context: &ExecutionContext,
+    ) -> std::result::Result<tensor4all_tensorbackend::SrcErrorEstimate, FactorizeError> {
+        self.validate_context(context)
+            .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+        #[cfg(feature = "tenferro-cuda")]
+        if matches!(context, ExecutionContext::Cuda(_)) {
+            return self.resident_src_error_estimate(context);
+        }
+        #[cfg(not(feature = "tenferro-cuda"))]
+        let _ = context;
+        TensorFactorizationLike::src_error_estimate(self)
+    }
+}
+
+impl IdxTensor {
+    /// Resident batch-native probe factorization by full thin-QR recompute.
+    ///
+    /// Reconstructs the full sketch block `[Q_prev R_prev, A_new]` with resident
+    /// matmul/concatenation and runs one thin QR in the owning runtime. This
+    /// replaces the host `IncrementalQr` block update without any host
+    /// round-trip: no `IncrementalQrState` is stored, so the adaptive estimator
+    /// solves the full triangular system at each growth step. The recomputed
+    /// factor spans the same column space as the incremental update.
+    ///
+    /// Unlike the host block update, this recompute is not rank-revealing:
+    /// linearly dependent appended columns are retained, so a rank-deficient
+    /// (but not row-saturated) block reports a larger rank than the host path
+    /// and a square R where the host path yields a non-square one. Appended
+    /// SRC probe blocks are iid random draws, for which dependence is
+    /// measure-zero; a device-side rank guard plus a dependent-block test is a
+    /// tracked follow-up, not part of this primitive.
+    #[cfg(feature = "tenferro-cuda")]
+    fn resident_probe_batch_qr(
+        previous: Option<&FactorizeResult<IdxTensor>>,
+        batch_tensor: &IdxTensor,
+        batch_index: &DynIndex,
+        left_inds: &[DynIndex],
+    ) -> std::result::Result<FactorizeResult<IdxTensor>, FactorizeError> {
+        use crate::defaults::idx_tensor::unfold_split_inner;
+
+        // The host path consumes `batch_index` as the appended-axis label;
+        // reject a mismatched label before any arithmetic, as the device path
+        // otherwise never observes it.
+        if !batch_tensor.indices().contains(batch_index) {
+            return Err(FactorizeError::ComputationError(anyhow::anyhow!(
+                "resident probe batch is missing its batch index"
+            )));
+        }
+        let (appended_inner, _, m, b, _, _) = unfold_split_inner(batch_tensor, left_inds)
+            .context("resident probe batch unfold failed")
+            .map_err(FactorizeError::ComputationError)?;
+        if !matches!(appended_inner.dtype(), DType::F64 | DType::C64) {
+            return Err(FactorizeError::UnsupportedStorage(
+                "incremental SRC factorization currently supports f64 and Complex64 tensors",
+            ));
+        }
+        if b == 0 {
+            if let Some(previous) = previous {
+                return Ok(previous.clone());
+            }
+            return Err(FactorizeError::ComputationError(anyhow::anyhow!(
+                "incremental SRC factorization requires at least one column"
+            )));
+        }
+        let full_inner = if let Some(previous) = previous {
+            let (q_inner, _, previous_rows, _, _, _) =
+                unfold_split_inner(&previous.left, left_inds)
+                    .context("resident previous Q unfold failed")
+                    .map_err(FactorizeError::ComputationError)?;
+            if previous_rows != m {
+                return Err(FactorizeError::ComputationError(anyhow::anyhow!(
+                    "previous and appended sketch row dimensions differ: {previous_rows} vs {m}"
+                )));
+            }
+            let (r_inner, _, _, _, _, _) =
+                unfold_split_inner(&previous.right, std::slice::from_ref(&previous.bond_index))
+                    .context("resident previous R unfold failed")
+                    .map_err(FactorizeError::ComputationError)?;
+            let reconstructed = q_inner.matmul(&r_inner).map_err(|error| {
+                FactorizeError::ComputationError(
+                    anyhow::Error::new(error).context("resident sketch reconstruction failed"),
+                )
+            })?;
+            EagerTensor::concatenate(&[&reconstructed, &appended_inner], 1).map_err(|error| {
+                FactorizeError::ComputationError(
+                    anyhow::Error::new(error).context("resident sketch concatenation failed"),
+                )
+            })?
+        } else {
+            appended_inner
+        };
+        let total_width = *full_inner.shape().get(1).ok_or_else(|| {
+            FactorizeError::ComputationError(anyhow::anyhow!(
+                "resident sketch factor is not rank-2"
+            ))
+        })?;
+        let (q_full, r_full) = full_inner.qr().map_err(|error| {
+            FactorizeError::ComputationError(
+                anyhow::Error::new(error).context("resident probe batch QR failed"),
+            )
+        })?;
+        let rank = q_full.shape().get(1).copied().ok_or_else(|| {
+            FactorizeError::ComputationError(anyhow::anyhow!(
+                "resident probe batch Q factor is not rank-2"
+            ))
+        })?;
+        let cap = DynIndex::new_bond(rank)
+            .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+        let batch = DynIndex::new_link(total_width)
+            .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+        let mut q_indices = left_inds.to_vec();
+        q_indices.push(cap.clone());
+        let q_dims: Vec<usize> = q_indices.iter().map(|index| index.dim()).collect();
+        let left = Self::from_inner(
+            q_indices,
+            q_full.reshape(&q_dims).map_err(|error| {
+                FactorizeError::ComputationError(
+                    anyhow::Error::new(error).context("resident probe batch Q reshape failed"),
+                )
+            })?,
+        )
+        .map_err(FactorizeError::ComputationError)?;
+        let right = Self::from_inner(
+            vec![cap.clone(), batch],
+            r_full.reshape(&[rank, total_width]).map_err(|error| {
+                FactorizeError::ComputationError(
+                    anyhow::Error::new(error).context("resident probe batch R reshape failed"),
+                )
+            })?,
+        )
+        .map_err(FactorizeError::ComputationError)?;
+        Ok(FactorizeResult::new(left, right, cap, None, rank))
+    }
+
+    /// Device-side Appendix-C estimator: solve and reduce on-device, read back
+    /// `ncols + 1` decision scalars.
+    ///
+    /// Singularity and non-finiteness surface as typed solve/validation errors;
+    /// unlike the host path there is no separate diagonal pre-check, but every
+    /// invalid input still fails instead of producing an estimate.
+    #[cfg(feature = "tenferro-cuda")]
+    fn resident_src_error_estimate(
+        &self,
+        context: &ExecutionContext,
+    ) -> std::result::Result<tensor4all_tensorbackend::SrcErrorEstimate, FactorizeError> {
+        use tensor4all_tensorbackend::SrcErrorEstimate;
+
+        let indices = self.indices();
+        if indices.len() != 2 {
+            return Err(FactorizeError::ComputationError(anyhow::anyhow!(
+                "SRC QR factor must have rank 2, got {}",
+                indices.len()
+            )));
+        }
+        let nrows = indices[0].dim();
+        let ncols = indices[1].dim();
+        if nrows != ncols {
+            return Err(FactorizeError::ComputationError(anyhow::anyhow!(
+                "SRC estimator requires a square R, got {nrows}x{ncols}"
+            )));
+        }
+        if nrows == 0 {
+            return Err(FactorizeError::ComputationError(anyhow::anyhow!(
+                "SRC estimator requires a non-empty R"
+            )));
+        }
+        let inner = self.cuda_eager_inner().ok_or_else(|| {
+            FactorizeError::ComputationError(anyhow::anyhow!(
+                "SRC estimator requires a resident eager QR factor"
+            ))
+        })?;
+        let ExecutionContext::Cuda(cuda) = context else {
+            return Err(FactorizeError::ComputationError(anyhow::anyhow!(
+                "SRC device estimator requires a CUDA execution context"
+            )));
+        };
+        // Adjoint R^H of the upper-triangular R is lower-triangular.
+        let adjoint = inner
+            .transpose(&[1, 0])
+            .and_then(|transposed| transposed.conj())
+            .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+        let identity = Self::resident_identity(cuda, nrows, inner.dtype())?;
+        // Solve R^H X = I for X = R^{-†}.
+        let solved = adjoint
+            .triangular_solve(&identity, true, true, false, false)
+            .map_err(|error| {
+                FactorizeError::ComputationError(
+                    anyhow::Error::new(error)
+                        .context("SRC inverse-adjoint triangular solve failed"),
+                )
+            })?;
+        let column_sums = solved
+            .abs()
+            .and_then(|magnitudes| magnitudes.reduce_sum_squares(&[0]))
+            .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+        let total = inner
+            .abs()
+            .and_then(|magnitudes| magnitudes.reduce_sum_squares(&[0, 1]))
+            .and_then(|scalar| scalar.reshape(&[1]))
+            .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+        let column_norms_sq = Self::read_resident_vector(&column_sums, ncols, context)?;
+        let total_norm_sq = Self::read_resident_vector(&total, 1, context)?;
+        Self::src_estimate_from_decision_scalars(&column_norms_sq, total_norm_sq[0], ncols)
+            .map(|(error, norm)| SrcErrorEstimate { error, norm })
+            .map_err(FactorizeError::ComputationError)
+    }
+
+    /// Build an `n x n` identity in the operand's owning runtime.
+    ///
+    /// Host-originated construction data takes the same explicit upload path
+    /// as [`IdxTensor::from_dense_in`]; the transfer is part of the estimator's
+    /// decision payload, not hidden arithmetic.
+    #[cfg(feature = "tenferro-cuda")]
+    fn resident_identity(
+        cuda: &Arc<tensor4all_tensorbackend::CudaExecutionContext>,
+        n: usize,
+        dtype: DType,
+    ) -> std::result::Result<EagerTensor, FactorizeError> {
+        let native = match dtype {
+            DType::F64 => {
+                let mut data = vec![0.0_f64; n * n];
+                for diagonal in 0..n {
+                    data[diagonal + diagonal * n] = 1.0;
+                }
+                NativeTensor::from_vec_col_major(vec![n, n], data)
+            }
+            DType::C64 => {
+                let mut data = vec![Complex64::new(0.0, 0.0); n * n];
+                for diagonal in 0..n {
+                    data[diagonal + diagonal * n] = Complex64::new(1.0, 0.0);
+                }
+                NativeTensor::from_vec_col_major(vec![n, n], data)
+            }
+            _other => {
+                return Err(FactorizeError::UnsupportedStorage(
+                    "SRC adaptive estimation currently supports f64 and Complex64 QR factors",
+                ));
+            }
+        }
+        .map_err(|error| {
+            FactorizeError::ComputationError(
+                anyhow::Error::new(error).context("SRC estimator identity construction failed"),
+            )
+        })?;
+        let uploaded = cuda.upload_cuda(&native).map_err(|error| {
+            FactorizeError::ComputationError(
+                anyhow::Error::new(error).context("SRC estimator identity upload failed"),
+            )
+        })?;
+        let runtime = cuda.eager_runtime().map_err(|error| {
+            FactorizeError::ComputationError(
+                anyhow::Error::new(error).context("SRC estimator eager runtime failed"),
+            )
+        })?;
+        // `validate_context` already pinned the factor to this exact CUDA
+        // context, so the uploaded identity lands in the factor's runtime.
+        EagerTensor::from_tensor_in(uploaded, runtime).map_err(|error| {
+            FactorizeError::ComputationError(
+                anyhow::Error::new(error).context("SRC estimator identity wrapping failed"),
+            )
+        })
+    }
+
+    /// Wrap a resident decision vector and read it back through `context`.
+    #[cfg(feature = "tenferro-cuda")]
+    fn read_resident_vector(
+        eager: &EagerTensor,
+        len: usize,
+        context: &ExecutionContext,
+    ) -> std::result::Result<Vec<f64>, FactorizeError> {
+        if eager.shape() != [len] {
+            return Err(FactorizeError::ComputationError(anyhow::anyhow!(
+                "device SRC decision vector has shape {:?}, expected [{len}]",
+                eager.shape()
+            )));
+        }
+        let decision = Self::from_inner(vec![DynIndex::new_dyn(len)], eager.clone())
+            .map_err(FactorizeError::ComputationError)?;
+        decision
+            .read_decision_data(context)
+            .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))
+    }
+
+    /// Scalar Appendix-C formula from the `ncols + 1` decision values.
+    ///
+    /// Mirrors `src_error_estimate_from_inverse_adjoint`: column norms must be
+    /// finite and nonzero, and both estimates must be finite.
+    #[cfg(feature = "tenferro-cuda")]
+    fn src_estimate_from_decision_scalars(
+        column_norms_sq: &[f64],
+        total_norm_sq: f64,
+        ncols: usize,
+    ) -> std::result::Result<(f64, f64), anyhow::Error> {
+        if !total_norm_sq.is_finite() {
+            return Err(anyhow::anyhow!(
+                "SRC estimator requires finite entries in R"
+            ));
+        }
+        let mut inverse_column_error_sq = 0.0_f64;
+        for (col, &column_norm_sq) in column_norms_sq.iter().enumerate() {
+            if !column_norm_sq.is_finite() || column_norm_sq == 0.0 {
+                return Err(anyhow::anyhow!(
+                    "SRC inverse-adjoint solve returned an invalid column norm at column {col}"
+                ));
+            }
+            inverse_column_error_sq += 1.0 / column_norm_sq;
+        }
+        let sketch_width = ncols as f64;
+        let error_sq = inverse_column_error_sq / sketch_width;
+        let norm_estimate_sq = total_norm_sq / sketch_width;
+        if !error_sq.is_finite() || !norm_estimate_sq.is_finite() {
+            return Err(anyhow::anyhow!(
+                "SRC estimator produced a non-finite estimate"
+            ));
+        }
+        Ok((error_sq.sqrt(), norm_estimate_sq.sqrt()))
     }
 }
 
@@ -7303,6 +7678,82 @@ impl IdxTensor {
             }
         }
         Ok(())
+    }
+
+    /// Read back a small algorithm-decision tensor through its owning context.
+    ///
+    /// This is the explicit synchronization/readback boundary for rank
+    /// selection and adaptive stopping payloads (singular values, norm
+    /// vectors, scalar estimates). With a CUDA context the resident value is
+    /// downloaded through that exact context; no arithmetic operand is ever
+    /// reconstructed on the host from this payload.
+    ///
+    /// # Arguments
+    ///
+    /// * `context` - Caller-owned execution context the tensor must belong to.
+    ///
+    /// # Returns
+    ///
+    /// The decision values in column-major order (`f64`, or the real part for
+    /// `Complex64`, matching the existing rank-selection semantics).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tensor4all_core::{DynIndex, ExecutionContext, IdxTensor};
+    /// use tensor4all_tensorbackend::CpuExecutionContext;
+    /// use tenferro_cpu::CpuBackend;
+    ///
+    /// let context = ExecutionContext::Cpu(Arc::new(
+    ///     CpuExecutionContext::from_backend(CpuBackend::new()),
+    /// ));
+    /// let tensor = IdxTensor::from_dense_in(
+    ///     &context,
+    ///     vec![DynIndex::new_dyn(3)],
+    ///     vec![0.5_f64, 2.0, 1.0],
+    /// )?;
+    /// assert_eq!(tensor.read_decision_data(&context)?, vec![0.5, 2.0, 1.0]);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdxTensorError`] when the tensor does not belong to `context`,
+    /// when the explicit transfer fails, or when the storage is neither `f64`
+    /// nor `Complex64`.
+    pub fn read_decision_data(
+        &self,
+        context: &ExecutionContext,
+    ) -> std::result::Result<Vec<f64>, IdxTensorError> {
+        self.validate_context(context)?;
+        #[cfg(feature = "tenferro-cuda")]
+        if let ExecutionContext::Cuda(cuda) = context {
+            let host = self.download(cuda).map_err(|error| {
+                IdxTensorError::operation("decision readback download", anyhow::Error::new(error))
+            })?;
+            return Self::decision_values(&host);
+        }
+        Self::decision_values(self)
+    }
+
+    fn decision_values(host: &Self) -> std::result::Result<Vec<f64>, IdxTensorError> {
+        if host.is_f64() {
+            host.to_vec::<f64>().map_err(|error| {
+                IdxTensorError::operation("decision readback", anyhow::Error::new(error))
+            })
+        } else if host.is_c64() {
+            host.to_vec::<Complex64>()
+                .map(|values| values.into_iter().map(|value| value.re).collect())
+                .map_err(|error| {
+                    IdxTensorError::operation("decision readback", anyhow::Error::new(error))
+                })
+        } else {
+            Err(IdxTensorError::operation(
+                "decision readback",
+                anyhow::anyhow!("decision payloads support f64 and Complex64 storage only"),
+            ))
+        }
     }
 }
 

--- a/crates/tensor4all-core/src/defaults/qr.rs
+++ b/crates/tensor4all-core/src/defaults/qr.rs
@@ -5,9 +5,10 @@
 use crate::defaults::idx_tensor::unfold_split_inner;
 use crate::defaults::DynIndex;
 use crate::global_default::GlobalDefault;
-use crate::IdxTensor;
+use crate::{ExecutionContext, IdxTensor};
 use num_complex::{Complex64, ComplexFloat};
 use tenferro::DType;
+use tenferro_ad::EagerTensor;
 use tenferro_linalg::EagerTensorLinalgExt;
 use thiserror::Error;
 
@@ -138,14 +139,55 @@ where
         })
         .collect();
 
+    Ok(retained_rank_from_row_norms(&row_norms, rtol))
+}
+
+/// Select the retained QR rank from per-row norms of the upper-triangular factor.
+///
+/// Shared by the host dense path and the device path (which reduces the norms
+/// on-device and reads back only this `k`-element decision vector).
+fn retained_rank_from_row_norms(row_norms: &[f64], rtol: f64) -> usize {
     let max_row_norm = row_norms.iter().cloned().fold(0.0_f64, f64::max);
     if max_row_norm == 0.0 {
-        return Ok(1);
+        return 1;
     }
 
     let threshold = rtol * max_row_norm;
     let r = row_norms.iter().filter(|&&norm| norm >= threshold).count();
-    Ok(r.max(1))
+    r.max(1)
+}
+
+/// Read the `k` upper-triangular row norms of a resident `R` factor.
+///
+/// All arithmetic stays in the operand's owning runtime; only the `k`-element
+/// decision vector crosses the explicit readback boundary through `context`.
+#[cfg(feature = "tenferro-cuda")]
+fn resident_row_norms(
+    r_inner: &EagerTensor,
+    k: usize,
+    context: &ExecutionContext,
+) -> Result<Vec<f64>, QrError> {
+    let upper = r_inner
+        .triu(0)
+        .map_err(|error| QrError::ComputationError(anyhow::Error::new(error)))?;
+    let magnitudes = upper
+        .abs()
+        .map_err(|error| QrError::ComputationError(anyhow::Error::new(error)))?;
+    let sum_squares = magnitudes
+        .reduce_sum_squares(&[1])
+        .map_err(|error| QrError::ComputationError(anyhow::Error::new(error)))?;
+    if sum_squares.shape() != [k] {
+        return Err(QrError::ComputationError(anyhow::anyhow!(
+            "device QR row-norm reduction returned shape {:?}, expected [{k}]",
+            sum_squares.shape()
+        )));
+    }
+    let decision = IdxTensor::from_inner(vec![DynIndex::new_dyn(k)], sum_squares)
+        .map_err(QrError::ComputationError)?;
+    let values = decision
+        .read_decision_data(context)
+        .map_err(|error| QrError::ComputationError(anyhow::Error::new(error)))?;
+    Ok(values.into_iter().map(|value| value.sqrt()).collect())
 }
 
 /// Compute QR decomposition of a tensor with arbitrary rank, returning (Q, R).
@@ -250,47 +292,151 @@ pub fn qr_with<T>(
     left_inds: &[DynIndex],
     options: &QrOptions,
 ) -> Result<(IdxTensor, IdxTensor), QrError> {
+    if t.is_cuda_resident() {
+        return Err(QrError::ComputationError(anyhow::anyhow!(
+            "CUDA-resident input requires qr_with_in with the owning execution context"
+        )));
+    }
     // Unfold tensor into an eager rank-2 tensor so linalg AD nodes stay connected.
     let (matrix_inner, _, m, n, left_indices, right_indices) = unfold_split_inner(t, left_inds)
         .map_err(|e| anyhow::anyhow!("Failed to unfold tensor: {}", e))
         .map_err(QrError::ComputationError)?;
     let k = m.min(n);
-    let (mut q_inner, mut r_inner) = matrix_inner
+    let (q_inner, r_inner) = matrix_inner
         .qr()
         .map_err(|e| QrError::ComputationError(anyhow::anyhow!("{e}")))?;
 
-    let r = if options.truncate {
-        // Determine rtol to use
-        let rtol = options.rtol.unwrap_or(default_qr_rtol());
-        if !rtol.is_finite() || rtol < 0.0 {
-            return Err(QrError::InvalidRtol(rtol));
-        }
+    let r = qr_retained_rank(&r_inner, k, n, options, None)?;
+    qr_assemble(q_inner, r_inner, k, r, left_indices, right_indices)
+}
 
-        let value = r_inner
-            .value()
-            .map_err(|source| QrError::ComputationError(anyhow::Error::new(source)))?;
-        match r_inner.dtype() {
-            DType::F64 => {
-                let values = value
-                    .as_slice::<f64>()
-                    .map_err(|source| QrError::ComputationError(anyhow::Error::new(source)))?;
-                compute_retained_rank_qr_from_dense(values, k, n, rtol)?
-            }
-            DType::C64 => {
-                let values = value
-                    .as_slice::<Complex64>()
-                    .map_err(|source| QrError::ComputationError(anyhow::Error::new(source)))?;
-                compute_retained_rank_qr_from_dense(values, k, n, rtol)?
-            }
-            other => {
-                return Err(QrError::ComputationError(anyhow::anyhow!(
-                    "native QR returned unsupported scalar type {other:?}"
-                )));
-            }
+/// Compute QR decomposition in a caller-owned execution context.
+///
+/// The factorization, truncation slicing, and result assembly all execute in
+/// `context`. With a CUDA context the retained-rank decision reads back only
+/// the `k`-element row-norm vector through [`IdxTensor::read_decision_data`];
+/// with a CPU context the rank decision uses the same host read as [`qr_with`].
+///
+/// # Arguments
+///
+/// * `t` - Input tensor, which must belong to `context`.
+/// * `left_inds` - Indices to place on the left (row) side of the unfolded matrix.
+/// * `options` - QR options including rtol for truncation control.
+/// * `context` - Caller-owned execution context owning the input and results.
+///
+/// # Examples
+///
+/// ```
+/// use std::sync::Arc;
+/// use tensor4all_core::qr::{QrOptions, qr_with_in};
+/// use tensor4all_core::{DynIndex, ExecutionContext, IdxTensor, TensorContractionLike};
+/// use tensor4all_tensorbackend::CpuExecutionContext;
+/// use tenferro_cpu::CpuBackend;
+///
+/// let context = ExecutionContext::Cpu(Arc::new(
+///     CpuExecutionContext::from_backend(CpuBackend::new()),
+/// ));
+/// let i = DynIndex::new_dyn(4);
+/// let j = DynIndex::new_dyn(3);
+/// let data: Vec<f64> = (0..12).map(|x| x as f64).collect();
+/// let t = IdxTensor::from_dense_in(&context, vec![i.clone(), j.clone()], data)?;
+/// let (q, r) = qr_with_in::<f64>(&t, &[i.clone()], &QrOptions::default(), &context)?;
+/// let recovered = q.contract_pair(&r)?;
+/// let expected = t.to_vec::<f64>()?;
+/// let actual = recovered.to_vec::<f64>()?;
+/// let residual = expected
+///     .iter()
+///     .zip(actual.iter())
+///     .map(|(a, b)| (a - b).abs())
+///     .fold(0.0_f64, f64::max);
+/// assert!(residual < 1e-12, "QR reconstruction residual {residual}");
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// # Errors
+///
+/// Returns `QrError` when the tensor does not belong to `context`, when the
+/// indices, storage, or options are invalid, or when the factorization or
+/// explicit decision readback fails.
+pub fn qr_with_in<T>(
+    t: &IdxTensor,
+    left_inds: &[DynIndex],
+    options: &QrOptions,
+    context: &ExecutionContext,
+) -> Result<(IdxTensor, IdxTensor), QrError> {
+    t.validate_context(context)
+        .map_err(|error| QrError::ComputationError(anyhow::Error::new(error)))?;
+    let (matrix_inner, _, m, n, left_indices, right_indices) = unfold_split_inner(t, left_inds)
+        .map_err(|e| anyhow::anyhow!("Failed to unfold tensor: {}", e))
+        .map_err(QrError::ComputationError)?;
+    let k = m.min(n);
+    let (q_inner, r_inner) = matrix_inner
+        .qr()
+        .map_err(|e| QrError::ComputationError(anyhow::anyhow!("{e}")))?;
+
+    let r = qr_retained_rank(&r_inner, k, n, options, Some(context))?;
+    qr_assemble(q_inner, r_inner, k, r, left_indices, right_indices)
+}
+
+/// Select the retained QR rank, reading the decision payload through `context`
+/// for device-resident factors and directly from host memory otherwise.
+fn qr_retained_rank(
+    r_inner: &EagerTensor,
+    k: usize,
+    n: usize,
+    options: &QrOptions,
+    context: Option<&ExecutionContext>,
+) -> Result<usize, QrError> {
+    if !options.truncate {
+        return Ok(k);
+    }
+    // Determine rtol to use
+    let rtol = options.rtol.unwrap_or(default_qr_rtol());
+    if !rtol.is_finite() || rtol < 0.0 {
+        return Err(QrError::InvalidRtol(rtol));
+    }
+
+    #[cfg(feature = "tenferro-cuda")]
+    if let Some(context) = context {
+        if matches!(context, ExecutionContext::Cuda(_)) {
+            let row_norms = resident_row_norms(r_inner, k, context)?;
+            return Ok(retained_rank_from_row_norms(&row_norms, rtol));
         }
-    } else {
-        k
-    };
+    }
+    #[cfg(not(feature = "tenferro-cuda"))]
+    let _ = context;
+
+    let value = r_inner
+        .value()
+        .map_err(|source| QrError::ComputationError(anyhow::Error::new(source)))?;
+    match r_inner.dtype() {
+        DType::F64 => {
+            let values = value
+                .as_slice::<f64>()
+                .map_err(|source| QrError::ComputationError(anyhow::Error::new(source)))?;
+            compute_retained_rank_qr_from_dense(values, k, n, rtol)
+        }
+        DType::C64 => {
+            let values = value
+                .as_slice::<Complex64>()
+                .map_err(|source| QrError::ComputationError(anyhow::Error::new(source)))?;
+            compute_retained_rank_qr_from_dense(values, k, n, rtol)
+        }
+        other => Err(QrError::ComputationError(anyhow::anyhow!(
+            "native QR returned unsupported scalar type {other:?}"
+        ))),
+    }
+}
+
+/// Slice the thin factors to the retained rank and wrap them as [`IdxTensor`]s.
+fn qr_assemble(
+    mut q_inner: EagerTensor,
+    mut r_inner: EagerTensor,
+    k: usize,
+    r: usize,
+    left_indices: Vec<DynIndex>,
+    right_indices: Vec<DynIndex>,
+) -> Result<(IdxTensor, IdxTensor), QrError> {
     if r < k {
         let keep: Vec<usize> = (0..r).collect();
         q_inner = q_inner

--- a/crates/tensor4all-core/src/defaults/svd.rs
+++ b/crates/tensor4all-core/src/defaults/svd.rs
@@ -14,7 +14,7 @@ use crate::truncation::{
     validate_svd_truncation_options, validate_svd_truncation_policy, SingularValueMeasure,
     SvdTruncationOptionsError, SvdTruncationPolicy, ThresholdScale, TruncationRule,
 };
-use crate::IdxTensor;
+use crate::{ExecutionContext, IdxTensor};
 use num_complex::Complex64;
 use std::sync::Mutex;
 use tenferro::DType;
@@ -242,6 +242,27 @@ fn singular_values_from_eager(tensor: &EagerTensor) -> Result<Vec<f64>, SvdError
     }
 }
 
+/// Read the singular-value decision vector of a resident factor.
+///
+/// The factor stays resident; only its values cross the explicit readback
+/// boundary through `context`.
+#[cfg(feature = "tenferro-cuda")]
+fn resident_singular_values(
+    s_inner: &EagerTensor,
+    context: &ExecutionContext,
+) -> Result<Vec<f64>, SvdError> {
+    let indices: Vec<DynIndex> = s_inner
+        .shape()
+        .iter()
+        .map(|&dim| DynIndex::new_dyn(dim))
+        .collect();
+    let decision =
+        IdxTensor::from_inner(indices, s_inner.clone()).map_err(SvdError::ComputationError)?;
+    decision
+        .read_decision_data(context)
+        .map_err(|error| SvdError::ComputationError(anyhow::Error::new(error)))
+}
+
 type SvdTruncatedEagerResult = (
     EagerTensor,
     EagerTensor,
@@ -257,6 +278,43 @@ fn svd_truncated_inner(
     left_inds: &[DynIndex],
     options: &SvdOptions,
 ) -> Result<SvdTruncatedEagerResult, SvdError> {
+    if t.is_cuda_resident() {
+        return Err(SvdError::ComputationError(anyhow::anyhow!(
+            "CUDA-resident input requires svd_with_in with the owning execution context"
+        )));
+    }
+    svd_truncated_inner_scoped(t, left_inds, options, None)
+}
+
+/// Compute truncated SVD in a caller-owned execution context.
+///
+/// The factorization and truncation slicing execute in `context`. With a CUDA
+/// context only the singular-value decision vector crosses the explicit
+/// readback boundary (via [`IdxTensor::read_decision_data`); with a CPU
+/// context the decision uses the same host read as [`svd_with`].
+///
+/// # Errors
+///
+/// Returns `SvdError` when the tensor does not belong to `context`, when the
+/// indices or options are invalid, or when the factorization or explicit
+/// decision readback fails.
+pub(crate) fn svd_truncated_inner_in(
+    t: &IdxTensor,
+    left_inds: &[DynIndex],
+    options: &SvdOptions,
+    context: &ExecutionContext,
+) -> Result<SvdTruncatedEagerResult, SvdError> {
+    t.validate_context(context)
+        .map_err(|error| SvdError::ComputationError(anyhow::Error::new(error)))?;
+    svd_truncated_inner_scoped(t, left_inds, options, Some(context))
+}
+
+fn svd_truncated_inner_scoped(
+    t: &IdxTensor,
+    left_inds: &[DynIndex],
+    options: &SvdOptions,
+    context: Option<&ExecutionContext>,
+) -> Result<SvdTruncatedEagerResult, SvdError> {
     let (matrix_inner, _, m, n, left_indices, right_indices) = unfold_split_inner(t, left_inds)
         .map_err(|e| anyhow::anyhow!("Failed to unfold tensor: {}", e))
         .map_err(SvdError::ComputationError)?;
@@ -265,7 +323,18 @@ fn svd_truncated_inner(
     let (mut u_inner, mut s_inner, mut vt_inner) = matrix_inner
         .svd()
         .map_err(|e| SvdError::ComputationError(anyhow::anyhow!("{e}")))?;
-    let s_full = singular_values_from_eager(&s_inner)?;
+    let s_full = match context {
+        #[cfg(feature = "tenferro-cuda")]
+        Some(ExecutionContext::Cuda(_)) => {
+            let context = context.expect("CUDA context is present");
+            resident_singular_values(&s_inner, context)?
+        }
+        _ => {
+            #[cfg(not(feature = "tenferro-cuda"))]
+            let _ = context;
+            singular_values_from_eager(&s_inner)?
+        }
+    };
     let mut r = if options.truncate {
         // Shared root guard: reject `max_bond_dim == Some(0)` and invalid
         // explicit policies before any truncation, so the caller cannot
@@ -396,6 +465,87 @@ pub fn svd_with<T>(
     let (u_inner, s_inner, vt_inner, _singular_values, bond_index, left_indices, right_indices) =
         svd_truncated_inner(t, left_inds, options)?;
 
+    svd_assemble(
+        u_inner,
+        s_inner,
+        vt_inner,
+        bond_index,
+        left_indices,
+        right_indices,
+    )
+}
+
+/// Compute SVD decomposition in a caller-owned execution context.
+///
+/// The factorization, truncation slicing, and result assembly all execute in
+/// `context`. With a CUDA context only the singular-value decision vector
+/// crosses the explicit readback boundary; with a CPU context the decision
+/// uses the same host read as [`svd_with`].
+///
+/// # Arguments
+///
+/// * `t` - Input tensor, which must belong to `context`.
+/// * `left_inds` - Indices to place on the left (row) side of the unfolded matrix.
+/// * `options` - SVD options including truncation policy and bond cap.
+/// * `context` - Caller-owned execution context owning the input and results.
+///
+/// # Examples
+///
+/// ```
+/// use std::sync::Arc;
+/// use tensor4all_core::svd::{SvdOptions, svd_with_in};
+/// use tensor4all_core::{DynIndex, ExecutionContext, IdxTensor, SvdTruncationPolicy};
+/// use tensor4all_tensorbackend::CpuExecutionContext;
+/// use tenferro_cpu::CpuBackend;
+///
+/// let context = ExecutionContext::Cpu(Arc::new(
+///     CpuExecutionContext::from_backend(CpuBackend::new()),
+/// ));
+/// let i = DynIndex::new_dyn(4);
+/// let j = DynIndex::new_dyn(4);
+/// let mut data = vec![0.0_f64; 16];
+/// data[0] = 1.0;
+/// let tensor = IdxTensor::from_dense_in(&context, vec![i.clone(), j.clone()], data)?;
+/// let opts = SvdOptions::new().with_policy(SvdTruncationPolicy::new(1e-10));
+/// let (u, s, _v) = svd_with_in::<f64>(&tensor, &[i.clone()], &opts, &context)?;
+/// assert_eq!(s.dims()[0], 1);
+/// assert_eq!(u.dims()[0], 4);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// # Errors
+///
+/// Returns `SvdError` when the tensor does not belong to `context`, when the
+/// indices or options are invalid, or when the factorization or explicit
+/// decision readback fails.
+pub fn svd_with_in<T>(
+    t: &IdxTensor,
+    left_inds: &[DynIndex],
+    options: &SvdOptions,
+    context: &ExecutionContext,
+) -> Result<(IdxTensor, IdxTensor, IdxTensor), SvdError> {
+    let (u_inner, s_inner, vt_inner, _singular_values, bond_index, left_indices, right_indices) =
+        svd_truncated_inner_in(t, left_inds, options, context)?;
+
+    svd_assemble(
+        u_inner,
+        s_inner,
+        vt_inner,
+        bond_index,
+        left_indices,
+        right_indices,
+    )
+}
+
+/// Wrap the truncated eager factors as [`IdxTensor`]s.
+fn svd_assemble(
+    u_inner: EagerTensor,
+    s_inner: EagerTensor,
+    vt_inner: EagerTensor,
+    bond_index: DynIndex,
+    left_indices: Vec<DynIndex>,
+    right_indices: Vec<DynIndex>,
+) -> Result<(IdxTensor, IdxTensor, IdxTensor), SvdError> {
     let mut u_indices = left_indices;
     u_indices.push(bond_index.clone());
     let u_dims: Vec<usize> = u_indices.iter().map(|idx| idx.dim).collect();
@@ -446,8 +596,28 @@ pub(crate) fn svd_for_factorize(
 ) -> Result<SvdFactorizeResult, SvdError> {
     let (u_inner, s_inner, vt_inner, singular_values, bond_index, left_indices, right_indices) =
         svd_truncated_inner(t, left_inds, options)?;
-    let rank = singular_values.len();
+    svd_factorize_assemble(
+        u_inner,
+        s_inner,
+        vt_inner,
+        singular_values,
+        bond_index,
+        left_indices,
+        right_indices,
+    )
+}
 
+/// Wrap the truncated eager factors as [`IdxTensor`]s, returning `V^H` directly.
+fn svd_factorize_assemble(
+    u_inner: EagerTensor,
+    s_inner: EagerTensor,
+    vt_inner: EagerTensor,
+    singular_values: Vec<f64>,
+    bond_index: DynIndex,
+    left_indices: Vec<DynIndex>,
+    right_indices: Vec<DynIndex>,
+) -> Result<SvdFactorizeResult, SvdError> {
+    let rank = singular_values.len();
     let mut u_indices = left_indices;
     u_indices.push(bond_index.clone());
     let u_dims: Vec<usize> = u_indices.iter().map(|idx| idx.dim).collect();

--- a/crates/tensor4all-core/src/defaults/svd.rs
+++ b/crates/tensor4all-core/src/defaults/svd.rs
@@ -323,17 +323,20 @@ fn svd_truncated_inner_scoped(
     let (mut u_inner, mut s_inner, mut vt_inner) = matrix_inner
         .svd()
         .map_err(|e| SvdError::ComputationError(anyhow::anyhow!("{e}")))?;
-    let s_full = match context {
-        #[cfg(feature = "tenferro-cuda")]
-        Some(ExecutionContext::Cuda(_)) => {
-            let context = context.expect("CUDA context is present");
+    #[cfg(feature = "tenferro-cuda")]
+    let s_full = if let Some(context) = context {
+        if matches!(context, ExecutionContext::Cuda(_)) {
             resident_singular_values(&s_inner, context)?
-        }
-        _ => {
-            #[cfg(not(feature = "tenferro-cuda"))]
-            let _ = context;
+        } else {
             singular_values_from_eager(&s_inner)?
         }
+    } else {
+        singular_values_from_eager(&s_inner)?
+    };
+    #[cfg(not(feature = "tenferro-cuda"))]
+    let s_full = {
+        let _ = context;
+        singular_values_from_eager(&s_inner)?
     };
     let mut r = if options.truncate {
         // Shared root guard: reject `max_bond_dim == Some(0)` and invalid

--- a/crates/tensor4all-core/src/defaults/svd/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/svd/tests/mod.rs
@@ -175,3 +175,33 @@ fn svd_with_rejects_zero_max_bond_dim_and_infinite_thresholds() {
         );
     }
 }
+
+#[test]
+fn svd_with_in_matches_host_path_on_explicit_cpu_context() {
+    use std::sync::Arc;
+
+    use tenferro_cpu::CpuBackend;
+    use tensor4all_tensorbackend::CpuExecutionContext;
+
+    use crate::ExecutionContext;
+
+    let context = ExecutionContext::Cpu(Arc::new(CpuExecutionContext::from_backend(
+        CpuBackend::new(),
+    )));
+    let i = DynIndex::new_dyn(4);
+    let j = DynIndex::new_dyn(4);
+    let mut data = vec![0.0_f64; 16];
+    data[0] = 1.0;
+    data[5] = 0.5;
+    let tensor = IdxTensor::from_dense_in(&context, vec![i.clone(), j.clone()], data).unwrap();
+
+    let options = SvdOptions::new().with_policy(SvdTruncationPolicy::new(1e-10));
+    let (u_in, s_in, _v_in) =
+        svd_with_in::<f64>(&tensor, std::slice::from_ref(&i), &options, &context).unwrap();
+    let (u, s, _v) = svd_with::<f64>(&tensor, std::slice::from_ref(&i), &options).unwrap();
+
+    assert_eq!(s_in.dims(), s.dims());
+    assert_eq!(u_in.dims(), u.dims());
+    u_in.validate_context(&context).unwrap();
+    s_in.validate_context(&context).unwrap();
+}

--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -160,8 +160,8 @@ pub mod qr {
 pub mod svd {
     //! Re-export of SVD decomposition operations.
     pub use crate::defaults::svd::{
-        default_svd_truncation_policy, set_default_svd_truncation_policy, svd, svd_with, SvdError,
-        SvdOptions,
+        default_svd_truncation_policy, set_default_svd_truncation_policy, svd, svd_with,
+        svd_with_in, SvdError, SvdOptions,
     };
 }
 

--- a/crates/tensor4all-core/src/tensor_like.rs
+++ b/crates/tensor4all-core/src/tensor_like.rs
@@ -1166,6 +1166,79 @@ pub trait TensorFactorizationLike: TensorIndex {
             "SRC adaptive estimation is not supported for this tensor type",
         ))
     }
+
+    /// Evaluate the Appendix-C adaptive SRC error estimate in a caller-owned
+    /// execution context.
+    ///
+    /// Context-scoped counterpart of [`Self::src_error_estimate`]: all
+    /// arithmetic executes in `context`, with only bounded decision scalars
+    /// crossing the explicit readback boundary on device-resident inputs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tensor4all_core::{DynIndex, ExecutionContext, IdxTensor, TensorFactorizationLike};
+    /// use tensor4all_tensorbackend::CpuExecutionContext;
+    /// use tenferro_cpu::CpuBackend;
+    ///
+    /// let context = ExecutionContext::Cpu(Arc::new(
+    ///     CpuExecutionContext::from_backend(CpuBackend::new()),
+    /// ));
+    /// let cap = DynIndex::new_dyn(2);
+    /// let batch = DynIndex::new_dyn(2);
+    /// let r = IdxTensor::from_dense_in(
+    ///     &context,
+    ///     vec![cap, batch],
+    ///     vec![2.0_f64, 0.0, 0.0, 3.0],
+    /// )?;
+    /// let estimate = r.src_error_estimate_in(&context)?;
+    /// // error = sqrt(mean(1/||x_col||^2)) with x = R^{-T}: (4 + 9)/2 -> sqrt.
+    /// let expected = ((4.0_f64 + 9.0) / 2.0).sqrt();
+    /// assert!((estimate.error - expected).abs() < 1e-12, "got {}", estimate.error);
+    /// assert!((estimate.norm - (13.0_f64 / 2.0).sqrt()).abs() < 1e-12);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns `FactorizeError` when the estimate is unsupported for this
+    /// tensor type, when the factor does not belong to `context`, or when the
+    /// solve, reductions, or explicit decision readback fail.
+    fn src_error_estimate_in(
+        &self,
+        _context: &tensor4all_tensorbackend::ExecutionContext,
+    ) -> std::result::Result<tensor4all_tensorbackend::SrcErrorEstimate, FactorizeError> {
+        Err(FactorizeError::UnsupportedStorage(
+            "context-scoped SRC adaptive estimation is not supported for this tensor type",
+        ))
+    }
+
+    /// Batch-native incremental probe factorization in a caller-owned context.
+    ///
+    /// Context-scoped counterpart of
+    /// [`Self::factorize_probe_batch_incremental`]: sketch columns, QR factors,
+    /// and results all stay in `context` with no host round-trip.
+    ///
+    /// # Errors
+    ///
+    /// Returns `FactorizeError` when the factorization is unsupported for this
+    /// tensor type, when an input does not belong to `context`, or when the
+    /// resident factorization fails.
+    fn factorize_probe_batch_incremental_in(
+        _previous: Option<&FactorizeResult<Self>>,
+        _batch_tensor: &Self,
+        _batch_index: &<Self as TensorIndex>::Index,
+        _left_inds: &[<Self as TensorIndex>::Index],
+        _context: &tensor4all_tensorbackend::ExecutionContext,
+    ) -> std::result::Result<FactorizeResult<Self>, FactorizeError>
+    where
+        Self: TensorVectorSpace + TensorConstructionLike,
+    {
+        Err(FactorizeError::UnsupportedStorage(
+            "context-scoped incremental probe factorization is not supported for this tensor type",
+        ))
+    }
 }
 
 /// Constructors and selection helpers for index-labelled tensors.

--- a/crates/tensor4all-core/src/tensor_like/tests/mod.rs
+++ b/crates/tensor4all-core/src/tensor_like/tests/mod.rs
@@ -859,3 +859,30 @@ fn tensor_factorization_preserves_multi_axis_probe_row_order() {
         "reconstructed multi-axis sketch differs: actual={actual:?}, expected={expected:?}"
     );
 }
+
+#[test]
+fn tensor_like_default_context_seam_reports_unsupported() {
+    use std::sync::Arc;
+
+    use tenferro_cpu::CpuBackend;
+    use tensor4all_tensorbackend::{CpuExecutionContext, ExecutionContext};
+
+    let context = ExecutionContext::Cpu(Arc::new(CpuExecutionContext::from_backend(
+        CpuBackend::new(),
+    )));
+    let tensor = DefaultOnlyTensor {
+        indices: Vec::new(),
+        data: vec![1.0],
+    };
+    let error = tensor.src_error_estimate_in(&context).unwrap_err();
+    assert!(matches!(error, FactorizeError::UnsupportedStorage(_)));
+    let error = DefaultOnlyTensor::factorize_probe_batch_incremental_in(
+        None,
+        &tensor,
+        &DynIndex::new_dyn(1),
+        &[],
+        &context,
+    )
+    .unwrap_err();
+    assert!(matches!(error, FactorizeError::UnsupportedStorage(_)));
+}

--- a/crates/tensor4all-core/tests/context_foundation.rs
+++ b/crates/tensor4all-core/tests/context_foundation.rs
@@ -33,6 +33,25 @@ fn context_validation_rejects_a_different_cpu_runtime() {
     assert!(tensor.validate_context(&second).is_err());
 }
 
+#[test]
+fn decision_readback_returns_values_in_the_supplied_cpu_runtime() {
+    let context = cpu_context();
+    let tensor = IdxTensor::from_dense_in(
+        &context,
+        vec![DynIndex::new_dyn(3)],
+        vec![0.5_f64, 2.0, 1.0],
+    )
+    .unwrap();
+
+    assert_eq!(
+        tensor.read_decision_data(&context).unwrap(),
+        vec![0.5, 2.0, 1.0]
+    );
+
+    let other = cpu_context();
+    assert!(tensor.read_decision_data(&other).is_err());
+}
+
 #[cfg(feature = "tenferro-cuda")]
 #[test]
 #[ignore]
@@ -43,4 +62,21 @@ fn context_scoped_cuda_construction_stays_in_the_selected_runtime() {
         IdxTensor::from_dense_in(&context, vec![DynIndex::new_dyn(2)], vec![1.0_f64, 2.0]).unwrap();
 
     tensor.validate_context(&context).unwrap();
+}
+
+#[cfg(feature = "tenferro-cuda")]
+#[test]
+#[ignore]
+fn decision_readback_downloads_through_the_owning_cuda_runtime() {
+    let cuda = tensor4all_tensorbackend::CudaExecutionContext::new().unwrap();
+    let context = ExecutionContext::Cuda(Arc::new(cuda));
+    let tensor =
+        IdxTensor::from_dense_in(&context, vec![DynIndex::new_dyn(2)], vec![1.0_f64, 2.0]).unwrap();
+
+    assert_eq!(tensor.read_decision_data(&context).unwrap(), vec![1.0, 2.0]);
+
+    let foreign = ExecutionContext::Cuda(Arc::new(
+        tensor4all_tensorbackend::CudaExecutionContext::new().unwrap(),
+    ));
+    assert!(tensor.read_decision_data(&foreign).is_err());
 }

--- a/crates/tensor4all-core/tests/cuda_context_factorization.rs
+++ b/crates/tensor4all-core/tests/cuda_context_factorization.rs
@@ -1,0 +1,346 @@
+//! CUDA residency tests for context-scoped factorization (issue #720).
+//!
+//! Each test uploads host fixtures into one caller-owned [`ExecutionContext`],
+//! runs the `_in` factorization/estimator entry, and checks exact-context
+//! residency plus numerical parity against the CPU path. Complex QR parity is
+//! reconstruction-based: QR is unique only up to per-column unit phases
+//! (CUDA yields real R diagonals; CPU/faer leaves small imaginary residues).
+
+#![cfg(feature = "tenferro-cuda")]
+
+use std::sync::Arc;
+use tensor4all_core::CudaExecutionContext;
+
+#[test]
+fn probe_cuda_qr_with_in_matches_cpu() {
+    use tensor4all_core::qr::{qr_with, qr_with_in, QrOptions};
+    use tensor4all_core::{DynIndex, ExecutionContext, IdxTensor};
+    use tensor4all_tensorbackend::CpuExecutionContext;
+
+    let cuda = Arc::new(CudaExecutionContext::new().unwrap());
+    let context = ExecutionContext::Cuda(Arc::clone(&cuda));
+
+    for dtype_c64 in [false, true] {
+        let i = DynIndex::new_dyn(6);
+        let j = DynIndex::new_dyn(4);
+        // Full-rank fixture: diagonal-heavy + small off-diagonal
+        let host = if dtype_c64 {
+            use num_complex::Complex64;
+            let data: Vec<Complex64> = (0..24)
+                .map(|k| {
+                    let (r, c) = (k % 6, k / 6);
+                    Complex64::new(
+                        if r == c {
+                            4.0 + r as f64
+                        } else {
+                            0.1 * (r + c) as f64
+                        },
+                        0.05 * (r as f64 - c as f64),
+                    )
+                })
+                .collect();
+            IdxTensor::from_dense(vec![i.clone(), j.clone()], data).unwrap()
+        } else {
+            let data: Vec<f64> = (0..24)
+                .map(|k| {
+                    let (r, c) = (k % 6, k / 6);
+                    if r == c {
+                        4.0 + r as f64
+                    } else {
+                        0.1 * (r + c) as f64
+                    }
+                })
+                .collect();
+            IdxTensor::from_dense(vec![i.clone(), j.clone()], data).unwrap()
+        };
+
+        let resident = host.upload_cuda(&cuda).unwrap();
+        resident.validate_context(&context).unwrap();
+
+        let options = QrOptions::new().with_rtol(1e-10);
+        let (q, r) = if dtype_c64 {
+            qr_with_in::<num_complex::Complex64>(&resident, &[i.clone()], &options, &context)
+                .unwrap()
+        } else {
+            qr_with_in::<f64>(&resident, &[i.clone()], &options, &context).unwrap()
+        };
+        q.validate_context(&context).unwrap();
+        r.validate_context(&context).unwrap();
+
+        // Residency: host read must fail without explicit download
+        assert!(q.to_vec::<f64>().is_err() || dtype_c64);
+
+        // Numerical parity against CPU, via explicit download + whole-result maxabs
+        let (cpu_q, cpu_r) = if dtype_c64 {
+            qr_with::<num_complex::Complex64>(&host, &[i.clone()], &options).unwrap()
+        } else {
+            qr_with::<f64>(&host, &[i.clone()], &options).unwrap()
+        };
+        assert_eq!(q.dims(), cpu_q.dims());
+        assert_eq!(r.dims(), cpu_r.dims());
+
+        let q_back = q.download(&cuda).unwrap();
+        let r_back = r.download(&cuda).unwrap();
+        // Parity via reconstruction: complex QR is unique only up to per-column
+        // unit phases (CUDA yields real R diagonals; CPU/faer leaves small
+        // imaginary residues), so direct Q/R comparison is phase-fragile.
+        {
+            use tensor4all_core::TensorContractionLike;
+            let cuda_recon = q_back.contract_pair(&r_back).unwrap();
+            let cpu_recon = cpu_q.contract_pair(&cpu_r).unwrap();
+            let residual = if dtype_c64 {
+                use num_complex::Complex64;
+                let got: Vec<Complex64> = cuda_recon.to_vec().unwrap();
+                let want: Vec<Complex64> = cpu_recon.to_vec().unwrap();
+                got.iter()
+                    .zip(want.iter())
+                    .map(|(a, b)| (a - b).norm())
+                    .fold(0.0_f64, f64::max)
+            } else {
+                let got: Vec<f64> = cuda_recon.to_vec().unwrap();
+                let want: Vec<f64> = cpu_recon.to_vec().unwrap();
+                got.iter()
+                    .zip(want.iter())
+                    .map(|(a, b)| (a - b).abs())
+                    .fold(0.0_f64, f64::max)
+            };
+            assert!(residual < 1e-9, "CUDA/CPU reconstruction parity {residual}");
+        }
+        if !dtype_c64 {
+            // Real QR fixes column signs up to roundoff: direct comparison valid.
+            let got: Vec<f64> = q_back.to_vec().unwrap();
+            let want: Vec<f64> = cpu_q.to_vec().unwrap();
+            let residual = got
+                .iter()
+                .zip(want.iter())
+                .map(|(a, b)| (a - b).abs())
+                .fold(0.0_f64, f64::max);
+            assert!(residual < 1e-9, "CUDA/CPU Q parity residual {residual}");
+            let got: Vec<f64> = r_back.to_vec().unwrap();
+            let want: Vec<f64> = cpu_r.to_vec().unwrap();
+            let residual = got
+                .iter()
+                .zip(want.iter())
+                .map(|(a, b)| (a - b).abs())
+                .fold(0.0_f64, f64::max);
+            assert!(residual < 1e-9, "CUDA/CPU R parity residual {residual}");
+        }
+
+        // Context-free entry rejects resident inputs before any work
+        assert!(qr_with::<f64>(&resident, &[i.clone()], &options).is_err());
+        // Foreign context is rejected
+        let foreign = ExecutionContext::Cuda(Arc::new(CudaExecutionContext::new().unwrap()));
+        assert!(qr_with_in::<f64>(&resident, &[i.clone()], &options, &foreign).is_err());
+    }
+}
+
+#[test]
+fn probe_cuda_svd_with_in_matches_cpu() {
+    use tensor4all_core::svd::{svd_with, svd_with_in, SvdOptions};
+    use tensor4all_core::{DynIndex, ExecutionContext, IdxTensor, SvdTruncationPolicy};
+
+    let cuda = Arc::new(CudaExecutionContext::new().unwrap());
+    let context = ExecutionContext::Cuda(Arc::clone(&cuda));
+    let i = DynIndex::new_dyn(6);
+    let j = DynIndex::new_dyn(4);
+    // Rank-2 fixture: diagonal-heavy data
+    let data: Vec<f64> = (0..24)
+        .map(|k| {
+            let (r, c) = (k % 6, k / 6);
+            if r == c {
+                if r < 2 {
+                    4.0 + r as f64
+                } else {
+                    1e-13 * r as f64
+                }
+            } else {
+                1e-13 * (r + c) as f64
+            }
+        })
+        .collect();
+    let host = IdxTensor::from_dense(vec![i.clone(), j.clone()], data.clone()).unwrap();
+    let resident = host.upload_cuda(&cuda).unwrap();
+
+    let options = SvdOptions::new().with_policy(SvdTruncationPolicy::new(1e-10));
+    let (u, s, v) = svd_with_in::<f64>(&resident, &[i.clone()], &options, &context).unwrap();
+    u.validate_context(&context).unwrap();
+    v.validate_context(&context).unwrap();
+    // S uses diagonal storage (download support for resident diagonal factors
+    // is a PR4 final-SVD prerequisite); residency is shown by the absence of
+    // host readability, matching the cuda_transfer test idiom.
+    assert!(s.to_vec::<f64>().is_err());
+
+    let (cpu_u, cpu_s, _cpu_v) = svd_with::<f64>(&host, &[i.clone()], &options).unwrap();
+    assert_eq!(s.dims(), cpu_s.dims());
+    assert_eq!(u.dims(), cpu_u.dims());
+    // Rank decision parity: the fixture truncates to rank 2 on both paths.
+    assert_eq!(s.dims(), vec![2, 2]);
+
+    // Context-free entry rejects resident inputs before any work
+    assert!(svd_with::<f64>(&resident, &[i.clone()], &options).is_err());
+}
+
+#[test]
+fn probe_cuda_src_error_estimate_matches_cpu() {
+    use tensor4all_core::{DynIndex, ExecutionContext, IdxTensor, TensorFactorizationLike};
+
+    let cuda = Arc::new(CudaExecutionContext::new().unwrap());
+    let context = ExecutionContext::Cuda(Arc::clone(&cuda));
+
+    // Upper-triangular 4x4 R fixture, column-major
+    let cap = DynIndex::new_dyn(4);
+    let batch = DynIndex::new_dyn(4);
+    let mut data = vec![0.0_f64; 16];
+    for row in 0..4 {
+        for col in row..4 {
+            data[row + col * 4] = 3.0 + row as f64 + 0.5 * col as f64;
+        }
+    }
+    let host = IdxTensor::from_dense(vec![cap, batch], data).unwrap();
+    let resident = host.upload_cuda(&cuda).unwrap();
+
+    let device = resident.src_error_estimate_in(&context).unwrap();
+    let expected = host.src_error_estimate().unwrap();
+    assert!(
+        (device.error - expected.error).abs() < 1e-12,
+        "error: device={} cpu={}",
+        device.error,
+        expected.error
+    );
+    assert!(
+        (device.norm - expected.norm).abs() < 1e-12,
+        "norm: device={} cpu={}",
+        device.norm,
+        expected.norm
+    );
+
+    // Context-free entry rejects resident inputs before any work
+    assert!(resident.src_error_estimate().is_err());
+    // Foreign context is rejected
+    let foreign = ExecutionContext::Cuda(Arc::new(CudaExecutionContext::new().unwrap()));
+    assert!(resident.src_error_estimate_in(&foreign).is_err());
+    // Non-square and rank-1 factors fail with typed errors
+    let bad_rank =
+        IdxTensor::from_dense_in(&context, vec![DynIndex::new_dyn(2)], vec![1.0, 2.0]).unwrap();
+    assert!(bad_rank.src_error_estimate_in(&context).is_err());
+}
+
+#[test]
+fn probe_cuda_incremental_probe_batch_matches_host() {
+    use tensor4all_core::{DynIndex, ExecutionContext, IdxTensor};
+    use tensor4all_core::{TensorContractionLike, TensorFactorizationLike};
+
+    let cuda = Arc::new(CudaExecutionContext::new().unwrap());
+    let context = ExecutionContext::Cuda(Arc::clone(&cuda));
+
+    // 8x6 sketch in two blocks of 3 columns (column-major f64)
+    let rows: Vec<DynIndex> = (0..1).map(|_| DynIndex::new_dyn(8)).collect();
+    let left = rows[0].clone();
+    let data: Vec<f64> = (0..48)
+        .map(|k| {
+            let (r, c) = (k % 8, k / 8);
+            if r == c {
+                5.0 + r as f64
+            } else {
+                0.1 * (r as f64 + 1.0) / (c as f64 + 1.0)
+            }
+        })
+        .collect();
+    let block_a = DynIndex::new_dyn(3);
+    let block_b = DynIndex::new_dyn(3);
+    let host_a = IdxTensor::from_dense(
+        vec![left.clone(), block_a.clone()],
+        data.iter()
+            .enumerate()
+            .filter(|(k, _)| (k / 8) < 3)
+            .map(|(_, v)| *v)
+            .collect(),
+    )
+    .unwrap();
+    let host_b = IdxTensor::from_dense(
+        vec![left.clone(), block_b.clone()],
+        data.iter()
+            .enumerate()
+            .filter(|(k, _)| (k / 8) >= 3)
+            .map(|(_, v)| *v)
+            .collect(),
+    )
+    .unwrap();
+    let resident_a = host_a.upload_cuda(&cuda).unwrap();
+    let resident_b = host_b.upload_cuda(&cuda).unwrap();
+
+    // Device growth loop
+    let first = IdxTensor::factorize_probe_batch_incremental_in(
+        None,
+        &resident_a,
+        &block_a,
+        &[left.clone()],
+        &context,
+    )
+    .unwrap();
+    assert_eq!(first.rank, 3);
+    first.left.validate_context(&context).unwrap();
+    first.right.validate_context(&context).unwrap();
+    let grown = IdxTensor::factorize_probe_batch_incremental_in(
+        Some(&first),
+        &resident_b,
+        &block_b,
+        &[left.clone()],
+        &context,
+    )
+    .unwrap();
+    assert_eq!(grown.rank, 6);
+    grown.left.validate_context(&context).unwrap();
+    grown.right.validate_context(&context).unwrap();
+    // The resident path stores no host IncrementalQrState (code-evident via
+    // FactorizeResult::new); the estimator below takes the full-solve branch.
+
+    // Host growth loop for reference
+    let host_first =
+        IdxTensor::factorize_probe_batch_incremental(None, &host_a, &block_a, &[left.clone()])
+            .unwrap();
+    let host_grown = IdxTensor::factorize_probe_batch_incremental(
+        Some(&host_first),
+        &host_b,
+        &block_b,
+        &[left.clone()],
+    )
+    .unwrap();
+    assert_eq!(host_grown.rank, grown.rank);
+
+    // Both spans reconstruct the full sketch: compare reconstructions
+    let dev_recon = grown
+        .left
+        .contract_pair(&grown.right)
+        .unwrap()
+        .download(&cuda)
+        .unwrap();
+    let host_recon = host_grown.left.contract_pair(&host_grown.right).unwrap();
+    let got: Vec<f64> = dev_recon.to_vec().unwrap();
+    let want: Vec<f64> = host_recon.to_vec().unwrap();
+    assert_eq!(got.len(), want.len());
+    let residual = got
+        .iter()
+        .zip(want.iter())
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0_f64, f64::max);
+    assert!(
+        residual < 1e-9,
+        "incremental reconstruction parity {residual}"
+    );
+
+    // The grown R feeds the device estimator
+    let estimate = grown.right.src_error_estimate_in(&context).unwrap();
+    let expected = host_grown.right.src_error_estimate().unwrap();
+    assert!((estimate.error - expected.error).abs() < 1e-12);
+    assert!((estimate.norm - expected.norm).abs() < 1e-12);
+
+    // Context-free entry rejects resident inputs
+    assert!(IdxTensor::factorize_probe_batch_incremental(
+        None,
+        &resident_a,
+        &block_a,
+        &[left.clone()]
+    )
+    .is_err());
+}

--- a/scripts/library-panics-baseline.json
+++ b/scripts/library-panics-baseline.json
@@ -1,5 +1,5 @@
 [
-  "crates/tensor4all-core/src/defaults/idx_tensor.rs:6739:debug_assert_eq",
+  "crates/tensor4all-core/src/defaults/idx_tensor.rs:7114:debug_assert_eq",
   "crates/tensor4all-core/src/matrixlu.rs:741:debug_assert_eq",
   "crates/tensor4all-core/src/matrixluci/source.rs:103:assert",
   "crates/tensor4all-core/src/matrixluci/source.rs:108:assert_eq",


### PR DESCRIPTION
Implements **PR3** of `docs/design/context-scoped-src-contraction.md` for #720: context-aware factorization and SRC decision primitives.

## What

Context-scoped counterparts for every factorization/decision operation SRC needs on CUDA-resident inputs:

- `IdxTensor::read_decision_data` — the explicit bounded synchronization/readback boundary (4th method of the #721 seam). CUDA downloads through the owning context; CPU reads directly. f64/C64.
- `qr_with_in` — on-device upper-triangular row norms (`triu → abs → reduce_sum_squares`, only the k-element decision vector crosses the boundary). CPU path unchanged.
- `svd_truncated_inner_in` / `svd_with_in` — singular-value decision vector readback only.
- `src_error_estimate_in` (trait method + `IdxTensor` override) — device-side Appendix-C estimator: `R^H X = I` triangular solve and norm reductions on-device, `ncols + 1` decision scalars read back, scalar formula mirrors `src_error_estimate_from_inverse_adjoint`.
- `factorize_probe_batch_incremental_in` (trait method + override) — resident `[Q@R, A]` reconstruction + thin-QR recompute, no host `IncrementalQr` round-trip, no stored host state.
- Context-free entries (`qr_with`, `svd_truncated_inner`, `src_error_estimate`) reject CUDA-resident inputs with typed errors before any work.
- New error sites preserve `#[source]` chains (`anyhow::Error::new(...).context(...)`).

No SRC algorithm code is touched; CPU host paths are behavior-preserving refactors (extracted `qr_assemble` / `svd_assemble` / `svd_factorize_assemble` / scoped inner).

## Verification (all green)

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets` with `-D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc`
- `tensor4all-core` lib: 443 passed; `tensor4all-treetn` lib: 500 passed (SRC CPU behavior unchanged); doctests: 312 passed (incl. new runnable doctests for `qr_with_in`, `svd_with_in`, `read_decision_data`, trait `src_error_estimate_in`)
- A100 (`tenferro` pin `007e3bb`): `context_foundation` 5/5 + new `cuda_context_factorization` 4/4 with `--include-ignored` — exact-context residency asserts on every output, CUDA/CPU parity (QR f64 direct 1e-12, C64 reconstruction-based due to unitary phase-convention difference; SVD rank decision; estimator 1e-12; incremental reconstruction 1e-9 + estimator 1e-12), mixed/foreign-context typed rejections
- `scripts/repository-rules-review.py --base main --worktree --dry-run`: pass, no findings
- `cargo run -p xtask --release -- api-dump`: complete inventory verified

## Review gate

- Pre-implementation design verdict: `reviewer-flash` (DeepSeek family, read-only) **Correct-to-implement**, recorded in the design doc.
- Post-diff verdict: `reviewer-flash` **Correct-to-merge** (1 Important finding accepted as documented limitation, minors fixed).
- Re-review of the 3 post-verdict fixes (docstring accuracy, `batch_index` guard, source chains): **CONFIRMED**, 0 findings.

## Coverage attestation

New code paths (CUDA device branches, `_in` entries, resident helpers, early rejections) are each exercised by the new CPU tests, doctests, and A100 CUDA tests above. No shared helper lost its sole exerciser: host paths remain covered by the pre-existing `qr`/`svd`/`factorize` suites (all passing). No thresholds changed.

## Known limitations / follow-ups (not in this slice)

- Resident incremental QR is not rank-revealing (documented in code): dependent appended blocks report larger rank than host; device-side rank guard + dependent-block test follow up (needed before adaptive parity claims).
- Transfer instrumentation / recording-context "no unclassified transfer" assertion is PR4 scope.
- Resident Diagonal storage (SVD `S` factors) validate/download support is a PR4 final-SVD prerequisite.
- Sibling bug found during audit, outside this slice: `IdxTensor::scale` mints its scalar operand in the process-global CPU context (breaks any explicit-context tensor) — belongs to #623, SRC production paths don't call it.
- Remaining SRC production context-free constructions (`T::from_dense`/`T::ones` in `src_probe.rs`, `src_tree.rs`, `src_chain.rs`) migrate in PR4.

Closes nothing yet — #720 stays open pending PR4 (full SRC migration + fixed/adaptive × chain/tree × `final_svd` matrix gates).
