### PR TITLE
Make SRC contraction placement-aware for CUDA-resident TreeTNs (#720 PR4)

### DIFF
--- a/crates/tensor4all-core/src/defaults/contract.rs
+++ b/crates/tensor4all-core/src/defaults/contract.rs
@@ -28,6 +28,7 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 use petgraph::algo::connected_components;
 use petgraph::prelude::*;
+use tenferro::TensorValue;
 use tenferro_einsum::{EagerEinsumExt, EinsumSubscripts};
 use tensor4all_tensorbackend::{
     einsum_native_tensor_reads, einsum_native_tensors_owned, NativeTensorReadInput,
@@ -1014,11 +1015,65 @@ fn contract_impl(tensors: &[&IdxTensor], options: ContractionOptions<'_>) -> Res
     Ok(result)
 }
 
+/// Contract a resident structured/diagonal pair through the eager plan path.
+///
+/// Pairwise fast paths borrow native host payloads, which device-resident
+/// operands cannot provide. This builds the same 2-tensor plan the N-ary
+/// executor uses (diagonal-aware) and runs it in the operands' owning
+/// runtime. Conjugation flags materialize first via resident eager ops.
+#[cfg(feature = "tenferro-cuda")]
+pub(crate) fn contract_pair_via_plan(
+    lhs: &IdxTensor,
+    rhs: &IdxTensor,
+    options: PairwiseContractionOptions,
+) -> Result<IdxTensor> {
+    let lhs_owned;
+    let rhs_owned;
+    let (lhs, rhs) = match (options.lhs_conj, options.rhs_conj) {
+        (false, false) => (lhs, rhs),
+        (true, false) => {
+            lhs_owned = lhs.conj();
+            (&lhs_owned, rhs)
+        }
+        (false, true) => {
+            rhs_owned = rhs.conj();
+            (lhs, &rhs_owned)
+        }
+        (true, true) => {
+            lhs_owned = lhs.conj();
+            rhs_owned = rhs.conj();
+            (&lhs_owned, &rhs_owned)
+        }
+    };
+    let tensors = [lhs, rhs];
+    let plan = build_contraction_plan(&tensors, ContractionOptions::new())?;
+    execute_contraction_plan(&tensors, &plan, false)
+}
+
 fn execute_contraction_plan(
     tensors: &[&IdxTensor],
     plan: &ContractionPlan,
     has_retained_indices: bool,
 ) -> Result<IdxTensor> {
+    // Device-resident operands cannot enter the native host session below;
+    // run them through the owning-runtime eager einsum path (the same
+    // dispatch the tracked path uses). Host operands keep the native path
+    // unchanged. Mixed host/device sets keep failing loudly in the native
+    // path instead of silently migrating.
+    #[cfg(feature = "tenferro-cuda")]
+    if !tensors.is_empty() && tensors.iter().all(|tensor| tensor.is_cuda_resident()) {
+        let operands = tensors
+            .iter()
+            .map(|tensor| tensor.as_inner())
+            .collect::<Result<Vec<_>>>()?;
+        let subscripts = build_einsum_subscripts_from_usize_ids(&plan.input_ids, &plan.output_ids)?;
+        let result = operands.as_slice().einsum_subscripts(&subscripts)?;
+        return IdxTensor::from_inner_with_axis_classes(
+            plan.result_indices.clone(),
+            result,
+            plan.result_axis_classes.clone(),
+        );
+    }
     let any_grad = tensors.iter().any(|tensor| tensor.tracks_grad());
     if any_grad {
         let first_dtype = tensors[0].as_inner()?.dtype();
@@ -1079,11 +1134,42 @@ fn execute_contraction_plan(
         .map(|(tensor, ids)| (tensor, *ids))
         .collect::<Vec<_>>();
     let result_native = einsum_native_tensor_reads(&operand_refs, &plan.output_ids)?;
-    IdxTensor::from_untracked_native_with_axis_classes(
-        plan.result_indices.clone(),
-        result_native,
-        plan.result_axis_classes.clone(),
-    )
+    // Wrap the result in the operands' common eager runtime when they share
+    // one, so explicit-context tensors stay in their context instead of
+    // falling back to the process-global default. Mixed runtimes keep the
+    // legacy default wrap; rejecting them is #623 scope, not this seam's.
+    let mut common: Option<std::sync::Arc<tenferro_ad::EagerRuntime>> = None;
+    let mut mixed = false;
+    for tensor in tensors {
+        if let Some(runtime) = tensor.eager_runtime() {
+            match &common {
+                None => common = Some(runtime),
+                Some(first) => {
+                    if first.id() != runtime.id() {
+                        mixed = true;
+                    }
+                }
+            }
+        }
+    }
+    match (common, mixed) {
+        (Some(runtime), false) => {
+            let inner = tenferro_ad::extension::adopt_untracked_eager_value(
+                runtime,
+                TensorValue::from_tensor(result_native),
+            )?;
+            IdxTensor::from_inner_with_axis_classes(
+                plan.result_indices.clone(),
+                inner,
+                plan.result_axis_classes.clone(),
+            )
+        }
+        _ => IdxTensor::from_untracked_native_with_axis_classes(
+            plan.result_indices.clone(),
+            result_native,
+            plan.result_axis_classes.clone(),
+        ),
+    }
 }
 
 fn build_einsum_subscripts_from_usize_ids(

--- a/crates/tensor4all-core/src/defaults/factorize.rs
+++ b/crates/tensor4all-core/src/defaults/factorize.rs
@@ -42,13 +42,16 @@ use num_complex::{Complex64, ComplexFloat};
 use tenferro_ad::EagerTensor;
 use tensor4all_tensorbackend::{Matrix, TensorElement};
 
-use crate::defaults::svd::{compute_retained_rank, svd_for_factorize};
-use crate::qr::{qr_with, QrOptions};
+use crate::defaults::svd::{
+    compute_retained_rank, svd_for_factorize, svd_for_factorize_in, SvdFactorizeResult,
+};
+use crate::qr::{qr_with, qr_with_in, QrOptions};
 use crate::svd::SvdOptions;
 use crate::truncation::{
     validate_svd_truncation_policy, SingularValueMeasure, SvdTruncationPolicy, ThresholdScale,
     TruncationRule,
 };
+use crate::ExecutionContext;
 
 // Re-export types from tensor_like for backwards compatibility
 pub use crate::tensor_like::{
@@ -424,6 +427,221 @@ pub fn factorize_full_rank(
     }
 }
 
+/// Factorize a tensor in a caller-owned execution context.
+///
+/// Context-scoped counterpart of [`factorize`]: the input must belong to
+/// `context`, and QR/SVD factors, truncation, and results stay in `context`
+/// with only bounded decision payloads crossing the explicit readback
+/// boundary on CUDA. LU and CI have no context-scoped path and return a typed
+/// error; run them through [`factorize`] on host inputs instead.
+///
+/// # Arguments
+/// * `t` - Input tensor, which must belong to `context`.
+/// * `left_inds` - Indices to place on the left side.
+/// * `options` - Factorization options.
+/// * `context` - Caller-owned execution context owning the input and results.
+///
+/// # Examples
+///
+/// ```
+/// use std::sync::Arc;
+/// use tensor4all_core::{
+///     DynIndex, ExecutionContext, FactorizeOptions, TensorContractionLike,
+///     factorize_in, Canonical, FactorizeAlg,
+/// };
+/// use tensor4all_tensorbackend::CpuExecutionContext;
+/// use tenferro_cpu::CpuBackend;
+///
+/// let context = ExecutionContext::Cpu(Arc::new(
+///     CpuExecutionContext::from_backend(CpuBackend::new()),
+/// ));
+/// let i = DynIndex::new_dyn(4);
+/// let j = DynIndex::new_dyn(3);
+/// let data: Vec<f64> = (0..12).map(|x| x as f64).collect();
+/// let tensor =
+///     tensor4all_core::IdxTensor::from_dense_in(&context, vec![i.clone(), j.clone()], data)?;
+/// let options = FactorizeOptions::qr();
+/// let result = factorize_in(&tensor, &[i.clone()], &options, &context)?;
+/// let recovered = result.left.contract_pair(&result.right)?;
+/// assert_eq!(recovered.dims(), vec![4, 3]);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// # Errors
+/// Returns `FactorizeError` when the tensor does not belong to `context`,
+/// when the storage, algorithm, or options are unsupported, or when the
+/// factorization or explicit decision readback fails.
+pub fn factorize_in(
+    t: &IdxTensor,
+    left_inds: &[DynIndex],
+    options: &FactorizeOptions,
+    context: &ExecutionContext,
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
+    options.validate()?;
+    t.validate_context(context)
+        .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+
+    if t.is_diag() {
+        return Err(FactorizeError::UnsupportedStorage(
+            "Diagonal storage not supported for factorize",
+        ));
+    }
+
+    if !(t.is_f64() || t.is_complex()) {
+        return Err(FactorizeError::UnsupportedStorage(
+            "factorize currently supports only f64 and Complex64 tensors",
+        ));
+    }
+
+    match options.alg {
+        FactorizeAlg::SVD => factorize_svd_with_options_in(t, left_inds, options, context),
+        FactorizeAlg::QR => factorize_qr_with_options_in(t, left_inds, options, context),
+        FactorizeAlg::LU | FactorizeAlg::CI => Err(FactorizeError::UnsupportedStorage(
+            "LU and CI factorization have no context-scoped path; use factorize() on host inputs",
+        )),
+    }
+}
+
+/// Full-rank factorization in a caller-owned execution context.
+///
+/// Context-scoped counterpart of [`factorize_full_rank`] with the same
+/// algorithm coverage: QR and SVD execute in `context`; LU and CI return a
+/// typed error.
+///
+/// # Errors
+/// Returns `FactorizeError` when the tensor does not belong to `context`,
+/// when the storage or algorithm is unsupported, or when the factorization
+/// fails.
+pub fn factorize_full_rank_in(
+    t: &IdxTensor,
+    left_inds: &[DynIndex],
+    alg: FactorizeAlg,
+    canonical: Canonical,
+    context: &ExecutionContext,
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
+    t.validate_context(context)
+        .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+
+    if t.is_diag() {
+        return Err(FactorizeError::UnsupportedStorage(
+            "Diagonal storage not supported for factorize",
+        ));
+    }
+
+    if !(t.is_f64() || t.is_complex()) {
+        return Err(FactorizeError::UnsupportedStorage(
+            "factorize currently supports only f64 and Complex64 tensors",
+        ));
+    }
+
+    match alg {
+        FactorizeAlg::SVD => {
+            factorize_svd_with_options_in_full_rank(t, left_inds, canonical, context)
+        }
+        FactorizeAlg::QR => factorize_qr_full_rank_in(t, left_inds, canonical, context),
+        FactorizeAlg::LU | FactorizeAlg::CI => Err(FactorizeError::UnsupportedStorage(
+            "LU and CI factorization have no context-scoped path; use factorize_full_rank() on host inputs",
+        )),
+    }
+}
+
+fn factorize_svd_with_options_in(
+    t: &IdxTensor,
+    left_inds: &[DynIndex],
+    options: &FactorizeOptions,
+    context: &ExecutionContext,
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
+    let mut svd_options = SvdOptions::new();
+    if let Some(policy) = options.svd_policy {
+        svd_options = svd_options.with_policy(policy);
+    }
+    if let Some(max_bond_dim) = options.max_bond_dim {
+        svd_options = svd_options.with_max_bond_dim(max_bond_dim);
+    }
+
+    factorize_svd_with_eager_options_in(t, left_inds, options.canonical, &svd_options, context)
+}
+
+fn factorize_svd_with_options_in_full_rank(
+    t: &IdxTensor,
+    left_inds: &[DynIndex],
+    canonical: Canonical,
+    context: &ExecutionContext,
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
+    let svd_options = SvdOptions::full_rank();
+    factorize_svd_with_eager_options_in(t, left_inds, canonical, &svd_options, context)
+}
+
+fn factorize_svd_with_eager_options_in(
+    t: &IdxTensor,
+    left_inds: &[DynIndex],
+    canonical: Canonical,
+    svd_options: &SvdOptions,
+    context: &ExecutionContext,
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
+    let result = svd_for_factorize_in(t, left_inds, svd_options, context)
+        .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+    assemble_svd_factors(result, canonical)
+}
+
+fn factorize_qr_with_options_in(
+    t: &IdxTensor,
+    left_inds: &[DynIndex],
+    options: &FactorizeOptions,
+    context: &ExecutionContext,
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
+    if options.canonical == Canonical::Right {
+        return Err(FactorizeError::UnsupportedCanonical(
+            "QR only supports Canonical::Left (would need LQ for right)",
+        ));
+    }
+
+    let qr_options = if let Some(rtol) = options.qr_rtol {
+        QrOptions::new().with_rtol(rtol)
+    } else {
+        QrOptions::new()
+    };
+
+    factorize_qr_with_eager_options_in(t, left_inds, &qr_options, context)
+}
+
+fn factorize_qr_full_rank_in(
+    t: &IdxTensor,
+    left_inds: &[DynIndex],
+    canonical: Canonical,
+    context: &ExecutionContext,
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
+    if canonical == Canonical::Right {
+        return Err(FactorizeError::UnsupportedCanonical(
+            "QR only supports Canonical::Left (would need LQ for right)",
+        ));
+    }
+
+    factorize_qr_with_eager_options_in(t, left_inds, &QrOptions::full_rank(), context)
+}
+
+fn factorize_qr_with_eager_options_in(
+    t: &IdxTensor,
+    left_inds: &[DynIndex],
+    qr_options: &QrOptions,
+    context: &ExecutionContext,
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
+    let (q, r) = qr_with_in::<f64>(t, left_inds, qr_options, context)
+        .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+
+    let bond_index = q
+        .indices
+        .last()
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("QR factorization returned a rank-0 Q tensor"))?;
+    let q_dims = q.dims();
+    let rank = *q_dims
+        .last()
+        .ok_or_else(|| anyhow::anyhow!("QR factorization returned Q with no dimensions"))?;
+
+    Ok(FactorizeResult::new(q, r, bond_index, None, rank))
+}
+
 fn factorize_impl_f64(
     t: &IdxTensor,
     left_inds: &[DynIndex],
@@ -511,6 +729,17 @@ fn factorize_svd_with_options(
     svd_options: &SvdOptions,
 ) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
     let result = svd_for_factorize(t, left_inds, svd_options)?;
+    assemble_svd_factors(result, canonical)
+}
+
+/// Absorb the SVD factors into left/right canonical form.
+///
+/// Shared by the host and context-scoped SVD factorization paths: contracts
+/// `S` into one side and renames the leftover `sim` leg back to `bond`.
+fn assemble_svd_factors(
+    result: SvdFactorizeResult,
+    canonical: Canonical,
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
     let u = result.u;
     let s = result.s;
     let vh = result.vh;

--- a/crates/tensor4all-core/src/defaults/idx_tensor.rs
+++ b/crates/tensor4all-core/src/defaults/idx_tensor.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant};
 use tenferro::{
     DType, DotGeneralConfig, Tensor as NativeTensor, TensorRead, TensorValue, TensorView,
 };
-use tenferro_ad::{extension::adopt_untracked_eager_value, EagerTensor};
+use tenferro_ad::{extension::adopt_untracked_eager_value, EagerRuntime, EagerTensor};
 use tenferro_einsum::{EagerEinsumExt, EinsumSubscripts};
 use tenferro_linalg::EagerTensorLinalgExt;
 use tensor4all_tensorbackend::{
@@ -1754,7 +1754,29 @@ impl IdxTensor {
             &refs,
             &plan.output_payload_roots,
         )?;
-        let payload_inner = EagerTensor::from_tensor_in(payload, default_eager_ctx()?)?;
+        // Wrap the result in the operands' common eager runtime when they share
+        // one, so explicit-context tensors (e.g. SVD factors) stay in their
+        // context instead of falling back to the process-global default.
+        // Mixed runtimes keep the legacy default wrap; rejecting them is #623
+        // scope, not this seam's.
+        let mut common: Option<Arc<EagerRuntime>> = None;
+        let mut mixed = false;
+        for operand in operands {
+            if let Some(inner) = operand.storage.eager() {
+                match &common {
+                    None => common = Some(Arc::clone(inner.runtime())),
+                    Some(runtime) => {
+                        if runtime.id() != inner.ctx_id() {
+                            mixed = true;
+                        }
+                    }
+                }
+            }
+        }
+        let payload_inner = match (common, mixed) {
+            (Some(runtime), false) => EagerTensor::from_tensor_in(payload, runtime)?,
+            _ => EagerTensor::from_tensor_in(payload, default_eager_ctx()?)?,
+        };
         Self::from_structured_payload_inner(
             result_indices,
             payload_inner,
@@ -5690,6 +5712,15 @@ impl TensorFactorizationLike for IdxTensor {
         crate::factorize::factorize(self, left_inds, options)
     }
 
+    fn factorize_in(
+        &self,
+        left_inds: &[DynIndex],
+        options: &FactorizeOptions,
+        context: &ExecutionContext,
+    ) -> std::result::Result<FactorizeResult<Self>, FactorizeError> {
+        crate::factorize::factorize_in(self, left_inds, options, context)
+    }
+
     fn factorize_auto(
         &self,
         left_inds: &[DynIndex],
@@ -5705,6 +5736,16 @@ impl TensorFactorizationLike for IdxTensor {
         canonical: crate::Canonical,
     ) -> std::result::Result<FactorizeResult<Self>, FactorizeError> {
         crate::factorize::factorize_full_rank(self, left_inds, alg, canonical)
+    }
+
+    fn factorize_full_rank_in(
+        &self,
+        left_inds: &[DynIndex],
+        alg: crate::FactorizeAlg,
+        canonical: crate::Canonical,
+        context: &ExecutionContext,
+    ) -> std::result::Result<FactorizeResult<Self>, FactorizeError> {
+        crate::factorize::factorize_full_rank_in(self, left_inds, alg, canonical, context)
     }
 
     fn factorize_probe_columns_incremental(
@@ -5745,13 +5786,19 @@ impl TensorFactorizationLike for IdxTensor {
         batch_tensor
             .validate_context(context)
             .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
-        #[cfg(feature = "tenferro-cuda")]
-        if matches!(context, ExecutionContext::Cuda(_)) {
-            return Self::resident_probe_batch_qr(previous, batch_tensor, batch_index, left_inds);
+        // Compatibility boundary: the process-global CPU context keeps the
+        // historical host `IncrementalQr` matrix path (bitwise-identical
+        // numerics for legacy callers). Every other explicit context uses the
+        // scoped recompute path with no host round-trip.
+        if context.is_global_default_cpu() {
+            return factorize_probe_batch_incremental_impl(
+                previous,
+                batch_tensor,
+                batch_index,
+                left_inds,
+            );
         }
-        #[cfg(not(feature = "tenferro-cuda"))]
-        let _ = context;
-        factorize_probe_batch_incremental_impl(previous, batch_tensor, batch_index, left_inds)
+        Self::resident_probe_batch_qr(previous, batch_tensor, batch_index, left_inds)
     }
 
     fn src_error_estimate(
@@ -5828,7 +5875,6 @@ impl IdxTensor {
     /// SRC probe blocks are iid random draws, for which dependence is
     /// measure-zero; a device-side rank guard plus a dependent-block test is a
     /// tracked follow-up, not part of this primitive.
-    #[cfg(feature = "tenferro-cuda")]
     fn resident_probe_batch_qr(
         previous: Option<&FactorizeResult<IdxTensor>>,
         batch_tensor: &IdxTensor,
@@ -6562,6 +6608,20 @@ impl TensorConstructionLike for IdxTensor {
         IdxTensor::from_dense(indices.to_vec(), vec![1.0_f64; total_size])
     }
 
+    fn ones_in(
+        context: &tensor4all_tensorbackend::ExecutionContext,
+        indices: &[DynIndex],
+    ) -> std::result::Result<Self, Self::Error> {
+        IdxTensor::ones_in(context, indices)
+    }
+
+    fn validate_context(
+        &self,
+        context: &tensor4all_tensorbackend::ExecutionContext,
+    ) -> std::result::Result<(), Self::Error> {
+        IdxTensor::validate_context(self, context)
+    }
+
     fn from_dense_any(
         indices: Vec<DynIndex>,
         data: Vec<AnyScalar>,
@@ -6574,6 +6634,14 @@ impl TensorConstructionLike for IdxTensor {
         data: Vec<T>,
     ) -> std::result::Result<Self, Self::Error> {
         IdxTensor::from_dense(indices, data)
+    }
+
+    fn from_dense_in<T: TensorElement + Into<AnyScalar>>(
+        context: &tensor4all_tensorbackend::ExecutionContext,
+        indices: Vec<DynIndex>,
+        data: Vec<T>,
+    ) -> std::result::Result<Self, Self::Error> {
+        IdxTensor::from_dense_in(context, indices, data)
     }
 
     fn stack_along_new_index(

--- a/crates/tensor4all-core/src/defaults/idx_tensor.rs
+++ b/crates/tensor4all-core/src/defaults/idx_tensor.rs
@@ -5715,6 +5715,18 @@ impl TensorVectorSpace for IdxTensor {
         IdxTensor::scale(self, scalar)
     }
 
+    fn scale_in(
+        &self,
+        factor: f64,
+        context: &ExecutionContext,
+    ) -> std::result::Result<Self, Self::Error> {
+        IdxTensor::scale_in(self, factor, context)
+    }
+
+    fn norm_in(&self, context: &ExecutionContext) -> std::result::Result<f64, Self::Error> {
+        IdxTensor::norm_in(self, context)
+    }
+
     fn inner_product(&self, other: &Self) -> std::result::Result<crate::AnyScalar, Self::Error> {
         IdxTensor::inner_product(self, other)
     }
@@ -7839,6 +7851,190 @@ impl IdxTensor {
                 anyhow::anyhow!("decision payloads support f64 and Complex64 storage only"),
             ))
         }
+    }
+
+    /// Scale every element by a real factor in a caller-owned context.
+    ///
+    /// The scalar is built in the tensor's owning runtime (explicit upload
+    /// for CUDA) and multiplied there; host-storage CPU tensors are adopted
+    /// into `context` first via explicit construction. With a CPU context
+    /// this matches [`IdxTensor::scale`] bit-for-bit.
+    ///
+    /// # Arguments
+    ///
+    /// * `factor` - Real scaling factor.
+    /// * `context` - Caller-owned execution context the tensor belongs to.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tensor4all_core::{DynIndex, ExecutionContext, IdxTensor};
+    /// use tensor4all_tensorbackend::CpuExecutionContext;
+    /// use tenferro_cpu::CpuBackend;
+    ///
+    /// let context = ExecutionContext::Cpu(Arc::new(
+    ///     CpuExecutionContext::from_backend(CpuBackend::new()),
+    /// ));
+    /// let tensor = IdxTensor::from_dense_in(
+    ///     &context,
+    ///     vec![DynIndex::new_dyn(2)],
+    ///     vec![1.0_f64, 2.0],
+    /// )?;
+    /// let scaled = tensor.scale_in(3.0, &context)?;
+    /// assert_eq!(scaled.to_vec::<f64>()?, vec![3.0, 6.0]);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdxTensorError`] when the tensor does not belong to
+    /// `context`, when the storage is neither `f64` nor `Complex64`, or when
+    /// the scalar construction, upload, or multiplication fails.
+    pub fn scale_in(
+        &self,
+        factor: f64,
+        context: &ExecutionContext,
+    ) -> std::result::Result<Self, IdxTensorError> {
+        self.validate_context(context)?;
+        let adopted_storage;
+        let operand: &EagerTensor = match self.eager_runtime() {
+            Some(_) => self.as_inner()?,
+            // Host storage (CPU only; CUDA validated above): adopt into the
+            // context through explicit construction.
+            None => {
+                adopted_storage = Self::adopt_host_into_context(self, context)?;
+                adopted_storage.as_inner()?
+            }
+        };
+        let scalar = Self::context_scalar_in(operand, factor, context)?;
+        let scaled = operand.mul(&scalar).map_err(|error| {
+            IdxTensorError::operation(
+                "context-scoped scaling",
+                anyhow::Error::new(error).context("eager multiplication failed"),
+            )
+        })?;
+        Self::from_inner(self.indices.clone(), scaled).map_err(IdxTensorError::from)
+    }
+
+    /// Adopt host storage into a context through explicit construction.
+    fn adopt_host_into_context(
+        tensor: &Self,
+        context: &ExecutionContext,
+    ) -> std::result::Result<Self, IdxTensorError> {
+        if tensor.is_f64() {
+            let values = tensor.to_vec::<f64>().map_err(|error| {
+                IdxTensorError::operation("context adoption", anyhow::Error::new(error))
+            })?;
+            Self::from_dense_in(context, tensor.indices.clone(), values)
+        } else if tensor.is_c64() {
+            let values = tensor.to_vec::<Complex64>().map_err(|error| {
+                IdxTensorError::operation("context adoption", anyhow::Error::new(error))
+            })?;
+            Self::from_dense_in(context, tensor.indices.clone(), values)
+        } else {
+            Err(IdxTensorError::operation(
+                "context adoption",
+                anyhow::anyhow!("adoption supports f64 and Complex64 storage only"),
+            ))
+        }
+    }
+
+    /// Build a scalar in the operand's owning runtime (explicit upload for CUDA).
+    fn context_scalar_in(
+        operand: &EagerTensor,
+        factor: f64,
+        context: &ExecutionContext,
+    ) -> std::result::Result<EagerTensor, IdxTensorError> {
+        let native: NativeTensor = match operand.dtype() {
+            DType::F64 => NativeTensor::from_vec_col_major(vec![], vec![factor]),
+            DType::C64 => {
+                NativeTensor::from_vec_col_major(vec![], vec![Complex64::new(factor, 0.0)])
+            }
+            other => {
+                return Err(IdxTensorError::operation(
+                    "context-scoped scaling",
+                    anyhow::anyhow!("unsupported scalar dtype {other:?}"),
+                ));
+            }
+        }
+        .map_err(|error| {
+            IdxTensorError::operation("context-scoped scaling", anyhow::anyhow!("{error}"))
+        })?;
+        let runtime = Self::context_eager_runtime(context)?;
+        let resident = match context {
+            ExecutionContext::Cpu(_) => native,
+            #[cfg(feature = "tenferro-cuda")]
+            ExecutionContext::Cuda(cuda) => cuda.upload_cuda(&native).map_err(|error| {
+                IdxTensorError::operation(
+                    "context-scoped scaling",
+                    anyhow::Error::new(error).context("scalar upload failed"),
+                )
+            })?,
+        };
+        EagerTensor::from_tensor_in(resident, runtime).map_err(|error| {
+            IdxTensorError::operation(
+                "context-scoped scaling",
+                anyhow::Error::new(error).context("scalar wrapping failed"),
+            )
+        })
+    }
+
+    /// Resolve the eager runtime owned by a context.
+    fn context_eager_runtime(
+        context: &ExecutionContext,
+    ) -> std::result::Result<Arc<EagerRuntime>, IdxTensorError> {
+        match context {
+            ExecutionContext::Cpu(context) => context.eager_runtime().map_err(|error| {
+                IdxTensorError::operation("context-scoped scaling", anyhow::Error::new(error))
+            }),
+            #[cfg(feature = "tenferro-cuda")]
+            ExecutionContext::Cuda(context) => context.eager_runtime().map_err(|error| {
+                IdxTensorError::operation("context-scoped scaling", anyhow::Error::new(error))
+            }),
+        }
+    }
+
+    /// Frobenius norm in a caller-owned execution context.
+    ///
+    /// Reductions run in the tensor's owning runtime; only the scalar result
+    /// crosses the explicit readback boundary on CUDA. With a CPU context
+    /// this delegates to [`IdxTensor::norm`] unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdxTensorError`] when the tensor does not belong to
+    /// `context`, when the storage is neither `f64` nor `Complex64`, or when
+    /// the reductions or explicit readback fail.
+    pub fn norm_in(&self, context: &ExecutionContext) -> std::result::Result<f64, IdxTensorError> {
+        self.validate_context(context)?;
+        #[cfg(feature = "tenferro-cuda")]
+        if matches!(context, ExecutionContext::Cuda(_)) {
+            let inner = self.cuda_eager_inner().ok_or_else(|| {
+                IdxTensorError::operation(
+                    "context-scoped norm",
+                    anyhow::anyhow!("tensor has no resident eager value"),
+                )
+            })?;
+            let rank = inner.shape().len();
+            let axes: Vec<usize> = (0..rank).collect();
+            let squared = inner
+                .abs()
+                .and_then(|magnitudes| magnitudes.reduce_sum_squares(&axes))
+                .map_err(|error| {
+                    IdxTensorError::operation("context-scoped norm", anyhow::anyhow!("{error}"))
+                })?;
+            let scalar = squared.reshape(&[1]).map_err(|error| {
+                IdxTensorError::operation("context-scoped norm", anyhow::anyhow!("{error}"))
+            })?;
+            let values = Self::read_resident_vector(&scalar, 1, context).map_err(|error| {
+                IdxTensorError::operation("context-scoped norm", anyhow::Error::new(error))
+            })?;
+            return Ok(values[0].sqrt());
+        }
+        #[cfg(not(feature = "tenferro-cuda"))]
+        let _ = context;
+        self.norm()
     }
 }
 

--- a/crates/tensor4all-core/src/defaults/idx_tensor.rs
+++ b/crates/tensor4all-core/src/defaults/idx_tensor.rs
@@ -2444,22 +2444,16 @@ impl IdxTensor {
             .into());
         }
 
-        let rank = self.indices.len();
-        let mut starts = vec![0_i64; rank];
-        let mut slice_sizes = self.dims();
+        // Slice positionally axis by axis in the operand's own runtime.
+        // (A starts-tensor + dynamic_slice build would need an explicit
+        // host-to-device upload for resident operands, which this
+        // context-free helper cannot name.)
+        let mut sliced = self.try_materialized_inner()?.clone();
         for (&axis, &position) in selected_axes.iter().zip(positions.iter()) {
-            starts[axis] = i64::try_from(position)
-                .map_err(|_| anyhow::anyhow!("selected coordinate does not fit in i64"))?;
-            slice_sizes[axis] = 1;
+            sliced = sliced
+                .slice_axis(axis, position..position + 1)
+                .map_err(|error| anyhow::anyhow!("select_indices slicing failed: {error}"))?;
         }
-
-        let starts_tensor = EagerTensor::from_tensor_in(
-            NativeTensor::from_vec_col_major(vec![rank], starts).map_err(anyhow::Error::new)?,
-            default_eager_ctx()?,
-        )?;
-        let sliced = self
-            .try_materialized_inner()?
-            .dynamic_slice(&starts_tensor, &slice_sizes)?;
         Self::from_inner(kept_indices, sliced.reshape(&kept_dims)?).map_err(IdxTensorError::from)
     }
 
@@ -3134,6 +3128,17 @@ impl IdxTensor {
             .or_else(|| self.eager_cache.get().map(AsRef::as_ref))
     }
 
+    /// Borrow the owning eager runtime without materializing or transferring.
+    ///
+    /// Returns `None` for tensors with no eager value. Used to keep
+    /// contraction results in their operands' context.
+    pub(crate) fn eager_runtime(&self) -> Option<Arc<EagerRuntime>> {
+        self.storage
+            .eager()
+            .or_else(|| self.eager_cache.get().map(AsRef::as_ref))
+            .map(|inner| Arc::clone(inner.runtime()))
+    }
+
     /// Check whether this tensor's eager value is device-resident.
     ///
     /// Metadata-only: inspects placement without reading data, transferring,
@@ -3593,6 +3598,18 @@ impl IdxTensor {
         other: &Self,
         options: PairwiseContractionOptions,
     ) -> Result<Self> {
+        // Device-resident structured/diagonal operands cannot enter the native
+        // host session used below; route them through the owning-runtime eager
+        // plan executor (which also serves N-ary resident contraction).
+        // Dense-dense resident pairs keep the pairwise eager path, and host
+        // operands keep this function unchanged.
+        #[cfg(feature = "tenferro-cuda")]
+        if self.is_cuda_resident()
+            && other.is_cuda_resident()
+            && self.should_use_structured_payload_contract(other)
+        {
+            return super::contract::contract_pair_via_plan(self, other, options);
+        }
         let self_indices = profile_pairwise_contract_section("operand_indices", || {
             self.operand_indices_for_contraction(options.lhs_conj)
         });

--- a/crates/tensor4all-core/src/defaults/svd.rs
+++ b/crates/tensor4all-core/src/defaults/svd.rs
@@ -610,6 +610,36 @@ pub(crate) fn svd_for_factorize(
     )
 }
 
+/// Compute truncated SVD for factorization in a caller-owned context.
+///
+/// Context-scoped counterpart of [`svd_for_factorize`]: the factorization and
+/// truncation slicing execute in `context`, with only the singular-value
+/// decision vector crossing the explicit readback boundary on CUDA.
+///
+/// # Errors
+///
+/// Returns `SvdError` when the tensor does not belong to `context`, when the
+/// indices or options are invalid, or when the factorization or explicit
+/// decision readback fails.
+pub(crate) fn svd_for_factorize_in(
+    t: &IdxTensor,
+    left_inds: &[DynIndex],
+    options: &SvdOptions,
+    context: &ExecutionContext,
+) -> Result<SvdFactorizeResult, SvdError> {
+    let (u_inner, s_inner, vt_inner, singular_values, bond_index, left_indices, right_indices) =
+        svd_truncated_inner_in(t, left_inds, options, context)?;
+    svd_factorize_assemble(
+        u_inner,
+        s_inner,
+        vt_inner,
+        singular_values,
+        bond_index,
+        left_indices,
+        right_indices,
+    )
+}
+
 /// Wrap the truncated eager factors as [`IdxTensor`]s, returning `V^H` directly.
 fn svd_factorize_assemble(
     u_inner: EagerTensor,

--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -167,7 +167,9 @@ pub mod svd {
 
 // Re-export linear algebra items for top-level access
 pub use defaults::direct_sum::direct_sum;
-pub use defaults::factorize::{factorize, factorize_full_rank};
+pub use defaults::factorize::{
+    factorize, factorize_full_rank, factorize_full_rank_in, factorize_in,
+};
 pub use defaults::qr::{default_qr_rtol, qr, qr_with, set_default_qr_rtol, QrError, QrOptions};
 pub use defaults::svd::{
     default_svd_truncation_policy, set_default_svd_truncation_policy, svd, svd_with, SvdError,

--- a/crates/tensor4all-core/src/tensor_like.rs
+++ b/crates/tensor4all-core/src/tensor_like.rs
@@ -672,6 +672,26 @@ pub trait TensorVectorSpace: TensorIndex {
     /// failure.
     fn scale(&self, scalar: AnyScalar) -> std::result::Result<Self, Self::Error>;
 
+    /// Real scalar multiplication in a caller-owned execution context.
+    ///
+    /// Context-scoped counterpart of [`Self::scale`] for real factors: the
+    /// scalar is constructed in the tensor's owning runtime (explicit upload
+    /// for CUDA), so explicit-context tensors never enter the process-global
+    /// default context.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Self::Error` when scoped scaling is unsupported for this
+    /// tensor type, when the tensor does not belong to `context`, or when
+    /// the construction, upload, or multiplication fails.
+    fn scale_in(
+        &self,
+        _factor: f64,
+        _context: &tensor4all_tensorbackend::ExecutionContext,
+    ) -> std::result::Result<Self, Self::Error> {
+        Err(anyhow::anyhow!("context-scoped scaling is not supported for this tensor type").into())
+    }
+
     /// Inner product (dot product) of two tensors.
     ///
     /// Computes `⟨self, other⟩ = Σ conj(self)_i * other_i`.
@@ -703,6 +723,25 @@ pub trait TensorVectorSpace: TensorIndex {
     /// ```
     fn norm(&self) -> std::result::Result<f64, Self::Error> {
         Ok(self.norm_squared()?.sqrt())
+    }
+
+    /// Frobenius norm in a caller-owned execution context.
+    ///
+    /// Context-scoped counterpart of [`Self::norm`]: reductions run in the
+    /// tensor's owning runtime and only the scalar result crosses the
+    /// explicit readback boundary on CUDA. CPU contexts delegate to
+    /// [`Self::norm`] unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Self::Error` when scoped norm evaluation is unsupported for
+    /// this tensor type, when the tensor does not belong to `context`, or
+    /// when the reductions or explicit readback fail.
+    fn norm_in(
+        &self,
+        _context: &tensor4all_tensorbackend::ExecutionContext,
+    ) -> std::result::Result<f64, Self::Error> {
+        Err(anyhow::anyhow!("context-scoped norm is not supported for this tensor type").into())
     }
 
     /// Compute the maximum absolute value of all tensor elements.

--- a/crates/tensor4all-core/src/tensor_like.rs
+++ b/crates/tensor4all-core/src/tensor_like.rs
@@ -944,6 +944,29 @@ pub trait TensorFactorizationLike: TensorIndex {
         options: &FactorizeOptions,
     ) -> std::result::Result<FactorizeResult<Self>, FactorizeError>;
 
+    /// Factorize this tensor in a caller-owned execution context.
+    ///
+    /// Context-scoped counterpart of [`Self::factorize`]: the input must
+    /// belong to `context`, and factors, truncation, and results stay in
+    /// `context` with only bounded decision payloads crossing the explicit
+    /// readback boundary on device-resident inputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `FactorizeError` when scoped factorization is unsupported for
+    /// this tensor type, when the tensor does not belong to `context`, or
+    /// when the factorization fails.
+    fn factorize_in(
+        &self,
+        _left_inds: &[<Self as TensorIndex>::Index],
+        _options: &FactorizeOptions,
+        _context: &tensor4all_tensorbackend::ExecutionContext,
+    ) -> std::result::Result<FactorizeResult<Self>, FactorizeError> {
+        Err(FactorizeError::UnsupportedStorage(
+            "context-scoped factorization is not supported for this tensor type",
+        ))
+    }
+
     /// Factorize this tensor using policy-aware automatic SVD/eigen selection.
     ///
     /// Implementations may use Hermitian Gram eigendecomposition when the
@@ -1010,6 +1033,29 @@ pub trait TensorFactorizationLike: TensorIndex {
         alg: FactorizeAlg,
         canonical: Canonical,
     ) -> std::result::Result<FactorizeResult<Self>, FactorizeError>;
+
+    /// Full-rank factorization in a caller-owned execution context.
+    ///
+    /// Context-scoped counterpart of [`Self::factorize_full_rank`] with the
+    /// same algorithm coverage as the scoped free functions: QR and SVD
+    /// execute in `context`; other algorithms return a typed error.
+    ///
+    /// # Errors
+    ///
+    /// Returns `FactorizeError` when scoped factorization is unsupported for
+    /// this tensor type, when the tensor does not belong to `context`, or
+    /// when the factorization fails.
+    fn factorize_full_rank_in(
+        &self,
+        _left_inds: &[<Self as TensorIndex>::Index],
+        _alg: FactorizeAlg,
+        _canonical: Canonical,
+        _context: &tensor4all_tensorbackend::ExecutionContext,
+    ) -> std::result::Result<FactorizeResult<Self>, FactorizeError> {
+        Err(FactorizeError::UnsupportedStorage(
+            "context-scoped full-rank factorization is not supported for this tensor type",
+        ))
+    }
 
     /// Factorize a probe prefix, optionally extending an existing QR prefix.
     ///
@@ -1305,6 +1351,63 @@ pub trait TensorConstructionLike: TensorContractionLike {
     /// overflow failure) or the underlying construction reports a failure.
     fn ones(indices: &[<Self as TensorIndex>::Index]) -> std::result::Result<Self, Self::Error>;
 
+    /// Create an all-ones tensor in a caller-owned execution context.
+    ///
+    /// Context-scoped counterpart of [`Self::ones`]: the result belongs to
+    /// `context`, with an explicit host-to-device transfer for CUDA contexts.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tensor4all_core::{DynIndex, ExecutionContext, TensorConstructionLike};
+    /// use tensor4all_core::IdxTensor;
+    /// use tensor4all_tensorbackend::CpuExecutionContext;
+    /// use tenferro_cpu::CpuBackend;
+    ///
+    /// let context = ExecutionContext::Cpu(Arc::new(
+    ///     CpuExecutionContext::from_backend(CpuBackend::new()),
+    /// ));
+    /// let tensor = <IdxTensor as TensorConstructionLike>::ones_in(
+    ///     &context,
+    ///     &[DynIndex::new_dyn(2)],
+    /// )?;
+    /// assert_eq!(tensor.to_vec::<f64>()?, vec![1.0, 1.0]);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns `Self::Error` when construction is unsupported for this tensor
+    /// type, when the tensor would not belong to `context`, or when the
+    /// explicit transfer fails.
+    fn ones_in(
+        _context: &tensor4all_tensorbackend::ExecutionContext,
+        _indices: &[<Self as TensorIndex>::Index],
+    ) -> std::result::Result<Self, Self::Error> {
+        Err(anyhow::anyhow!(
+            "context-scoped ones construction is not supported for this tensor type"
+        )
+        .into())
+    }
+
+    /// Validate that this tensor belongs to the supplied execution context.
+    ///
+    /// Generic SRC entries call this on every input tensor before RNG
+    /// advancement or contraction, so mixed host/CUDA inputs and foreign CUDA
+    /// contexts fail at the boundary with typed errors.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Self::Error` when validation is unsupported for this tensor
+    /// type or when the tensor does not belong to `context`.
+    fn validate_context(
+        &self,
+        _context: &tensor4all_tensorbackend::ExecutionContext,
+    ) -> std::result::Result<(), Self::Error> {
+        Err(anyhow::anyhow!("context validation is not supported for this tensor type").into())
+    }
+
     /// Construct a tensor from a column-major dense payload.
     ///
     /// Implementations with a native dense storage path should override this
@@ -1420,6 +1523,53 @@ pub trait TensorConstructionLike: TensorContractionLike {
         T: TensorElement + Into<AnyScalar>,
     {
         Self::from_dense_any(indices, data.into_iter().map(Into::into).collect())
+    }
+
+    /// Construct a tensor from a column-major dense payload in a caller-owned
+    /// execution context.
+    ///
+    /// Context-scoped counterpart of [`Self::from_dense`]: host-originated
+    /// data takes one explicit construction transfer for CUDA contexts, and
+    /// the result belongs to `context`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tensor4all_core::{DynIndex, ExecutionContext, TensorConstructionLike};
+    /// use tensor4all_core::IdxTensor;
+    /// use tensor4all_tensorbackend::CpuExecutionContext;
+    /// use tenferro_cpu::CpuBackend;
+    ///
+    /// let context = ExecutionContext::Cpu(Arc::new(
+    ///     CpuExecutionContext::from_backend(CpuBackend::new()),
+    /// ));
+    /// let tensor = <IdxTensor as TensorConstructionLike>::from_dense_in(
+    ///     &context,
+    ///     vec![DynIndex::new_dyn(2)],
+    ///     vec![2.0_f64, 3.0],
+    /// )?;
+    /// assert_eq!(tensor.to_vec::<f64>()?, vec![2.0, 3.0]);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns `Self::Error` when construction is unsupported for this tensor
+    /// type, when the payload is invalid, or when the explicit transfer fails.
+    fn from_dense_in<T>(
+        _context: &tensor4all_tensorbackend::ExecutionContext,
+        _indices: Vec<<Self as TensorIndex>::Index>,
+        _data: Vec<T>,
+    ) -> std::result::Result<Self, Self::Error>
+    where
+        Self: TensorVectorSpace,
+        T: TensorElement + Into<AnyScalar>,
+    {
+        Err(anyhow::anyhow!(
+            "context-scoped dense construction is not supported for this tensor type"
+        )
+        .into())
     }
 
     /// Stack tensors along a newly created batch index.

--- a/crates/tensor4all-core/src/tensor_like.rs
+++ b/crates/tensor4all-core/src/tensor_like.rs
@@ -681,9 +681,9 @@ pub trait TensorVectorSpace: TensorIndex {
     ///
     /// # Errors
     ///
-    /// Returns `Self::Error` when scoped scaling is unsupported for this
-    /// tensor type, when the tensor does not belong to `context`, or when
-    /// the construction, upload, or multiplication fails.
+    /// Returns `Self::Error` with an `UnsupportedStorage` failure when scoped
+    /// scaling is unsupported for this tensor type; other failures report a
+    /// missing tensor context, an invalid payload, or a backend failure.
     fn scale_in(
         &self,
         _factor: f64,
@@ -734,9 +734,9 @@ pub trait TensorVectorSpace: TensorIndex {
     ///
     /// # Errors
     ///
-    /// Returns `Self::Error` when scoped norm evaluation is unsupported for
-    /// this tensor type, when the tensor does not belong to `context`, or
-    /// when the reductions or explicit readback fail.
+    /// Returns `Self::Error` with an `UnsupportedStorage` failure when scoped
+    /// norm evaluation is unsupported for this tensor type; other failures
+    /// report a missing tensor context or a backend failure.
     fn norm_in(
         &self,
         _context: &tensor4all_tensorbackend::ExecutionContext,
@@ -1417,9 +1417,9 @@ pub trait TensorConstructionLike: TensorContractionLike {
     ///
     /// # Errors
     ///
-    /// Returns `Self::Error` when construction is unsupported for this tensor
-    /// type, when the tensor would not belong to `context`, or when the
-    /// explicit transfer fails.
+    /// Returns `Self::Error` with an `UnsupportedStorage` failure when
+    /// construction is unsupported for this tensor type; other failures
+    /// report an invalid payload or a backend transfer failure.
     fn ones_in(
         _context: &tensor4all_tensorbackend::ExecutionContext,
         _indices: &[<Self as TensorIndex>::Index],
@@ -1438,8 +1438,9 @@ pub trait TensorConstructionLike: TensorContractionLike {
     ///
     /// # Errors
     ///
-    /// Returns `Self::Error` when validation is unsupported for this tensor
-    /// type or when the tensor does not belong to `context`.
+    /// Returns `Self::Error` with an `UnsupportedStorage` failure when
+    /// validation is unsupported for this tensor type, or a backend failure
+    /// when tensor placement does not belong to `context`.
     fn validate_context(
         &self,
         _context: &tensor4all_tensorbackend::ExecutionContext,
@@ -1594,8 +1595,9 @@ pub trait TensorConstructionLike: TensorContractionLike {
     ///
     /// # Errors
     ///
-    /// Returns `Self::Error` when construction is unsupported for this tensor
-    /// type, when the payload is invalid, or when the explicit transfer fails.
+    /// Returns `Self::Error` with an `UnsupportedStorage` failure when
+    /// construction is unsupported for this tensor type; other failures
+    /// report an invalid payload or a backend transfer failure.
     fn from_dense_in<T>(
         _context: &tensor4all_tensorbackend::ExecutionContext,
         _indices: Vec<<Self as TensorIndex>::Index>,

--- a/crates/tensor4all-core/src/tensor_like/tests/mod.rs
+++ b/crates/tensor4all-core/src/tensor_like/tests/mod.rs
@@ -874,6 +874,9 @@ fn tensor_like_default_context_seam_reports_unsupported() {
         indices: Vec::new(),
         data: vec![1.0],
     };
+    assert!(tensor.validate_context(&context).is_err());
+    assert!(DefaultOnlyTensor::ones_in(&context, &[]).is_err());
+    assert!(DefaultOnlyTensor::from_dense_in(&context, Vec::new(), Vec::<f64>::new()).is_err());
     let error = tensor.src_error_estimate_in(&context).unwrap_err();
     assert!(matches!(error, FactorizeError::UnsupportedStorage(_)));
     let error = DefaultOnlyTensor::factorize_probe_batch_incremental_in(

--- a/crates/tensor4all-core/src/tensor_like/tests/mod.rs
+++ b/crates/tensor4all-core/src/tensor_like/tests/mod.rs
@@ -877,6 +877,14 @@ fn tensor_like_default_context_seam_reports_unsupported() {
     assert!(tensor.validate_context(&context).is_err());
     assert!(DefaultOnlyTensor::ones_in(&context, &[]).is_err());
     assert!(DefaultOnlyTensor::from_dense_in(&context, Vec::new(), Vec::<f64>::new()).is_err());
+    assert!(tensor.scale_in(2.0, &context).is_err());
+    assert!(tensor.norm_in(&context).is_err());
+    assert!(tensor
+        .factorize_in(&[], &FactorizeOptions::qr(), &context)
+        .is_err());
+    assert!(tensor
+        .factorize_full_rank_in(&[], FactorizeAlg::QR, Canonical::Left, &context)
+        .is_err());
     let error = tensor.src_error_estimate_in(&context).unwrap_err();
     assert!(matches!(error, FactorizeError::UnsupportedStorage(_)));
     let error = DefaultOnlyTensor::factorize_probe_batch_incremental_in(

--- a/crates/tensor4all-core/tests/cuda_context_factorization.rs
+++ b/crates/tensor4all-core/tests/cuda_context_factorization.rs
@@ -344,3 +344,25 @@ fn probe_cuda_incremental_probe_batch_matches_host() {
     )
     .is_err());
 }
+
+#[test]
+fn cuda_scale_and_norm_in_match_cpu() {
+    use tensor4all_core::{DynIndex, ExecutionContext, IdxTensor};
+
+    let cuda = Arc::new(CudaExecutionContext::new().unwrap());
+    let context = ExecutionContext::Cuda(Arc::clone(&cuda));
+    let tensor = IdxTensor::from_dense_in(
+        &context,
+        vec![DynIndex::new_dyn(3)],
+        vec![1.0_f64, 2.0, 3.0],
+    )
+    .unwrap();
+
+    let norm = tensor.norm_in(&context).unwrap();
+    assert!((norm - 14.0_f64.sqrt()).abs() < 1e-12, "norm {norm}");
+
+    let scaled = tensor.scale_in(2.0, &context).unwrap();
+    scaled.validate_context(&context).unwrap();
+    let back = scaled.download(&cuda).unwrap();
+    assert_eq!(back.to_vec::<f64>().unwrap(), vec![2.0, 4.0, 6.0]);
+}

--- a/crates/tensor4all-tensorbackend/src/context.rs
+++ b/crates/tensor4all-tensorbackend/src/context.rs
@@ -21,6 +21,26 @@ pub enum ExecutionContext {
     Cuda(Arc<crate::cuda::CudaExecutionContext>),
 }
 
+impl ExecutionContext {
+    /// Check whether this is the process-global CPU context.
+    ///
+    /// Compatibility boundary: legacy CPU-global callers route through the
+    /// historical host code paths (bitwise-identical numerics) while explicit
+    /// contexts use the scoped primitives. Unavailable contexts report false.
+    #[cfg(feature = "global-defaults")]
+    pub fn is_global_default_cpu(&self) -> bool {
+        match self {
+            ExecutionContext::Cpu(context) => {
+                let own = context.eager_runtime().map(|runtime| runtime.id());
+                let global = defaults::default_eager_ctx().map(|runtime| runtime.id());
+                matches!((own, global), (Ok(a), Ok(b)) if a == b)
+            }
+            #[cfg(feature = "tenferro-cuda")]
+            ExecutionContext::Cuda(_) => false,
+        }
+    }
+}
+
 /// Error returned by explicit CPU context graph or eager-runtime operations.
 ///
 /// The original tenferro diagnostic is retained as the error source.
@@ -492,6 +512,25 @@ mod defaults {
             })
     }
 
+    /// Borrow the process-global CPU execution context.
+    ///
+    /// Compatibility entry for CPU-global convenience APIs (e.g. the legacy
+    /// context-free SRC entry): host tensors constructed through the global
+    /// default belong to this exact context, so they validate against it.
+    /// New code must take a caller-owned context instead of consulting this.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::{default_cpu_execution_context, ExecutionContext};
+    ///
+    /// let context = ExecutionContext::Cpu(default_cpu_execution_context());
+    /// assert!(matches!(context, ExecutionContext::Cpu(_)));
+    /// ```
+    pub fn default_cpu_execution_context() -> Arc<CpuExecutionContext> {
+        Arc::clone(default_context())
+    }
+
     #[cfg(test)]
     pub(crate) fn default_context_hits() -> usize {
         DEFAULT_CONTEXT_HITS.load(std::sync::atomic::Ordering::Relaxed)
@@ -509,7 +548,9 @@ mod defaults {
 #[cfg(all(test, feature = "global-defaults"))]
 pub(crate) use defaults::with_forced_eager_context_failure;
 #[cfg(feature = "global-defaults")]
-pub use defaults::{default_eager_ctx, with_default_backend, EagerContextError};
+pub use defaults::{
+    default_cpu_execution_context, default_eager_ctx, with_default_backend, EagerContextError,
+};
 #[cfg(feature = "global-defaults")]
 pub(crate) use defaults::{
     default_engine_buffer_pool_stats, reset_default_engine, reset_default_engine_buffer_pool,

--- a/crates/tensor4all-tensorbackend/src/context.rs
+++ b/crates/tensor4all-tensorbackend/src/context.rs
@@ -26,17 +26,25 @@ impl ExecutionContext {
     ///
     /// Compatibility boundary: legacy CPU-global callers route through the
     /// historical host code paths (bitwise-identical numerics) while explicit
-    /// contexts use the scoped primitives. Unavailable contexts report false.
-    #[cfg(feature = "global-defaults")]
+    /// contexts use the scoped primitives. Without the global-defaults
+    /// feature there is no global context, so this always reports false.
     pub fn is_global_default_cpu(&self) -> bool {
-        match self {
-            ExecutionContext::Cpu(context) => {
-                let own = context.eager_runtime().map(|runtime| runtime.id());
-                let global = defaults::default_eager_ctx().map(|runtime| runtime.id());
-                matches!((own, global), (Ok(a), Ok(b)) if a == b)
+        #[cfg(feature = "global-defaults")]
+        {
+            match self {
+                ExecutionContext::Cpu(context) => {
+                    let own = context.eager_runtime().map(|runtime| runtime.id());
+                    let global = defaults::default_eager_ctx().map(|runtime| runtime.id());
+                    matches!((own, global), (Ok(a), Ok(b)) if a == b)
+                }
+                #[cfg(feature = "tenferro-cuda")]
+                ExecutionContext::Cuda(_) => false,
             }
-            #[cfg(feature = "tenferro-cuda")]
-            ExecutionContext::Cuda(_) => false,
+        }
+        #[cfg(not(feature = "global-defaults"))]
+        {
+            let _ = self;
+            false
         }
     }
 }

--- a/crates/tensor4all-tensorbackend/src/lib.rs
+++ b/crates/tensor4all-tensorbackend/src/lib.rs
@@ -54,7 +54,9 @@ pub use backend::{
     MatrixSolveScalar, MatrixTriangularSolveScalar, SrcErrorEstimate, SvdResult,
 };
 #[cfg(feature = "global-defaults")]
-pub use context::{default_cpu_execution_context, default_eager_ctx, with_default_backend, EagerContextError};
+pub use context::{
+    default_cpu_execution_context, default_eager_ctx, with_default_backend, EagerContextError,
+};
 #[cfg(feature = "explicit-context")]
 pub use context::{CpuExecutionContext, CpuExecutionContextError, ExecutionContext};
 #[cfg(feature = "tenferro-cuda")]

--- a/crates/tensor4all-tensorbackend/src/lib.rs
+++ b/crates/tensor4all-tensorbackend/src/lib.rs
@@ -54,7 +54,7 @@ pub use backend::{
     MatrixSolveScalar, MatrixTriangularSolveScalar, SrcErrorEstimate, SvdResult,
 };
 #[cfg(feature = "global-defaults")]
-pub use context::{default_eager_ctx, with_default_backend, EagerContextError};
+pub use context::{default_cpu_execution_context, default_eager_ctx, with_default_backend, EagerContextError};
 #[cfg(feature = "explicit-context")]
 pub use context::{CpuExecutionContext, CpuExecutionContextError, ExecutionContext};
 #[cfg(feature = "tenferro-cuda")]

--- a/crates/tensor4all-treetn/Cargo.toml
+++ b/crates/tensor4all-treetn/Cargo.toml
@@ -44,6 +44,7 @@ thiserror.workspace = true
 
 [dev-dependencies]
 tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend", default-features = false }
+tenferro-cpu.workspace = true
 criterion.workspace = true
 
 [[bench]]

--- a/crates/tensor4all-treetn/src/lib.rs
+++ b/crates/tensor4all-treetn/src/lib.rs
@@ -60,7 +60,7 @@ pub use gse::{
     GseResult, GseTdvpOptions, GseTdvpResult,
 };
 pub use treetn::contraction;
-pub use treetn::contraction::{contract_src_with_rng, SrcOptions};
+pub use treetn::contraction::{contract_src_with_rng, contract_src_with_rng_in, SrcOptions};
 
 // dyn_treetn exports removed - use TreeTN<IdxTensor, V> directly
 pub use link_index_network::LinkIndexNetwork;

--- a/crates/tensor4all-treetn/src/treetn/canonicalize.rs
+++ b/crates/tensor4all-treetn/src/treetn/canonicalize.rs
@@ -167,12 +167,42 @@ where
         form: CanonicalForm,
         context_name: &str,
     ) -> Result<()> {
+        self.canonicalize_impl_scoped(canonical_region, form, context_name, None)
+    }
+
+    /// Context-scoped canonicalization.
+    ///
+    /// Only the unitary (QR) form has a scoped path; LU/CI forms and scalar
+    /// edge normalization return typed errors instead of running.
+    pub(crate) fn canonicalize_impl_in(
+        &mut self,
+        canonical_region: impl IntoIterator<Item = V>,
+        form: CanonicalForm,
+        context_name: &str,
+        context: &tensor4all_tensorbackend::ExecutionContext,
+    ) -> Result<()> {
+        self.canonicalize_impl_scoped(canonical_region, form, context_name, Some(context))
+    }
+
+    fn canonicalize_impl_scoped(
+        &mut self,
+        canonical_region: impl IntoIterator<Item = V>,
+        form: CanonicalForm,
+        context_name: &str,
+        context: Option<&tensor4all_tensorbackend::ExecutionContext>,
+    ) -> Result<()> {
         // Determine algorithm from form
         let alg = match form {
             CanonicalForm::Unitary => FactorizeAlg::QR,
             CanonicalForm::LU => FactorizeAlg::LU,
             CanonicalForm::CI => FactorizeAlg::CI,
         };
+        if context.is_some() && alg != FactorizeAlg::QR {
+            return Err(anyhow::anyhow!(
+                "{}: unsupported canonical form (only unitary has a context-scoped path)",
+                context_name
+            ));
+        }
 
         // Prepare sweep context
         let sweep_ctx = self.prepare_sweep_to_center(canonical_region, context_name)?;
@@ -185,7 +215,17 @@ where
 
         // Process edges in order (leaves towards center)
         for (src, dst) in &sweep_ctx.edges {
-            self.sweep_edge_full_rank(*src, *dst, alg, Canonical::Left, context_name)?;
+            match context {
+                Some(execution) => self.sweep_edge_full_rank_in(
+                    *src,
+                    *dst,
+                    alg,
+                    Canonical::Left,
+                    context_name,
+                    execution,
+                )?,
+                None => self.sweep_edge_full_rank(*src, *dst, alg, Canonical::Left, context_name)?,
+            }
         }
 
         // Set the canonical form

--- a/crates/tensor4all-treetn/src/treetn/canonicalize.rs
+++ b/crates/tensor4all-treetn/src/treetn/canonicalize.rs
@@ -224,7 +224,9 @@ where
                     context_name,
                     execution,
                 )?,
-                None => self.sweep_edge_full_rank(*src, *dst, alg, Canonical::Left, context_name)?,
+                None => {
+                    self.sweep_edge_full_rank(*src, *dst, alg, Canonical::Left, context_name)?
+                }
             }
         }
 

--- a/crates/tensor4all-treetn/src/treetn/contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction.rs
@@ -8,6 +8,20 @@
 //! - Successive randomized compression (`contract` with `ContractionMethod::Src`)
 //! - Validation (`validate_ortho_consistency`)
 //!
+//! ## SRC execution contexts
+//!
+//! [`contract_src_with_rng_in`](contract_src_with_rng_in) runs the full SRC
+//! schedule (chain and rooted-tree paths, fixed and adaptive modes, optional
+//! final SVD) against one caller-owned [`ExecutionContext`](tensor4all_tensorbackend::ExecutionContext).
+//! Both input trees, every probe/cap tensor, all intermediates, and the
+//! result belong to that context; only bounded decision payloads (rank
+//! selection, adaptive stopping scalars) cross the explicit readback
+//! boundary. Mixed host/CUDA inputs and foreign CUDA contexts fail validation
+//! before RNG advancement or contraction. The legacy [`contract`](contract)
+//! and [`contract_src_with_rng`](contract_src_with_rng) entries keep the
+//! CPU-global compatibility boundary for host inputs and reject resident
+//! inputs with a typed error.
+//!
 //! The SRC implementation follows Algorithm 1, Sections 3.1-3.5, and
 //! Appendices C--D of C. Camaño, E. N. Epperly, and J. A. Tropp,
 //! "Successive randomized compression: A randomized algorithm for the

--- a/crates/tensor4all-treetn/src/treetn/contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction.rs
@@ -37,6 +37,7 @@ use tensor4all_core::{
     validate_svd_truncation_options, Canonical, FactorizeAlg, FactorizeOptions, IndexLike,
     SvdTruncationPolicy, TensorIndex, TensorLike,
 };
+use tensor4all_tensorbackend::{default_cpu_execution_context, ExecutionContext};
 
 use super::TreeTN;
 
@@ -2052,7 +2053,11 @@ where
         }
         ContractionMethod::Src => {
             let mut rng = ChaCha8Rng::seed_from_u64(options.src_options.seed);
-            contract_src_with_rng_impl(tn_a, tn_b, center, &options, &mut rng)
+            // Legacy CPU-global compatibility boundary: host tensors built
+            // through the global default validate against this exact context.
+            // CUDA-resident inputs fail validation with a typed error.
+            let context = ExecutionContext::Cpu(default_cpu_execution_context());
+            contract_src_with_rng_impl(tn_a, tn_b, center, &options, &mut rng, &context)
         }
     }
 }
@@ -2124,7 +2129,99 @@ where
         .src_options
         .validate(options.max_bond_dim)
         .context("contract_src_with_rng: invalid SRC options")?;
-    contract_src_with_rng_impl(tn_a, tn_b, center, &options, rng)
+    // Legacy CPU-global compatibility boundary (see `contract` Src arm).
+    let context = ExecutionContext::Cpu(default_cpu_execution_context());
+    contract_src_with_rng_impl(tn_a, tn_b, center, &options, rng, &context)
+}
+
+/// Contract two TreeTNs with SRC in a caller-owned execution context.
+///
+/// This is the context-scoped counterpart of [`contract_src_with_rng`]: both
+/// input trees, every probe/cap tensor, all intermediates, and the result
+/// belong to `context`, with only bounded decision payloads crossing the
+/// explicit readback boundary on CUDA. Mixed host/CUDA inputs and foreign
+/// CUDA contexts fail validation before RNG advancement or contraction.
+///
+/// # Arguments
+/// * `tn_a`, `tn_b` - Input trees, both belonging to `context`.
+/// * `center` - Canonical center of the result.
+/// * `options` - Contraction options selecting [`ContractionMethod::Src`].
+/// * `rng` - Caller-owned RNG consumed for Gaussian probe randomness.
+/// * `context` - Caller-owned execution context owning inputs and results.
+///
+/// # Examples
+///
+/// ```
+/// use std::sync::Arc;
+/// use rand::SeedableRng;
+/// use rand_chacha::ChaCha8Rng;
+/// use tensor4all_core::{DynIndex, ExecutionContext, TensorConstructionLike};
+/// use tensor4all_core::IdxTensor;
+/// use tensor4all_tensorbackend::CpuExecutionContext;
+/// use tensor4all_treetn::{
+///     contraction::{contract_src_with_rng_in, ContractionOptions, SrcOptions},
+///     TreeTN,
+/// };
+/// use tenferro_cpu::CpuBackend;
+///
+/// let context = ExecutionContext::Cpu(Arc::new(
+///     CpuExecutionContext::from_backend(CpuBackend::new()),
+/// ));
+/// let shared = DynIndex::new_dyn(2);
+/// let output_a = DynIndex::new_dyn(2);
+/// let output_b = DynIndex::new_dyn(2);
+/// let tensor_a = <IdxTensor as TensorConstructionLike>::from_dense_in(
+///     &context,
+///     vec![shared.clone(), output_a],
+///     vec![1.0, 0.0, 0.0, 1.0],
+/// )?;
+/// let tensor_b = <IdxTensor as TensorConstructionLike>::from_dense_in(
+///     &context,
+///     vec![shared, output_b],
+///     vec![2.0, 0.0, 0.0, 3.0],
+/// )?;
+/// let tn_a = TreeTN::from_tensors(vec![tensor_a], vec![0])?;
+/// let tn_b = TreeTN::from_tensors(vec![tensor_b], vec![0])?;
+/// let options = ContractionOptions::src()
+///     .with_max_bond_dim(1)
+///     .with_src_options(SrcOptions::fixed());
+/// let mut rng = ChaCha8Rng::seed_from_u64(7);
+/// let result = contract_src_with_rng_in(&tn_a, &tn_b, &0, options, &mut rng, &context)?;
+/// assert_eq!(result.node_count(), 1);
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+///
+/// # Errors
+/// Returns an error when `options` does not select [`ContractionMethod::Src`],
+/// an option is invalid, the networks are incompatible, either input fails
+/// context validation, or probe generation, contraction, or factorization
+/// fails.
+pub fn contract_src_with_rng_in<T, V, R>(
+    tn_a: &TreeTN<T, V>,
+    tn_b: &TreeTN<T, V>,
+    center: &V,
+    options: ContractionOptions,
+    rng: &mut R,
+    context: &ExecutionContext,
+) -> std::result::Result<TreeTN<T, V>, TreeTNOperationError>
+where
+    T: TensorLike,
+    <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    R: Rng + ?Sized,
+{
+    if options.method != ContractionMethod::Src {
+        return Err(TreeTNOperationError::from(anyhow::anyhow!(
+            "contract_src_with_rng_in requires ContractionMethod::Src"
+        )));
+    }
+    validate_svd_truncation_options(options.max_bond_dim, options.svd_policy)
+        .context("contract_src_with_rng_in: invalid contraction options")?;
+    options
+        .src_options
+        .validate(options.max_bond_dim)
+        .context("contract_src_with_rng_in: invalid SRC options")?;
+    contract_src_with_rng_impl(tn_a, tn_b, center, &options, rng, context)
 }
 
 fn contract_src_with_rng_impl<T, V, R>(
@@ -2133,6 +2230,7 @@ fn contract_src_with_rng_impl<T, V, R>(
     center: &V,
     options: &ContractionOptions,
     rng: R,
+    context: &ExecutionContext,
 ) -> std::result::Result<TreeTN<T, V>, TreeTNOperationError>
 where
     T: TensorLike,
@@ -2140,6 +2238,19 @@ where
     V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
     R: Rng,
 {
+    // Validate both complete input trees against the caller-owned context
+    // before RNG advancement or contraction: mixed host/CUDA inputs and
+    // foreign CUDA contexts fail here with the offending node identified.
+    tn_a.validate_context(context).map_err(|error| {
+        TreeTNOperationError::from(anyhow::anyhow!(
+            "contract_src: input A validation failed: {error}"
+        ))
+    })?;
+    tn_b.validate_context(context).map_err(|error| {
+        TreeTNOperationError::from(anyhow::anyhow!(
+            "contract_src: input B validation failed: {error}"
+        ))
+    })?;
     let output_rank = options
         .max_bond_dim
         .or(options.src_options.max_rank)
@@ -2152,6 +2263,7 @@ where
         output_rank,
         &options.src_options,
         rng,
+        context,
     )
     .map_err(TreeTNOperationError::from)
 }

--- a/crates/tensor4all-treetn/src/treetn/contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction.rs
@@ -2206,10 +2206,10 @@ where
 /// ```
 ///
 /// # Errors
-/// Returns an error when `options` does not select [`ContractionMethod::Src`],
-/// an option is invalid, the networks are incompatible, either input fails
-/// context validation, or probe generation, contraction, or factorization
-/// fails.
+/// Returns [`TreeTNOperationError`] when `options` does not select [`ContractionMethod::Src`],
+/// an option is invalid, the networks have incompatible topologies, either input
+/// fails context validation (missing tensor or foreign placement), or probe
+/// generation, contraction, or factorization fails.
 pub fn contract_src_with_rng_in<T, V, R>(
     tn_a: &TreeTN<T, V>,
     tn_b: &TreeTN<T, V>,

--- a/crates/tensor4all-treetn/src/treetn/contraction/src_chain.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction/src_chain.rs
@@ -17,6 +17,7 @@ use std::hash::Hash;
 use tensor4all_core::{
     Canonical as FactorizeCanonical, FactorizeAlg, IndexLike, SvdTruncationPolicy, TensorLike,
 };
+use tensor4all_tensorbackend::ExecutionContext;
 
 use super::src_probe::{
     connect_result_edge, contract_prefix_with_probed_site_pair_batch_range, contract_retaining,
@@ -27,6 +28,7 @@ use super::src_probe::{
 use super::{SrcOptions, TreeTN};
 use crate::algorithm::CanonicalForm;
 
+#[allow(clippy::too_many_arguments)]
 /// Execute the paper's successive randomized compression schedule on a chain.
 pub(super) fn contract<T, V, R>(
     tn_a: &TreeTN<T, V>,
@@ -36,6 +38,7 @@ pub(super) fn contract<T, V, R>(
     max_bond_dim: usize,
     src_options: &SrcOptions,
     rng: R,
+    context: &ExecutionContext,
 ) -> Result<TreeTN<T, V>>
 where
     T: TensorLike,
@@ -61,10 +64,11 @@ where
         let mut result = TreeTN::new();
         let tensor = contract_site_pair(local[0].0, local[0].1, &[])?;
         result.add_tensor(chain[0].clone(), tensor)?;
-        result.canonicalize_impl(
+        result.canonicalize_impl_in(
             [center.clone()],
             CanonicalForm::Unitary,
             "contract_src: single-site canonicalization",
+            context,
         )?;
         return Ok(result);
     }
@@ -103,11 +107,17 @@ where
             cut_dimensions: &cut_dimensions,
             probes: &mut probes,
             final_svd: src_options.final_svd,
+            context,
         });
     }
     let sketch_options = src_options.sketch_options(svd_policy.is_some());
-    let mut prefixes =
-        PrefixCache::new(&local, &outputs, &mut probes, sketch_options.rank_increment);
+    let mut prefixes = PrefixCache::new(
+        &local,
+        &outputs,
+        &mut probes,
+        sketch_options.rank_increment,
+        context,
+    );
 
     let last = chain.len() - 1;
     let mut factors: Vec<Option<T>> = (0..chain.len()).map(|_| None).collect();
@@ -120,7 +130,7 @@ where
     };
     let (last_factor, last_cap, mut cap_environment) = if outputs[last].is_empty() {
         let cap = T::Index::new_link(1)?;
-        let factor = T::ones(std::slice::from_ref(&cap)).map_err(|error| {
+        let factor = T::ones_in(context, std::slice::from_ref(&cap)).map_err(|error| {
             anyhow::anyhow!("contract_src: scalar last-site cap construction failed: {error}")
         })?;
         let local_product = contract_site_pair(local[last].0, local[last].1, &[])?;
@@ -141,6 +151,7 @@ where
                 maximum_width: last_maximum_width,
                 src_options: &sketch_options,
                 label: "last-site",
+                context,
             },
             |start, width| {
                 let (prefix, batch_index) = prefixes.request(last - 1, start, width)?;
@@ -194,6 +205,7 @@ where
                 maximum_width: site_max_width,
                 src_options: &sketch_options,
                 label: &label,
+                context,
             },
             |start, width| {
                 let (stacked, batch_index) = prefixes.request(site - 1, start, width)?;
@@ -266,6 +278,7 @@ where
     cut_dimensions: &'a [usize],
     probes: &'a mut ProbeBank<T::Index, R>,
     final_svd: bool,
+    context: &'a ExecutionContext,
 }
 
 fn contract_fixed<T, V, R>(request: FixedContractionRequest<'_, T, V, R>) -> Result<TreeTN<T, V>>
@@ -286,6 +299,7 @@ where
         cut_dimensions,
         probes,
         final_svd,
+        context,
     } = request;
     let last = chain.len() - 1;
     let fixed_options = SrcOptions::fixed().with_final_svd(final_svd);
@@ -300,13 +314,13 @@ where
     if last_maximum_width == 0 {
         anyhow::bail!("contract_src: last-site output space has zero dimension");
     }
-    let mut prefixes = BatchedPrefixCache::new(local, outputs, probes);
+    let mut prefixes = BatchedPrefixCache::new(local, outputs, probes, context);
     let mut factors: Vec<Option<T>> = (0..chain.len()).map(|_| None).collect();
     let mut caps: Vec<Option<T::Index>> = (0..chain.len()).map(|_| None).collect();
 
     let (last_factor, last_cap, mut cap_environment) = if outputs[last].is_empty() {
         let cap = T::Index::new_link(1)?;
-        let factor = T::ones(std::slice::from_ref(&cap)).map_err(|error| {
+        let factor = T::ones_in(context, std::slice::from_ref(&cap)).map_err(|error| {
             anyhow::anyhow!("contract_src: scalar last-site cap construction failed: {error}")
         })?;
         let local_product = contract_site_pair(local[last].0, local[last].1, &[])?;
@@ -327,9 +341,10 @@ where
             0,
             last_maximum_width,
             &batch,
+            context,
         )
         .map_err(|error| anyhow::anyhow!("contract_src: last-site sketch failed: {error}"))?;
-        let (factor, cap) = factorize_fixed_batch(&sketch, &outputs[last], "last-site")?;
+        let (factor, cap) = factorize_fixed_batch(&sketch, &outputs[last], "last-site", context)?;
         let factor_conj = factor.conj();
         let environment = contract_site_pair(local[last].0, local[last].1, &[&factor_conj])
             .map_err(|error| {
@@ -368,13 +383,15 @@ where
             0,
             site_max_width,
             &batch,
+            context,
         )
         .map_err(|error| {
             anyhow::anyhow!("contract_src: site {site} prefix contraction failed: {error}")
         })?;
         let sketch = T::contract(&[&prefix_local, &right_environment])
             .map_err(|error| anyhow::anyhow!("contract_src: site {site} sketch failed: {error}"))?;
-        let (factor, cap) = factorize_fixed_batch(&sketch, &left_indices, &format!("site {site}"))?;
+        let (factor, cap) =
+            factorize_fixed_batch(&sketch, &left_indices, &format!("site {site}"), context)?;
         let factor_conj = factor.conj();
         let next_environment = contract_site_pair(
             local[site].0,
@@ -404,11 +421,12 @@ where
         connect_result_edge(&mut result, &chain[site - 1], &chain[site])?;
     }
     if final_svd {
-        result.truncate_impl(
+        result.truncate_impl_in(
             [center.clone()],
             svd_policy,
             Some(max_bond_dim),
             "contract_src: final truncate",
+            context,
         )?;
     } else {
         let rooted_edges = chain
@@ -460,13 +478,19 @@ fn factorize_fixed_batch<T>(
     sketch: &T,
     left_indices: &[T::Index],
     label: &str,
+    context: &ExecutionContext,
 ) -> Result<(T, T::Index)>
 where
     T: TensorLike,
     T::Index: IndexLike + Clone + Hash + Eq,
 {
     let factorized = sketch
-        .factorize_full_rank(left_indices, FactorizeAlg::QR, FactorizeCanonical::Left)
+        .factorize_full_rank_in(
+            left_indices,
+            FactorizeAlg::QR,
+            FactorizeCanonical::Left,
+            context,
+        )
         .map_err(|error| {
             anyhow::anyhow!(
                 "contract_src: {label} QR failed: {error}; sketch indices={:?}, left indices={:?}",
@@ -484,6 +508,7 @@ where
     local: &'a [(&'a T, &'a T)],
     outputs: &'a [Vec<T::Index>],
     probes: &'a mut ProbeBank<T::Index, R>,
+    context: &'a ExecutionContext,
     batch_size: usize,
     // Per-site list of (batch tensor, batch index, width) segments, storing
     // whatever chunk each `grow_segment` call actually produced. The first
@@ -518,6 +543,7 @@ where
     combined: Vec<T>,
     combined_batch: Option<T::Index>,
     generated_width: usize,
+    context: &'a ExecutionContext,
 }
 
 impl<'a, T, R> BatchedPrefixCache<'a, T, R>
@@ -530,11 +556,13 @@ where
         local: &'a [(&'a T, &'a T)],
         outputs: &'a [Vec<T::Index>],
         probes: &'a mut ProbeBank<T::Index, R>,
+        context: &'a ExecutionContext,
     ) -> Self {
         Self {
             local,
             outputs,
             probes,
+            context,
             combined: Vec::new(),
             combined_batch: None,
             generated_width: 0,
@@ -564,6 +592,7 @@ where
                 start,
                 segment_width,
                 &segment_batch,
+                self.context,
             )?;
             let mut segment_prefixes = vec![prefix.clone()];
             for prefix_site in 1..self.local.len() - 1 {
@@ -576,6 +605,7 @@ where
                     start,
                     segment_width,
                     &segment_batch,
+                    self.context,
                 )?;
                 segment_prefixes.push(prefix.clone());
             }
@@ -629,11 +659,13 @@ where
         outputs: &'a [Vec<T::Index>],
         probes: &'a mut ProbeBank<T::Index, R>,
         batch_size: usize,
+        context: &'a ExecutionContext,
     ) -> Self {
         Self {
             local,
             outputs,
             probes,
+            context,
             batch_size: batch_size.max(1),
             segments: (0..local.len() - 1).map(|_| Vec::new()).collect(),
             segment_total_width: 0,
@@ -652,6 +684,7 @@ where
             start,
             width,
             &batch,
+            self.context,
         )?;
         self.segments[0].push((prefix, batch, width));
         self.segment_total_width += width;
@@ -680,6 +713,7 @@ where
                     covered,
                     width,
                     &batch,
+                    self.context,
                 )?;
                 debug_assert_eq!(self.segments[next_site].len(), segment);
                 self.segments[next_site].push((extended, batch, width));
@@ -786,6 +820,7 @@ where
     maximum_width: usize,
     src_options: &'a SrcOptions,
     label: &'a str,
+    context: &'a ExecutionContext,
 }
 
 fn factorize_site_adaptive<T, F>(
@@ -806,6 +841,7 @@ where
         maximum_width,
         src_options,
         label,
+        context,
     } = request;
     let mut left = outputs.to_vec();
     if let Some(right_cap) = right_cap {
@@ -818,6 +854,7 @@ where
         src_options,
         label,
         make_batch,
+        context,
     )?;
     let factor_conj = factor.conj();
     let environment = if let Some(right_environment) = right_environment {
@@ -849,6 +886,9 @@ mod tests {
 
     #[test]
     fn request_grows_a_fresh_segment_and_reuses_a_previously_cached_one() {
+        let context = tensor4all_tensorbackend::ExecutionContext::Cpu(
+            tensor4all_tensorbackend::default_cpu_execution_context(),
+        );
         let (a0, b0, a1, b1) = two_site_local(3);
         let local = vec![(&a0, &b0), (&a1, &b1)];
         let outputs = vec![vec![a0.indices()[0].clone()], vec![a1.indices()[0].clone()]];
@@ -858,7 +898,7 @@ mod tests {
             42,
         )
         .unwrap();
-        let mut cache = PrefixCache::new(&local, &outputs, &mut probes, 3);
+        let mut cache = PrefixCache::new(&local, &outputs, &mut probes, 3, &context);
 
         let (first, first_batch) = cache.request(0, 0, 3).unwrap();
         assert_eq!(first_batch.dim(), 3);
@@ -884,6 +924,9 @@ mod tests {
 
     #[test]
     fn request_overgenerates_a_full_post_initial_segment_for_reuse() {
+        let context = tensor4all_tensorbackend::ExecutionContext::Cpu(
+            tensor4all_tensorbackend::default_cpu_execution_context(),
+        );
         let (a0, b0, a1, b1) = two_site_local(3);
         let local = vec![(&a0, &b0), (&a1, &b1)];
         let outputs = vec![vec![a0.indices()[0].clone()], vec![a1.indices()[0].clone()]];
@@ -895,7 +938,7 @@ mod tests {
         .unwrap();
         // batch_size 3, first caller only needs width 4. The cache computes
         // a full second increment so a later width-3 request can reuse it.
-        let mut cache = PrefixCache::new(&local, &outputs, &mut probes, 3);
+        let mut cache = PrefixCache::new(&local, &outputs, &mut probes, 3, &context);
         let (_first, _) = cache.request(0, 0, 4).unwrap();
         assert_eq!(cache.segments[0].len(), 2, "expected two width-3 segments");
         assert_eq!(
@@ -915,6 +958,9 @@ mod tests {
 
     #[test]
     fn request_extends_only_needed_segments_to_requested_site() {
+        let context = tensor4all_tensorbackend::ExecutionContext::Cpu(
+            tensor4all_tensorbackend::default_cpu_execution_context(),
+        );
         let outputs = (0..3).map(|_| DynIndex::new_dyn(3)).collect::<Vec<_>>();
         let inner = (0..3).map(|_| DynIndex::new_dyn(3)).collect::<Vec<_>>();
         let tensors = (0..3)
@@ -936,7 +982,7 @@ mod tests {
             .map(|output| vec![output])
             .collect::<Vec<_>>();
         let mut probes = ProbeBank::from_seed(outputs.clone(), 1, 42).unwrap();
-        let mut cache = PrefixCache::new(&local, &site_outputs, &mut probes, 2);
+        let mut cache = PrefixCache::new(&local, &site_outputs, &mut probes, 2, &context);
 
         cache.request(0, 0, 2).unwrap();
         cache.request(0, 2, 2).unwrap();
@@ -954,7 +1000,7 @@ mod tests {
         );
 
         let mut direct_probes = ProbeBank::from_seed(outputs, 1, 42).unwrap();
-        let mut direct = PrefixCache::new(&local, &site_outputs, &mut direct_probes, 2);
+        let mut direct = PrefixCache::new(&local, &site_outputs, &mut direct_probes, 2, &context);
         let (expected, _) = direct.request(1, 0, 2).unwrap();
         assert_eq!(
             lazy.to_vec::<f64>().unwrap(),
@@ -983,6 +1029,9 @@ mod tests {
 
     #[test]
     fn request_misaligned_range_spanning_a_segment_boundary_matches_a_direct_reference() {
+        let context = tensor4all_tensorbackend::ExecutionContext::Cpu(
+            tensor4all_tensorbackend::default_cpu_execution_context(),
+        );
         let (a0, b0, a1, b1) = two_site_local(3);
         let local = vec![(&a0, &b0), (&a1, &b1)];
         let outputs = vec![vec![a0.indices()[0].clone()], vec![a1.indices()[0].clone()]];
@@ -998,7 +1047,7 @@ mod tests {
         // fallback (unlike the ragged-reuse test above, whose second
         // request re-reads an existing segment exactly and so never
         // exercises this branch).
-        let mut cache = PrefixCache::new(&local, &outputs, &mut probes, 2);
+        let mut cache = PrefixCache::new(&local, &outputs, &mut probes, 2, &context);
         let (_first, _) = cache.request(0, 0, 2).unwrap();
         assert_eq!(
             cache.segments[0].len(),
@@ -1022,6 +1071,9 @@ mod tests {
         let mut reference_probes = ProbeBank::from_seed(index_list, 1, 42).unwrap();
         reference_probes.extend_to(3).unwrap();
         let reference_batch = DynIndex::new_link(2).unwrap();
+        let context = tensor4all_tensorbackend::ExecutionContext::Cpu(
+            tensor4all_tensorbackend::default_cpu_execution_context(),
+        );
         let reference = crate::treetn::contraction::src_probe::probed_site_pair_batch_range(
             &a0,
             &b0,
@@ -1030,6 +1082,7 @@ mod tests {
             1,
             2,
             &reference_batch,
+            &context,
         )
         .unwrap();
 

--- a/crates/tensor4all-treetn/src/treetn/contraction/src_chain.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction/src_chain.rs
@@ -249,11 +249,12 @@ where
     }
 
     if src_options.final_svd {
-        result.truncate_impl(
+        result.truncate_impl_in(
             [center.clone()],
             svd_policy,
             Some(max_bond_dim),
             "contract_src: final truncate",
+            context,
         )?;
     } else {
         let rooted_edges = chain

--- a/crates/tensor4all-treetn/src/treetn/contraction/src_probe.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction/src_probe.rs
@@ -21,6 +21,7 @@ use rand_chacha::ChaCha8Rng;
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use tensor4all_core::{IndexLike, TensorLike};
+use tensor4all_tensorbackend::ExecutionContext;
 
 use super::{SrcOptions, TreeTN};
 use crate::algorithm::CanonicalForm;
@@ -166,6 +167,22 @@ where
         .map_err(|error| anyhow::anyhow!("contract_src: probe construction failed: {error}"))
 }
 
+/// Context-scoped single probe column: the result belongs to `context`.
+fn single_probe_in<T, R>(
+    index: &T::Index,
+    probes: &ProbeBank<T::Index, R>,
+    column: usize,
+    context: &ExecutionContext,
+) -> Result<T>
+where
+    T: TensorLike,
+    T::Index: IndexLike + Clone + Hash + Eq,
+{
+    let data = probes.column(index, column)?.to_vec();
+    T::from_dense_in(context, vec![index.clone()], data)
+        .map_err(|error| anyhow::anyhow!("contract_src: probe construction failed: {error}"))
+}
+
 fn single_probe_batch<T, R>(
     index: &T::Index,
     probes: &ProbeBank<T::Index, R>,
@@ -189,6 +206,34 @@ where
         data.extend_from_slice(probes.column(index, column)?);
     }
     T::from_dense(vec![index.clone(), batch.clone()], data)
+        .map_err(|error| anyhow::anyhow!("contract_src: probe batch construction failed: {error}"))
+}
+
+/// Context-scoped probe batch: the result belongs to `context`.
+fn single_probe_batch_in<T, R>(
+    index: &T::Index,
+    probes: &ProbeBank<T::Index, R>,
+    first_column: usize,
+    width: usize,
+    batch: &T::Index,
+    context: &ExecutionContext,
+) -> Result<T>
+where
+    T: TensorLike,
+    T::Index: IndexLike + Clone + Hash + Eq,
+{
+    let capacity = index
+        .dim()
+        .checked_mul(width)
+        .ok_or_else(|| anyhow::anyhow!("contract_src: probe batch size overflow"))?;
+    let end_column = first_column
+        .checked_add(width)
+        .ok_or_else(|| anyhow::anyhow!("contract_src: probe batch column range overflow"))?;
+    let mut data = Vec::with_capacity(capacity);
+    for column in first_column..end_column {
+        data.extend_from_slice(probes.column(index, column)?);
+    }
+    T::from_dense_in(context, vec![index.clone(), batch.clone()], data)
         .map_err(|error| anyhow::anyhow!("contract_src: probe batch construction failed: {error}"))
 }
 
@@ -222,6 +267,32 @@ where
         .collect()
 }
 
+/// Context-scoped probe batch tensors: every result belongs to `context`.
+pub(super) fn probe_batch_tensors_in<T, R>(
+    outputs: &[T::Index],
+    probes: &ProbeBank<T::Index, R>,
+    first_column: usize,
+    width: usize,
+    batch: &T::Index,
+    context: &ExecutionContext,
+) -> Result<Vec<T>>
+where
+    T: TensorLike,
+    T::Index: IndexLike + Clone + Hash + Eq,
+{
+    if width == 0 || batch.dim() != width {
+        anyhow::bail!(
+            "contract_src: probe batch dimension {} does not match width {}",
+            batch.dim(),
+            width
+        );
+    }
+    outputs
+        .iter()
+        .map(|index| single_probe_batch_in::<T, R>(index, probes, first_column, width, batch, context))
+        .collect()
+}
+
 /// Return the checked product of a list of index dimensions.
 pub(super) fn product_dim<I: IndexLike>(indices: &[I]) -> Result<usize> {
     indices.iter().try_fold(1usize, |size, index| {
@@ -249,6 +320,31 @@ where
     let probe_tensors = outputs
         .iter()
         .map(|index| single_probe::<T, R>(index, probes, column))
+        .collect::<Result<Vec<_>>>()?;
+    let (a_probes, b_probes) = partition_probes(tensor_a, tensor_b, outputs, &probe_tensors)?;
+    let probed_a = contract_operand_with_probes(tensor_a, &a_probes, None)?;
+    let probed_b = contract_operand_with_probes(tensor_b, &b_probes, None)?;
+    T::contract(&[&probed_a, &probed_b]).map_err(|error| {
+        anyhow::anyhow!("contract_src: factorized probe contraction failed: {error}")
+    })
+}
+
+/// Context-scoped factorized probed site pair.
+fn probed_site_pair_in<T, R>(
+    tensor_a: &T,
+    tensor_b: &T,
+    outputs: &[T::Index],
+    probes: &ProbeBank<T::Index, R>,
+    column: usize,
+    context: &ExecutionContext,
+) -> Result<T>
+where
+    T: TensorLike,
+    T::Index: IndexLike + Clone + Hash + Eq,
+{
+    let probe_tensors = outputs
+        .iter()
+        .map(|index| single_probe_in::<T, R>(index, probes, column, context))
         .collect::<Result<Vec<_>>>()?;
     let (a_probes, b_probes) = partition_probes(tensor_a, tensor_b, outputs, &probe_tensors)?;
     let probed_a = contract_operand_with_probes(tensor_a, &a_probes, None)?;
@@ -291,6 +387,47 @@ where
         });
     }
     let probe_tensors = probe_batch_tensors(outputs, probes, first_column, width, batch)?;
+    let (a_probes, b_probes) = partition_probes(tensor_a, tensor_b, outputs, &probe_tensors)?;
+    let probed_a = contract_operand_with_probes(tensor_a, &a_probes, Some(batch))?;
+    let probed_b = contract_operand_with_probes(tensor_b, &b_probes, Some(batch))?;
+    contract_retaining(&[&probed_a, &probed_b], batch)
+}
+
+/// Context-scoped batched probed site pair.
+fn probed_site_pair_batch_range_in<T, R>(
+    tensor_a: &T,
+    tensor_b: &T,
+    outputs: &[T::Index],
+    probes: &ProbeBank<T::Index, R>,
+    first_column: usize,
+    width: usize,
+    batch: &T::Index,
+    context: &ExecutionContext,
+) -> Result<T>
+where
+    T: TensorLike,
+    T::Index: IndexLike + Clone + Hash + Eq,
+{
+    if width == 0 || batch.dim() != width {
+        anyhow::bail!(
+            "contract_src: probe batch dimension {} does not match width {}",
+            batch.dim(),
+            width
+        );
+    }
+    if outputs.is_empty() {
+        let local = T::contract(&[tensor_a, tensor_b]).map_err(|error| {
+            anyhow::anyhow!("contract_src: scalar local pair contraction failed: {error}")
+        })?;
+        let batch_values = T::ones_in(context, std::slice::from_ref(batch)).map_err(|error| {
+            anyhow::anyhow!("contract_src: scalar probe batch construction failed: {error}")
+        })?;
+        return local.outer_product(&batch_values).map_err(|error| {
+            anyhow::anyhow!("contract_src: scalar probe batch broadcast failed: {error}")
+        });
+    }
+    let probe_tensors =
+        probe_batch_tensors_in(outputs, probes, first_column, width, batch, context)?;
     let (a_probes, b_probes) = partition_probes(tensor_a, tensor_b, outputs, &probe_tensors)?;
     let probed_a = contract_operand_with_probes(tensor_a, &a_probes, Some(batch))?;
     let probed_b = contract_operand_with_probes(tensor_b, &b_probes, Some(batch))?;
@@ -344,6 +481,33 @@ where
     contract_operand_with_probes(&result, &b_probes, None)
 }
 
+/// Context-scoped unbatched probed prefix contraction.
+fn contract_prefix_with_probed_site_pair_in<T, R>(
+    prefix: &T,
+    tensor_a: &T,
+    tensor_b: &T,
+    outputs: &[T::Index],
+    probes: &ProbeBank<T::Index, R>,
+    column: usize,
+    context: &ExecutionContext,
+) -> Result<T>
+where
+    T: TensorLike,
+    T::Index: IndexLike + Clone + Hash + Eq,
+{
+    let probe_tensors = outputs
+        .iter()
+        .map(|index| single_probe_in::<T, R>(index, probes, column, context))
+        .collect::<Result<Vec<_>>>()?;
+    let (a_probes, b_probes) = partition_probes(tensor_a, tensor_b, outputs, &probe_tensors)?;
+    let mut result = T::contract(&[prefix, tensor_a])
+        .map_err(|error| anyhow::anyhow!("contract_src: prefix-A contraction failed: {error}"))?;
+    result = contract_operand_with_probes(&result, &a_probes, None)?;
+    result = T::contract(&[&result, tensor_b])
+        .map_err(|error| anyhow::anyhow!("contract_src: prefix-B contraction failed: {error}"))?;
+    contract_operand_with_probes(&result, &b_probes, None)
+}
+
 /// Contract a factorized local pair with an incoming batched prefix.
 // INVARIANT: `prefix`, the two local operands, the probe bank, and the batch
 // range are all one contraction step; keeping them explicit prevents the
@@ -371,6 +535,49 @@ where
         );
     }
     let probe_tensors = probe_batch_tensors(outputs, probes, first_column, width, batch)?;
+    let (a_probes, b_probes) = partition_probes(tensor_a, tensor_b, outputs, &probe_tensors)?;
+
+    let mut a_factors = Vec::with_capacity(a_probes.len() + 2);
+    a_factors.push(tensor_a);
+    a_factors.push(prefix);
+    a_factors.extend(a_probes.iter().copied());
+    let result = contract_retaining(&a_factors, batch)
+        .map_err(|error| anyhow::anyhow!("contract_src: prefix-A contraction failed: {error}"))?;
+
+    let mut b_factors = Vec::with_capacity(b_probes.len() + 2);
+    b_factors.push(tensor_b);
+    b_factors.push(&result);
+    b_factors.extend(b_probes.iter().copied());
+    contract_retaining(&b_factors, batch)
+        .map_err(|error| anyhow::anyhow!("contract_src: prefix-B contraction failed: {error}"))
+}
+
+/// Context-scoped batched probed prefix contraction.
+#[allow(clippy::too_many_arguments)]
+fn contract_prefix_with_probed_site_pair_batch_range_in<T, R>(
+    prefix: &T,
+    tensor_a: &T,
+    tensor_b: &T,
+    outputs: &[T::Index],
+    probes: &ProbeBank<T::Index, R>,
+    first_column: usize,
+    width: usize,
+    batch: &T::Index,
+    context: &ExecutionContext,
+) -> Result<T>
+where
+    T: TensorLike,
+    T::Index: IndexLike + Clone + Hash + Eq,
+{
+    if width == 0 || batch.dim() != width {
+        anyhow::bail!(
+            "contract_src: probe batch dimension {} does not match width {}",
+            batch.dim(),
+            width
+        );
+    }
+    let probe_tensors =
+        probe_batch_tensors_in(outputs, probes, first_column, width, batch, context)?;
     let (a_probes, b_probes) = partition_probes(tensor_a, tensor_b, outputs, &probe_tensors)?;
 
     let mut a_factors = Vec::with_capacity(a_probes.len() + 2);
@@ -681,6 +888,69 @@ where
             true
         } else {
             match factorized.right.src_error_estimate() {
+                Ok(estimate) => {
+                    estimate.error
+                        <= src_options.atol + src_options.rtol.unwrap_or(0.0) * estimate.norm
+                }
+                Err(error) => {
+                    return Err(anyhow::anyhow!(
+                        "contract_src: {label} adaptive estimator unavailable: {error}"
+                    ));
+                }
+            }
+        };
+        if !stop {
+            previous_width = width;
+            previous = Some(factorized);
+            width = width
+                .saturating_add(src_options.rank_increment)
+                .min(maximum_width);
+            continue;
+        }
+        return Ok((factorized.left, factorized.bond_index));
+    }
+}
+
+/// Context-scoped batch-native adaptive sketch growth loop.
+///
+/// The batch tensors produced by `make_batch` must already belong to
+/// `context` (callers build them with the `_in` probe constructors);
+/// factorization and estimation run through the scoped entries.
+pub(super) fn factorize_probe_batches_in<T, F>(
+    left_indices: &[T::Index],
+    initial_width: usize,
+    maximum_width: usize,
+    src_options: &SrcOptions,
+    label: &str,
+    mut make_batch: F,
+    context: &ExecutionContext,
+) -> Result<(T, T::Index)>
+where
+    T: TensorLike,
+    T::Index: IndexLike + Clone + Hash + Eq,
+    F: FnMut(usize, usize) -> Result<(T, T::Index)>,
+{
+    if maximum_width == 0 {
+        anyhow::bail!("contract_src: {label} has no usable probe columns");
+    }
+    let mut width = initial_width.min(maximum_width).max(1);
+    let mut previous_width = 0;
+    let mut previous = None;
+    loop {
+        let (batch_tensor, batch_index) = make_batch(previous_width, width - previous_width)?;
+        let factorized = T::factorize_probe_batch_incremental_in(
+            previous.as_ref(),
+            &batch_tensor,
+            &batch_index,
+            left_indices,
+            context,
+        )
+        .map_err(|error| anyhow::anyhow!("contract_src: {label} QR failed: {error}"))?;
+        let saturated = factorized.rank < width || width == maximum_width;
+        let stop = if src_options.rtol.is_none() || saturated {
+            true
+        } else {
+            match factorized.right.src_error_estimate_in(context) {
                 Ok(estimate) => {
                     estimate.error
                         <= src_options.atol + src_options.rtol.unwrap_or(0.0) * estimate.norm

--- a/crates/tensor4all-treetn/src/treetn/contraction/src_probe.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction/src_probe.rs
@@ -167,50 +167,8 @@ where
         .map_err(|error| anyhow::anyhow!("contract_src: probe construction failed: {error}"))
 }
 
-/// Context-scoped single probe column: the result belongs to `context`.
-fn single_probe_in<T, R>(
-    index: &T::Index,
-    probes: &ProbeBank<T::Index, R>,
-    column: usize,
-    context: &ExecutionContext,
-) -> Result<T>
-where
-    T: TensorLike,
-    T::Index: IndexLike + Clone + Hash + Eq,
-{
-    let data = probes.column(index, column)?.to_vec();
-    T::from_dense_in(context, vec![index.clone()], data)
-        .map_err(|error| anyhow::anyhow!("contract_src: probe construction failed: {error}"))
-}
-
-fn single_probe_batch<T, R>(
-    index: &T::Index,
-    probes: &ProbeBank<T::Index, R>,
-    first_column: usize,
-    width: usize,
-    batch: &T::Index,
-) -> Result<T>
-where
-    T: TensorLike,
-    T::Index: IndexLike + Clone + Hash + Eq,
-{
-    let capacity = index
-        .dim()
-        .checked_mul(width)
-        .ok_or_else(|| anyhow::anyhow!("contract_src: probe batch size overflow"))?;
-    let end_column = first_column
-        .checked_add(width)
-        .ok_or_else(|| anyhow::anyhow!("contract_src: probe batch column range overflow"))?;
-    let mut data = Vec::with_capacity(capacity);
-    for column in first_column..end_column {
-        data.extend_from_slice(probes.column(index, column)?);
-    }
-    T::from_dense(vec![index.clone(), batch.clone()], data)
-        .map_err(|error| anyhow::anyhow!("contract_src: probe batch construction failed: {error}"))
-}
-
 /// Context-scoped probe batch: the result belongs to `context`.
-fn single_probe_batch_in<T, R>(
+fn single_probe_batch<T, R>(
     index: &T::Index,
     probes: &ProbeBank<T::Index, R>,
     first_column: usize,
@@ -237,38 +195,8 @@ where
         .map_err(|error| anyhow::anyhow!("contract_src: probe batch construction failed: {error}"))
 }
 
-/// Build the factorized probe tensors for one batch of SRC columns.
-///
-/// Each returned tensor carries one physical output index and the shared
-/// `batch` index. Keeping these tensors separate lets a tree-message
-/// contraction eliminate incoming branch bonds before joining the two local
-/// operands, instead of materializing their full virtual-bond product.
-pub(super) fn probe_batch_tensors<T, R>(
-    outputs: &[T::Index],
-    probes: &ProbeBank<T::Index, R>,
-    first_column: usize,
-    width: usize,
-    batch: &T::Index,
-) -> Result<Vec<T>>
-where
-    T: TensorLike,
-    T::Index: IndexLike + Clone + Hash + Eq,
-{
-    if width == 0 || batch.dim() != width {
-        anyhow::bail!(
-            "contract_src: probe batch dimension {} does not match width {}",
-            batch.dim(),
-            width
-        );
-    }
-    outputs
-        .iter()
-        .map(|index| single_probe_batch::<T, R>(index, probes, first_column, width, batch))
-        .collect()
-}
-
 /// Context-scoped probe batch tensors: every result belongs to `context`.
-pub(super) fn probe_batch_tensors_in<T, R>(
+pub(super) fn probe_batch_tensors<T, R>(
     outputs: &[T::Index],
     probes: &ProbeBank<T::Index, R>,
     first_column: usize,
@@ -289,7 +217,7 @@ where
     }
     outputs
         .iter()
-        .map(|index| single_probe_batch_in::<T, R>(index, probes, first_column, width, batch, context))
+        .map(|index| single_probe_batch::<T, R>(index, probes, first_column, width, batch, context))
         .collect()
 }
 
@@ -329,72 +257,9 @@ where
     })
 }
 
-/// Context-scoped factorized probed site pair.
-fn probed_site_pair_in<T, R>(
-    tensor_a: &T,
-    tensor_b: &T,
-    outputs: &[T::Index],
-    probes: &ProbeBank<T::Index, R>,
-    column: usize,
-    context: &ExecutionContext,
-) -> Result<T>
-where
-    T: TensorLike,
-    T::Index: IndexLike + Clone + Hash + Eq,
-{
-    let probe_tensors = outputs
-        .iter()
-        .map(|index| single_probe_in::<T, R>(index, probes, column, context))
-        .collect::<Result<Vec<_>>>()?;
-    let (a_probes, b_probes) = partition_probes(tensor_a, tensor_b, outputs, &probe_tensors)?;
-    let probed_a = contract_operand_with_probes(tensor_a, &a_probes, None)?;
-    let probed_b = contract_operand_with_probes(tensor_b, &b_probes, None)?;
-    T::contract(&[&probed_a, &probed_b]).map_err(|error| {
-        anyhow::anyhow!("contract_src: factorized probe contraction failed: {error}")
-    })
-}
-
-/// Contract two local operands with a block of factorized probes.
-pub(super) fn probed_site_pair_batch_range<T, R>(
-    tensor_a: &T,
-    tensor_b: &T,
-    outputs: &[T::Index],
-    probes: &ProbeBank<T::Index, R>,
-    first_column: usize,
-    width: usize,
-    batch: &T::Index,
-) -> Result<T>
-where
-    T: TensorLike,
-    T::Index: IndexLike + Clone + Hash + Eq,
-{
-    if width == 0 || batch.dim() != width {
-        anyhow::bail!(
-            "contract_src: probe batch dimension {} does not match width {}",
-            batch.dim(),
-            width
-        );
-    }
-    if outputs.is_empty() {
-        let local = T::contract(&[tensor_a, tensor_b]).map_err(|error| {
-            anyhow::anyhow!("contract_src: scalar local pair contraction failed: {error}")
-        })?;
-        let batch_values = T::ones(std::slice::from_ref(batch)).map_err(|error| {
-            anyhow::anyhow!("contract_src: scalar probe batch construction failed: {error}")
-        })?;
-        return local.outer_product(&batch_values).map_err(|error| {
-            anyhow::anyhow!("contract_src: scalar probe batch broadcast failed: {error}")
-        });
-    }
-    let probe_tensors = probe_batch_tensors(outputs, probes, first_column, width, batch)?;
-    let (a_probes, b_probes) = partition_probes(tensor_a, tensor_b, outputs, &probe_tensors)?;
-    let probed_a = contract_operand_with_probes(tensor_a, &a_probes, Some(batch))?;
-    let probed_b = contract_operand_with_probes(tensor_b, &b_probes, Some(batch))?;
-    contract_retaining(&[&probed_a, &probed_b], batch)
-}
-
 /// Context-scoped batched probed site pair.
-fn probed_site_pair_batch_range_in<T, R>(
+#[allow(clippy::too_many_arguments)]
+pub(super) fn probed_site_pair_batch_range<T, R>(
     tensor_a: &T,
     tensor_b: &T,
     outputs: &[T::Index],
@@ -426,8 +291,7 @@ where
             anyhow::anyhow!("contract_src: scalar probe batch broadcast failed: {error}")
         });
     }
-    let probe_tensors =
-        probe_batch_tensors_in(outputs, probes, first_column, width, batch, context)?;
+    let probe_tensors = probe_batch_tensors(outputs, probes, first_column, width, batch, context)?;
     let (a_probes, b_probes) = partition_probes(tensor_a, tensor_b, outputs, &probe_tensors)?;
     let probed_a = contract_operand_with_probes(tensor_a, &a_probes, Some(batch))?;
     let probed_b = contract_operand_with_probes(tensor_b, &b_probes, Some(batch))?;
@@ -481,37 +345,7 @@ where
     contract_operand_with_probes(&result, &b_probes, None)
 }
 
-/// Context-scoped unbatched probed prefix contraction.
-fn contract_prefix_with_probed_site_pair_in<T, R>(
-    prefix: &T,
-    tensor_a: &T,
-    tensor_b: &T,
-    outputs: &[T::Index],
-    probes: &ProbeBank<T::Index, R>,
-    column: usize,
-    context: &ExecutionContext,
-) -> Result<T>
-where
-    T: TensorLike,
-    T::Index: IndexLike + Clone + Hash + Eq,
-{
-    let probe_tensors = outputs
-        .iter()
-        .map(|index| single_probe_in::<T, R>(index, probes, column, context))
-        .collect::<Result<Vec<_>>>()?;
-    let (a_probes, b_probes) = partition_probes(tensor_a, tensor_b, outputs, &probe_tensors)?;
-    let mut result = T::contract(&[prefix, tensor_a])
-        .map_err(|error| anyhow::anyhow!("contract_src: prefix-A contraction failed: {error}"))?;
-    result = contract_operand_with_probes(&result, &a_probes, None)?;
-    result = T::contract(&[&result, tensor_b])
-        .map_err(|error| anyhow::anyhow!("contract_src: prefix-B contraction failed: {error}"))?;
-    contract_operand_with_probes(&result, &b_probes, None)
-}
-
-/// Contract a factorized local pair with an incoming batched prefix.
-// INVARIANT: `prefix`, the two local operands, the probe bank, and the batch
-// range are all one contraction step; keeping them explicit prevents the
-// factorized MPO--MPO path from hiding a fused physical product.
+/// Context-scoped batched probed prefix contraction.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn contract_prefix_with_probed_site_pair_batch_range<T, R>(
     prefix: &T,
@@ -522,47 +356,6 @@ pub(super) fn contract_prefix_with_probed_site_pair_batch_range<T, R>(
     first_column: usize,
     width: usize,
     batch: &T::Index,
-) -> Result<T>
-where
-    T: TensorLike,
-    T::Index: IndexLike + Clone + Hash + Eq,
-{
-    if width == 0 || batch.dim() != width {
-        anyhow::bail!(
-            "contract_src: probe batch dimension {} does not match width {}",
-            batch.dim(),
-            width
-        );
-    }
-    let probe_tensors = probe_batch_tensors(outputs, probes, first_column, width, batch)?;
-    let (a_probes, b_probes) = partition_probes(tensor_a, tensor_b, outputs, &probe_tensors)?;
-
-    let mut a_factors = Vec::with_capacity(a_probes.len() + 2);
-    a_factors.push(tensor_a);
-    a_factors.push(prefix);
-    a_factors.extend(a_probes.iter().copied());
-    let result = contract_retaining(&a_factors, batch)
-        .map_err(|error| anyhow::anyhow!("contract_src: prefix-A contraction failed: {error}"))?;
-
-    let mut b_factors = Vec::with_capacity(b_probes.len() + 2);
-    b_factors.push(tensor_b);
-    b_factors.push(&result);
-    b_factors.extend(b_probes.iter().copied());
-    contract_retaining(&b_factors, batch)
-        .map_err(|error| anyhow::anyhow!("contract_src: prefix-B contraction failed: {error}"))
-}
-
-/// Context-scoped batched probed prefix contraction.
-#[allow(clippy::too_many_arguments)]
-fn contract_prefix_with_probed_site_pair_batch_range_in<T, R>(
-    prefix: &T,
-    tensor_a: &T,
-    tensor_b: &T,
-    outputs: &[T::Index],
-    probes: &ProbeBank<T::Index, R>,
-    first_column: usize,
-    width: usize,
-    batch: &T::Index,
     context: &ExecutionContext,
 ) -> Result<T>
 where
@@ -576,8 +369,7 @@ where
             width
         );
     }
-    let probe_tensors =
-        probe_batch_tensors_in(outputs, probes, first_column, width, batch, context)?;
+    let probe_tensors = probe_batch_tensors(outputs, probes, first_column, width, batch, context)?;
     let (a_probes, b_probes) = partition_probes(tensor_a, tensor_b, outputs, &probe_tensors)?;
 
     let mut a_factors = Vec::with_capacity(a_probes.len() + 2);
@@ -850,73 +642,12 @@ pub(super) fn initial_width(maximum_width: usize, src_options: &SrcOptions) -> u
     src_options.min_rank.min(maximum_width).max(1)
 }
 
-/// Batch-native adaptive sketch growth loop: `make_batch` receives
-/// `(start, width)` and returns one batch-indexed tensor covering exactly
-/// `[start, start + width)`, instead of being asked for individual columns
-/// one at a time. See
-/// `docs/superpowers/specs/2026-08-30-src-adaptive-batch-probe-columns-design.md`.
-pub(super) fn factorize_probe_batches<T, F>(
-    left_indices: &[T::Index],
-    initial_width: usize,
-    maximum_width: usize,
-    src_options: &SrcOptions,
-    label: &str,
-    mut make_batch: F,
-) -> Result<(T, T::Index)>
-where
-    T: TensorLike,
-    T::Index: IndexLike + Clone + Hash + Eq,
-    F: FnMut(usize, usize) -> Result<(T, T::Index)>,
-{
-    if maximum_width == 0 {
-        anyhow::bail!("contract_src: {label} has no usable probe columns");
-    }
-    let mut width = initial_width.min(maximum_width).max(1);
-    let mut previous_width = 0;
-    let mut previous = None;
-    loop {
-        let (batch_tensor, batch_index) = make_batch(previous_width, width - previous_width)?;
-        let factorized = T::factorize_probe_batch_incremental(
-            previous.as_ref(),
-            &batch_tensor,
-            &batch_index,
-            left_indices,
-        )
-        .map_err(|error| anyhow::anyhow!("contract_src: {label} QR failed: {error}"))?;
-        let saturated = factorized.rank < width || width == maximum_width;
-        let stop = if src_options.rtol.is_none() || saturated {
-            true
-        } else {
-            match factorized.right.src_error_estimate() {
-                Ok(estimate) => {
-                    estimate.error
-                        <= src_options.atol + src_options.rtol.unwrap_or(0.0) * estimate.norm
-                }
-                Err(error) => {
-                    return Err(anyhow::anyhow!(
-                        "contract_src: {label} adaptive estimator unavailable: {error}"
-                    ));
-                }
-            }
-        };
-        if !stop {
-            previous_width = width;
-            previous = Some(factorized);
-            width = width
-                .saturating_add(src_options.rank_increment)
-                .min(maximum_width);
-            continue;
-        }
-        return Ok((factorized.left, factorized.bond_index));
-    }
-}
-
 /// Context-scoped batch-native adaptive sketch growth loop.
 ///
 /// The batch tensors produced by `make_batch` must already belong to
-/// `context` (callers build them with the `_in` probe constructors);
+/// `context` (callers build them with the scoped probe constructors);
 /// factorization and estimation run through the scoped entries.
-pub(super) fn factorize_probe_batches_in<T, F>(
+pub(super) fn factorize_probe_batches<T, F>(
     left_indices: &[T::Index],
     initial_width: usize,
     maximum_width: usize,
@@ -1180,6 +911,9 @@ mod tests {
             IdxTensor::from_dense(vec![shared, output_b.clone()], vec![5.0, 6.0, 7.0, 8.0])
                 .unwrap();
         let probes = ProbeBank::from_seed(vec![output_a.clone(), output_b.clone()], 2, 23).unwrap();
+        let context = tensor4all_tensorbackend::ExecutionContext::Cpu(
+            tensor4all_tensorbackend::default_cpu_execution_context(),
+        );
         let actual = probed_site_pair_batch_range(
             &tensor_a,
             &tensor_b,
@@ -1188,6 +922,7 @@ mod tests {
             0,
             2,
             &batch,
+            &context,
         )
         .unwrap();
         assert_eq!(actual.indices(), std::slice::from_ref(&batch));
@@ -1260,6 +995,9 @@ mod tests {
         )
         .unwrap();
         let probes = ProbeBank::from_seed(vec![output_a.clone(), output_b.clone()], 2, 31).unwrap();
+        let context = tensor4all_tensorbackend::ExecutionContext::Cpu(
+            tensor4all_tensorbackend::default_cpu_execution_context(),
+        );
         let local = probed_site_pair_batch_range(
             &tensor_a,
             &tensor_b,
@@ -1268,9 +1006,13 @@ mod tests {
             0,
             2,
             &batch,
+            &context,
         )
         .unwrap();
         let reference = contract_retaining(&[&prefix, &local], &batch).unwrap();
+        let context = tensor4all_tensorbackend::ExecutionContext::Cpu(
+            tensor4all_tensorbackend::default_cpu_execution_context(),
+        );
         let actual = contract_prefix_with_probed_site_pair_batch_range(
             &prefix,
             &tensor_a,
@@ -1280,6 +1022,7 @@ mod tests {
             0,
             2,
             &batch,
+            &context,
         )
         .unwrap();
         let error = actual.distance(&reference).unwrap();
@@ -1331,6 +1074,9 @@ mod tests {
 
     #[test]
     fn scalar_probed_site_pair_batch_range_broadcasts_over_the_batch_axis() {
+        let context = tensor4all_tensorbackend::ExecutionContext::Cpu(
+            tensor4all_tensorbackend::default_cpu_execution_context(),
+        );
         let batch = DynIndex::new_dyn(3);
         let bank = ProbeBank::from_seed(vec![], 3, 17).unwrap();
 
@@ -1339,7 +1085,8 @@ mod tests {
         let local =
             IdxTensor::from_dense(vec![left.clone(), shared.clone()], vec![2.0, 3.0]).unwrap();
         let other = IdxTensor::from_dense(vec![shared], vec![4.0]).unwrap();
-        let pair = probed_site_pair_batch_range(&local, &other, &[], &bank, 0, 3, &batch).unwrap();
+        let pair = probed_site_pair_batch_range(&local, &other, &[], &bank, 0, 3, &batch, &context)
+            .unwrap();
         assert_eq!(pair.indices(), &[left, batch]);
         assert_eq!(
             pair.to_vec::<f64>().unwrap(),
@@ -1417,6 +1164,9 @@ mod tests {
         let src_options = SrcOptions::adaptive(1.0e-10, 4)
             .with_min_rank(1)
             .with_rank_increment(2);
+        let context = tensor4all_tensorbackend::ExecutionContext::Cpu(
+            tensor4all_tensorbackend::default_cpu_execution_context(),
+        );
         let (result, result_batch) = factorize_probe_batches::<IdxTensor, _>(
             &[row],
             2,
@@ -1431,6 +1181,7 @@ mod tests {
                     Ok((last_two.clone(), batch1.clone()))
                 }
             },
+            &context,
         )
         .unwrap();
 

--- a/crates/tensor4all-treetn/src/treetn/contraction/src_tree.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction/src_tree.rs
@@ -15,6 +15,7 @@ use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 
 use tensor4all_core::{IndexLike, SvdTruncationPolicy, TensorLike};
+use tensor4all_tensorbackend::ExecutionContext;
 
 use super::src_probe::{
     connect_result_edge, contract_retaining, factorize_probe_batches, initial_width,
@@ -37,6 +38,7 @@ type EnvironmentSegment<T, V> = (
     DirectedEnvironment<T, V>,
 );
 
+#[allow(clippy::too_many_arguments)]
 /// Execute successive randomized compression on a chain or a rooted tree.
 pub(super) fn contract<T, V, R>(
     tn_a: &TreeTN<T, V>,
@@ -46,6 +48,7 @@ pub(super) fn contract<T, V, R>(
     max_bond_dim: usize,
     src_options: &SrcOptions,
     rng: R,
+    context: &ExecutionContext,
 ) -> Result<TreeTN<T, V>>
 where
     T: TensorLike,
@@ -66,6 +69,7 @@ where
                 max_bond_dim,
                 src_options,
                 rng,
+                context,
             );
         }
     }
@@ -147,6 +151,7 @@ where
         &outputs,
         &mut probes,
         sketch_options.rank_increment,
+        context,
     );
 
     let mut result_tensors = HashMap::with_capacity(nodes.len());
@@ -176,7 +181,7 @@ where
             // A scalar-only subtree still needs a structural bridge. Its
             // scalar value stays in the projected source absorbed by parent.
             let cap = T::Index::new_link(1)?;
-            let factor = T::ones(std::slice::from_ref(&cap)).map_err(|error| {
+            let factor = T::ones_in(context, std::slice::from_ref(&cap)).map_err(|error| {
                 anyhow::anyhow!("contract_src: scalar tree cap construction failed: {error}")
             })?;
             let source = contract_factors(&source_factors, "contract_src: scalar tree source")?;
@@ -210,10 +215,11 @@ where
                     )
                 })?;
                 let factorized = sketch
-                    .factorize_full_rank(
+                    .factorize_full_rank_in(
                         &left_indices,
                         tensor4all_core::FactorizeAlg::QR,
                         tensor4all_core::Canonical::Left,
+                        context,
                     )
                     .map_err(|error| {
                         anyhow::anyhow!(
@@ -244,6 +250,7 @@ where
                                 )
                             })
                     },
+                    context,
                 )?
             };
             let factor_conj = factor.conj();
@@ -290,11 +297,12 @@ where
     }
 
     if src_options.final_svd {
-        result.truncate_impl(
+        result.truncate_impl_in(
             [center.clone()],
             svd_policy,
             Some(max_bond_dim),
             "contract_src: tree final truncate",
+            context,
         )?;
     } else {
         mark_result_canonical(&mut result, center, &edges)?;
@@ -317,6 +325,7 @@ where
     batch_size: usize,
     segments: Vec<EnvironmentSegment<T, V>>,
     segment_total_width: usize,
+    context: &'a ExecutionContext,
 }
 
 impl<'a, T, V, R> EnvironmentCache<'a, T, V, R>
@@ -326,6 +335,7 @@ where
     V: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
     R: Rng,
 {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         tn: &'a TreeTN<T, V>,
         edges: &'a [(V, V)],
@@ -334,6 +344,7 @@ where
         outputs: &'a HashMap<V, Vec<T::Index>>,
         probes: &'a mut ProbeBank<T::Index, R>,
         batch_size: usize,
+        context: &'a ExecutionContext,
     ) -> Self {
         Self {
             tn,
@@ -342,6 +353,7 @@ where
             local,
             outputs,
             probes,
+            context,
             batched_environments: HashMap::new(),
             batch_size: batch_size.max(1),
             segments: Vec::new(),
@@ -378,7 +390,14 @@ where
                     .ok_or_else(|| anyhow::anyhow!("contract_src: output list is missing"))?;
                 Ok((
                     node.clone(),
-                    probe_batch_tensors::<T, R>(site_outputs, self.probes, 0, width, &batch)?,
+                    probe_batch_tensors::<T, R>(
+                        site_outputs,
+                        self.probes,
+                        0,
+                        width,
+                        &batch,
+                        self.context,
+                    )?,
                 ))
             })
             .collect::<Result<HashMap<_, _>>>()?;
@@ -427,7 +446,14 @@ where
                     .ok_or_else(|| anyhow::anyhow!("contract_src: output list is missing"))?;
                 Ok((
                     node.clone(),
-                    probe_batch_tensors::<T, R>(site_outputs, self.probes, start, width, &batch)?,
+                    probe_batch_tensors::<T, R>(
+                        site_outputs,
+                        self.probes,
+                        start,
+                        width,
+                        &batch,
+                        self.context,
+                    )?,
                 ))
             })
             .collect::<Result<HashMap<_, _>>>()?;
@@ -909,8 +935,19 @@ mod tests {
         let mut probes = ProbeBank::from_seed(std::mem::take(&mut probe_indices), 1, 99).unwrap();
         // The first width-3 request is narrower than batch_size 5, so this
         // exercises the permitted short initial segment and its direct replay.
-        let mut cache =
-            EnvironmentCache::new(&tn_a, &edges, &nodes, &local, &outputs, &mut probes, 5);
+        let context = tensor4all_tensorbackend::ExecutionContext::Cpu(
+            tensor4all_tensorbackend::default_cpu_execution_context(),
+        );
+        let mut cache = EnvironmentCache::new(
+            &tn_a,
+            &edges,
+            &nodes,
+            &local,
+            &outputs,
+            &mut probes,
+            5,
+            &context,
+        );
         assert!(cache
             .request(&"B".to_string(), &"A".to_string(), 0, 0)
             .is_err());
@@ -975,8 +1012,19 @@ mod tests {
             .collect::<Vec<_>>();
 
         let mut probes = ProbeBank::from_seed(index_list, 1, 7).unwrap();
-        let mut cache =
-            EnvironmentCache::new(&tn_a, &edges, &nodes, &local, &outputs, &mut probes, 2);
+        let context = tensor4all_tensorbackend::ExecutionContext::Cpu(
+            tensor4all_tensorbackend::default_cpu_execution_context(),
+        );
+        let mut cache = EnvironmentCache::new(
+            &tn_a,
+            &edges,
+            &nodes,
+            &local,
+            &outputs,
+            &mut probes,
+            2,
+            &context,
+        );
 
         let (_wide, wide_batch) = cache
             .request(&"B".to_string(), &"A".to_string(), 0, 5)
@@ -1057,6 +1105,9 @@ mod tests {
             .iter()
             .map(|node| {
                 let (tensor_a, tensor_b) = local[node];
+                let context = tensor4all_tensorbackend::ExecutionContext::Cpu(
+                    tensor4all_tensorbackend::default_cpu_execution_context(),
+                );
                 let tensor = probed_site_pair_batch_range(
                     tensor_a,
                     tensor_b,
@@ -1065,6 +1116,7 @@ mod tests {
                     0,
                     3,
                     &batch,
+                    &context,
                 )
                 .unwrap();
                 (node.clone(), tensor)
@@ -1072,12 +1124,15 @@ mod tests {
             .collect::<std::collections::HashMap<_, _>>();
         let reference = directed_messages_batched(&tn_a, &edges, &prepaired, &batch).unwrap();
 
+        let context = tensor4all_tensorbackend::ExecutionContext::Cpu(
+            tensor4all_tensorbackend::default_cpu_execution_context(),
+        );
         let probe_batches = nodes
             .iter()
             .map(|node| {
                 (
                     node.clone(),
-                    probe_batch_tensors(&outputs[node], &probes, 0, 3, &batch).unwrap(),
+                    probe_batch_tensors(&outputs[node], &probes, 0, 3, &batch, &context).unwrap(),
                 )
             })
             .collect::<std::collections::HashMap<_, _>>();

--- a/crates/tensor4all-treetn/src/treetn/localupdate.rs
+++ b/crates/tensor4all-treetn/src/treetn/localupdate.rs
@@ -496,6 +496,10 @@ pub struct TruncateUpdater {
     pub max_bond_dim: Option<usize>,
     /// Explicit SVD truncation policy.
     pub svd_policy: Option<SvdTruncationPolicy>,
+    /// Caller-owned execution context. When set, the two-site SVD runs
+    /// through the context-scoped factorization path; otherwise the legacy
+    /// host path is used.
+    pub context: Option<tensor4all_tensorbackend::ExecutionContext>,
 }
 
 impl TruncateUpdater {
@@ -508,6 +512,25 @@ impl TruncateUpdater {
         Self {
             max_bond_dim,
             svd_policy,
+            context: None,
+        }
+    }
+
+    /// Create a truncation updater bound to a caller-owned execution context.
+    ///
+    /// # Arguments
+    /// * `max_bond_dim` - Maximum bond dimension (None for no limit)
+    /// * `svd_policy` - SVD truncation policy override (None uses the global default)
+    /// * `context` - Execution context owning the truncated tensors
+    pub fn new_in(
+        max_bond_dim: Option<usize>,
+        svd_policy: Option<SvdTruncationPolicy>,
+        context: tensor4all_tensorbackend::ExecutionContext,
+    ) -> Self {
+        Self {
+            max_bond_dim,
+            svd_policy,
+            context: Some(context),
         }
     }
 }
@@ -593,10 +616,15 @@ where
             .validate()
             .map_err(|error| anyhow::anyhow!("Invalid factorization options: {error}"))?;
 
-        // Factorize
-        let factorize_result = tensor_ab
-            .factorize(&left_inds, &options)
-            .map_err(|e| anyhow::anyhow!("Factorization failed: {}", e))?;
+        // Factorize (context-scoped when the updater carries a context).
+        let factorize_result = match &self.context {
+            Some(context) => tensor_ab
+                .factorize_in(&left_inds, &options, context)
+                .map_err(|e| anyhow::anyhow!("Factorization failed: {}", e))?,
+            None => tensor_ab
+                .factorize(&left_inds, &options)
+                .map_err(|e| anyhow::anyhow!("Factorization failed: {}", e))?,
+        };
 
         let new_tensor_a = factorize_result.left;
         let new_tensor_b = factorize_result.right;

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -836,21 +836,21 @@ where
             .ok_or_else(|| anyhow::anyhow!("Tensor not found for dst node {:?}", dst))
             .with_context(|| format!("{}: dst tensor not found", context_name))?;
 
-        let src_norm = tensor_src
-            .norm_in(context)
-            .map_err(|error| anyhow::anyhow!("{}: scalar norm failed: {error}", context_name))?;
+        let src_norm = tensor_src.norm_in(context).map_err(|error| {
+            anyhow::Error::new(error).context(format!("{context_name}: scalar norm failed"))
+        })?;
         let updated_src_tensor = if src_norm > 0.0 {
-            tensor_src
-                .scale_in(1.0 / src_norm, context)
-                .map_err(|error| {
-                    anyhow::anyhow!("{}: failed to normalize src tensor: {error}", context_name)
-                })?
+            tensor_src.scale_in(1.0 / src_norm, context).map_err(|error| {
+                anyhow::Error::new(error)
+                    .context(format!("{context_name}: failed to normalize src tensor"))
+            })?
         } else {
             tensor_src.clone()
         };
         let updated_dst_tensor = if src_norm > 0.0 {
             tensor_dst.scale_in(src_norm, context).map_err(|error| {
-                anyhow::anyhow!("{}: failed to scale dst tensor: {error}", context_name)
+                anyhow::Error::new(error)
+                    .context(format!("{context_name}: failed to scale dst tensor"))
             })?
         } else {
             tensor_dst.clone()

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -687,55 +687,32 @@ where
 
         let tensor_external_indices = tensor_src.external_indices();
         if left_inds.is_empty() {
-            // Compatibility boundary: the process-global CPU context keeps the
-            // historical scalar-norm transfer. Other explicit contexts have no
-            // scoped scalar-construction path, so they fail loudly here.
-            let legacy = context.is_none_or(|execution| execution.is_global_default_cpu());
-            if !legacy {
-                return Err(anyhow::anyhow!(
-                    "scalar edge normalization has no context-scoped path"
-                ))
-                .with_context(|| format!("{}: unsupported scalar edge", context_name))?;
-            }
-            let tensor_dst = self
-                .tensor(dst)
-                .ok_or_else(|| anyhow::anyhow!("Tensor not found for dst node {:?}", dst))
-                .with_context(|| format!("{}: dst tensor not found", context_name))?;
-
-            let src_norm = tensor_src.norm()?;
-            let updated_src_tensor = if src_norm > 0.0 {
-                tensor_src
-                    .scale(tensor4all_core::AnyScalar::new_real(1.0 / src_norm))
-                    .with_context(|| format!("{}: failed to normalize src tensor", context_name))?
-            } else {
-                tensor_src.clone()
-            };
-            let updated_dst_tensor = if src_norm > 0.0 {
-                tensor_dst
-                    .scale(tensor4all_core::AnyScalar::new_real(src_norm))
-                    .with_context(|| format!("{}: failed to scale dst tensor", context_name))?
-            } else {
-                tensor_dst.clone()
-            };
-
-            self.replace_tensor(src, updated_src_tensor)
-                .with_context(|| {
-                    format!("{}: failed to replace tensor at src node", context_name)
-                })?;
-            self.replace_tensor(dst, updated_dst_tensor)
-                .with_context(|| {
-                    format!("{}: failed to replace tensor at dst node", context_name)
-                })?;
-
-            let dst_name = self
-                .graph
-                .node_name(dst)
-                .ok_or_else(|| anyhow::anyhow!("Dst node name not found"))?
+            // Compatibility boundary: no-context and process-global CPU
+            // callers keep the historical scalar-norm transfer. Every other
+            // explicit context uses the scoped norm/scale path.
+            let tensor_src = self
+                .tensor(src)
+                .ok_or_else(|| anyhow::anyhow!("Tensor not found for node {:?}", src))
+                .with_context(|| format!("{}: tensor not found", context_name))?
                 .clone();
-            self.set_edge_ortho_towards(edge, Some(dst_name))
-                .with_context(|| format!("{}: failed to set ortho_towards", context_name))?;
-
-            return Ok(());
+            match context {
+                None => {
+                    return self.sweep_scalar_edge_legacy(src, dst, edge, tensor_src, context_name);
+                }
+                Some(execution) if execution.is_global_default_cpu() => {
+                    return self.sweep_scalar_edge_legacy(src, dst, edge, tensor_src, context_name);
+                }
+                Some(execution) => {
+                    return self.sweep_scalar_edge_in(
+                        src,
+                        dst,
+                        edge,
+                        tensor_src,
+                        execution,
+                        context_name,
+                    );
+                }
+            }
         }
 
         if left_inds.len() == tensor_external_indices.len() {
@@ -800,6 +777,120 @@ where
     // ------------------------------------------------------------------------
     // Public accessors
     // ------------------------------------------------------------------------
+
+    /// Historical scalar-edge normalization (no-context and global callers).
+    fn sweep_scalar_edge_legacy(
+        &mut self,
+        src: NodeIndex,
+        dst: NodeIndex,
+        edge: EdgeIndex,
+        tensor_src: T,
+        context_name: &str,
+    ) -> Result<()> {
+        let tensor_dst = self
+            .tensor(dst)
+            .ok_or_else(|| anyhow::anyhow!("Tensor not found for dst node {:?}", dst))
+            .with_context(|| format!("{}: dst tensor not found", context_name))?;
+
+        let src_norm = tensor_src.norm()?;
+        let updated_src_tensor = if src_norm > 0.0 {
+            tensor_src
+                .scale(tensor4all_core::AnyScalar::new_real(1.0 / src_norm))
+                .with_context(|| format!("{}: failed to normalize src tensor", context_name))?
+        } else {
+            tensor_src.clone()
+        };
+        let updated_dst_tensor = if src_norm > 0.0 {
+            tensor_dst
+                .scale(tensor4all_core::AnyScalar::new_real(src_norm))
+                .with_context(|| format!("{}: failed to scale dst tensor", context_name))?
+        } else {
+            tensor_dst.clone()
+        };
+
+        self.finish_scalar_edge_swap(
+            src,
+            dst,
+            edge,
+            updated_src_tensor,
+            updated_dst_tensor,
+            context_name,
+        )
+    }
+
+    /// Context-scoped scalar-edge normalization for explicit contexts.
+    ///
+    /// Transfers the source norm with `norm_in`/`scale_in`, so every value
+    /// stays in `context` on CPU and CUDA alike.
+    fn sweep_scalar_edge_in(
+        &mut self,
+        src: NodeIndex,
+        dst: NodeIndex,
+        edge: EdgeIndex,
+        tensor_src: T,
+        context: &tensor4all_tensorbackend::ExecutionContext,
+        context_name: &str,
+    ) -> Result<()> {
+        let tensor_dst = self
+            .tensor(dst)
+            .ok_or_else(|| anyhow::anyhow!("Tensor not found for dst node {:?}", dst))
+            .with_context(|| format!("{}: dst tensor not found", context_name))?;
+
+        let src_norm = tensor_src
+            .norm_in(context)
+            .map_err(|error| anyhow::anyhow!("{}: scalar norm failed: {error}", context_name))?;
+        let updated_src_tensor = if src_norm > 0.0 {
+            tensor_src
+                .scale_in(1.0 / src_norm, context)
+                .map_err(|error| {
+                    anyhow::anyhow!("{}: failed to normalize src tensor: {error}", context_name)
+                })?
+        } else {
+            tensor_src.clone()
+        };
+        let updated_dst_tensor = if src_norm > 0.0 {
+            tensor_dst.scale_in(src_norm, context).map_err(|error| {
+                anyhow::anyhow!("{}: failed to scale dst tensor: {error}", context_name)
+            })?
+        } else {
+            tensor_dst.clone()
+        };
+
+        self.finish_scalar_edge_swap(
+            src,
+            dst,
+            edge,
+            updated_src_tensor,
+            updated_dst_tensor,
+            context_name,
+        )
+    }
+
+    /// Shared tail of both scalar-edge paths: replace tensors and orient.
+    fn finish_scalar_edge_swap(
+        &mut self,
+        src: NodeIndex,
+        dst: NodeIndex,
+        edge: EdgeIndex,
+        updated_src_tensor: T,
+        updated_dst_tensor: T,
+        context_name: &str,
+    ) -> Result<()> {
+        self.replace_tensor(src, updated_src_tensor)
+            .with_context(|| format!("{}: failed to replace tensor at src node", context_name))?;
+        self.replace_tensor(dst, updated_dst_tensor)
+            .with_context(|| format!("{}: failed to replace tensor at dst node", context_name))?;
+
+        let dst_name = self
+            .graph
+            .node_name(dst)
+            .ok_or_else(|| anyhow::anyhow!("Dst node name not found"))?
+            .clone();
+        self.set_edge_ortho_towards(edge, Some(dst_name))
+            .with_context(|| format!("{}: failed to set ortho_towards", context_name))?;
+
+        Ok(())
+    }
 
     /// Get a reference to a tensor by NodeIndex.
     pub fn tensor(&self, node: NodeIndex) -> Option<&T> {
@@ -2191,5 +2282,94 @@ mod tests {
         assert_eq!(tn.node_count(), 0);
         assert_eq!(tn.edge_count(), 0);
         assert!(tn.node_names().is_empty());
+    }
+
+    #[test]
+    fn sweep_scalar_edge_in_matches_legacy_on_explicit_cpu() {
+        use std::sync::Arc;
+
+        use tenferro_cpu::CpuBackend;
+        use tensor4all_core::{DynIndex, TensorConstructionLike};
+        use tensor4all_tensorbackend::{CpuExecutionContext, ExecutionContext};
+
+        let context = ExecutionContext::Cpu(Arc::new(CpuExecutionContext::from_backend(
+            CpuBackend::new(),
+        )));
+        // Two-node tree: node 0 carries only the shared bond (scalar leaf),
+        // node 1 carries the bond plus a site leg.
+        let bond = DynIndex::new_dyn(3);
+        let site = DynIndex::new_dyn(2);
+        let leaf = <IdxTensor as TensorConstructionLike>::from_dense_in(
+            &context,
+            vec![bond.clone()],
+            vec![1.0_f64, 2.0, 3.0],
+        )
+        .unwrap();
+        let parent = <IdxTensor as TensorConstructionLike>::from_dense_in(
+            &context,
+            vec![bond.clone(), site.clone()],
+            vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+        )
+        .unwrap();
+        let mut tree = TreeTN::from_tensors(vec![leaf, parent], vec![0, 1]).unwrap();
+        let (src, dst) = (tree.node_index(&0).unwrap(), tree.node_index(&1).unwrap());
+
+        tree.sweep_edge_full_rank_in(
+            src,
+            dst,
+            FactorizeAlg::QR,
+            Canonical::Left,
+            "test",
+            &context,
+        )
+        .unwrap();
+
+        // Norm transfer: leaf normalized, parent scaled by the leaf norm.
+        let expected_norm = 14.0_f64.sqrt();
+        let leaf_back = tree.tensor(src).unwrap();
+        leaf_back.validate_context(&context).unwrap();
+        let leaf_values = leaf_back.to_vec::<f64>().unwrap();
+        for (got, want) in leaf_values
+            .iter()
+            .zip([1.0, 2.0, 3.0].iter().map(|v| v / expected_norm))
+        {
+            assert!((got - want).abs() < 1e-12, "leaf {leaf_values:?}");
+        }
+        let parent_back = tree.tensor(dst).unwrap();
+        parent_back.validate_context(&context).unwrap();
+        let parent_values = parent_back.to_vec::<f64>().unwrap();
+        for (got, want) in parent_values.iter().zip(
+            [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+                .iter()
+                .map(|v| v * expected_norm),
+        ) {
+            assert!((got - want).abs() < 1e-12, "parent {parent_values:?}");
+        }
+
+        // Legacy entry agrees exactly on host inputs.
+        let host_leaf = IdxTensor::from_dense(vec![bond.clone()], vec![1.0_f64, 2.0, 3.0]).unwrap();
+        let host_parent = IdxTensor::from_dense(
+            vec![bond.clone(), site.clone()],
+            vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+        )
+        .unwrap();
+        let mut host_tree = TreeTN::from_tensors(vec![host_leaf, host_parent], vec![0, 1]).unwrap();
+        let (host_src, host_dst) = (
+            host_tree.node_index(&0).unwrap(),
+            host_tree.node_index(&1).unwrap(),
+        );
+        host_tree
+            .sweep_edge_full_rank(
+                host_src,
+                host_dst,
+                FactorizeAlg::QR,
+                Canonical::Left,
+                "test",
+            )
+            .unwrap();
+        let legacy_leaf = host_tree.tensor(host_src).unwrap().to_vec::<f64>().unwrap();
+        assert_eq!(legacy_leaf, leaf_values);
+        let legacy_parent = host_tree.tensor(host_dst).unwrap().to_vec::<f64>().unwrap();
+        assert_eq!(legacy_parent, parent_values);
     }
 }

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -623,6 +623,35 @@ where
         canonical: Canonical,
         context_name: &str,
     ) -> Result<()> {
+        self.sweep_edge_full_rank_scoped(src, dst, alg, canonical, context_name, None)
+    }
+
+    /// Context-scoped full-rank edge sweep.
+    ///
+    /// Factorizes through `factorize_full_rank_in`, so LU/CI forms and scalar
+    /// edge normalization (which needs unscoped scalar construction) return
+    /// typed errors instead of running.
+    pub(crate) fn sweep_edge_full_rank_in(
+        &mut self,
+        src: NodeIndex,
+        dst: NodeIndex,
+        alg: FactorizeAlg,
+        canonical: Canonical,
+        context_name: &str,
+        context: &tensor4all_tensorbackend::ExecutionContext,
+    ) -> Result<()> {
+        self.sweep_edge_full_rank_scoped(src, dst, alg, canonical, context_name, Some(context))
+    }
+
+    fn sweep_edge_full_rank_scoped(
+        &mut self,
+        src: NodeIndex,
+        dst: NodeIndex,
+        alg: FactorizeAlg,
+        canonical: Canonical,
+        context_name: &str,
+        context: Option<&tensor4all_tensorbackend::ExecutionContext>,
+    ) -> Result<()> {
         // Find edge between src and dst
         let edge = {
             let g = self.graph.graph();
@@ -658,6 +687,16 @@ where
 
         let tensor_external_indices = tensor_src.external_indices();
         if left_inds.is_empty() {
+            // Compatibility boundary: the process-global CPU context keeps the
+            // historical scalar-norm transfer. Other explicit contexts have no
+            // scoped scalar-construction path, so they fail loudly here.
+            let legacy = context.is_none_or(|execution| execution.is_global_default_cpu());
+            if !legacy {
+                return Err(anyhow::anyhow!(
+                    "scalar edge normalization has no context-scoped path"
+                ))
+                .with_context(|| format!("{}: unsupported scalar edge", context_name))?;
+            }
             let tensor_dst = self
                 .tensor(dst)
                 .ok_or_else(|| anyhow::anyhow!("Tensor not found for dst node {:?}", dst))
@@ -707,11 +746,17 @@ where
             .with_context(|| format!("{}: invalid tensor rank for factorization", context_name));
         }
 
-        // Perform factorization
-        let factorize_result = tensor_src
-            .factorize_full_rank(&left_inds, alg, canonical)
-            .map_err(|e| anyhow::anyhow!("Factorization failed: {}", e))
-            .with_context(|| format!("{}: factorization failed", context_name))?;
+        // Perform factorization (context-scoped when a context is supplied).
+        let factorize_result = match context {
+            Some(execution) => tensor_src
+                .factorize_full_rank_in(&left_inds, alg, canonical, execution)
+                .map_err(|e| anyhow::anyhow!("Factorization failed: {}", e))
+                .with_context(|| format!("{}: factorization failed", context_name))?,
+            None => tensor_src
+                .factorize_full_rank(&left_inds, alg, canonical)
+                .map_err(|e| anyhow::anyhow!("Factorization failed: {}", e))
+                .with_context(|| format!("{}: factorization failed", context_name))?,
+        };
 
         let left_tensor = factorize_result.left;
         let right_tensor = factorize_result.right;
@@ -1240,6 +1285,62 @@ where
     /// Get all node indices in the tree tensor network.
     pub fn node_indices(&self) -> Vec<NodeIndex> {
         self.graph.graph().node_indices().collect()
+    }
+
+    /// Validate that every node tensor belongs to the supplied execution context.
+    ///
+    /// Generic SRC entries call this on both input trees before RNG advancement
+    /// or contraction, so mixed host/CUDA inputs and foreign CUDA contexts fail
+    /// at the boundary with the offending node identified.
+    ///
+    /// # Arguments
+    /// * `context` - Caller-owned execution context both inputs must belong to.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tensor4all_core::{DynIndex, ExecutionContext, IdxTensor, TensorConstructionLike};
+    /// use tensor4all_tensorbackend::CpuExecutionContext;
+    /// use tensor4all_treetn::TreeTN;
+    /// use tenferro_cpu::CpuBackend;
+    ///
+    /// let context = ExecutionContext::Cpu(Arc::new(
+    ///     CpuExecutionContext::from_backend(CpuBackend::new()),
+    /// ));
+    /// let index = DynIndex::new_dyn(2);
+    /// let tensor = <IdxTensor as TensorConstructionLike>::from_dense_in(
+    ///     &context,
+    ///     vec![index],
+    ///     vec![1.0_f64, 2.0],
+    /// )?;
+    /// let tree = TreeTN::from_tensors(vec![tensor], vec![0])?;
+    /// tree.validate_context(&context)?;
+    /// assert_eq!(tree.node_count(), 1);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// # Errors
+    /// Returns [`TreeTNOperationError`] identifying the offending node when any
+    /// tensor does not belong to `context`.
+    pub fn validate_context(
+        &self,
+        context: &tensor4all_tensorbackend::ExecutionContext,
+    ) -> std::result::Result<(), TreeTNOperationError> {
+        for node in self.graph.graph().node_indices() {
+            let tensor = self.tensor(node).ok_or_else(|| {
+                TreeTNOperationError::from(anyhow::anyhow!(
+                    "context validation: node {node:?} has no tensor"
+                ))
+            })?;
+            tensor.validate_context(context).map_err(|error| {
+                let name = self.graph.node_name(node);
+                TreeTNOperationError::from(anyhow::anyhow!(
+                    "context validation: node {name:?} does not belong to the supplied execution context: {error}"
+                ))
+            })?;
+        }
+        Ok(())
     }
 
     /// Get all node names in the tree tensor network.

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -840,10 +840,12 @@ where
             anyhow::Error::new(error).context(format!("{context_name}: scalar norm failed"))
         })?;
         let updated_src_tensor = if src_norm > 0.0 {
-            tensor_src.scale_in(1.0 / src_norm, context).map_err(|error| {
-                anyhow::Error::new(error)
-                    .context(format!("{context_name}: failed to normalize src tensor"))
-            })?
+            tensor_src
+                .scale_in(1.0 / src_norm, context)
+                .map_err(|error| {
+                    anyhow::Error::new(error)
+                        .context(format!("{context_name}: failed to normalize src tensor"))
+                })?
         } else {
             tensor_src.clone()
         };

--- a/crates/tensor4all-treetn/src/treetn/truncate.rs
+++ b/crates/tensor4all-treetn/src/treetn/truncate.rs
@@ -137,7 +137,13 @@ where
         V: Ord,
         <T::Index as IndexLike>::Id: Ord,
     {
-        self.truncate_impl_scoped(canonical_region, svd_policy, max_bond_dim, context_name, None)
+        self.truncate_impl_scoped(
+            canonical_region,
+            svd_policy,
+            max_bond_dim,
+            context_name,
+            None,
+        )
     }
 
     /// Context-scoped truncation.
@@ -236,9 +242,7 @@ where
 
         // Step 3: Apply truncation sweep
         let mut updater = match context {
-            Some(execution) => {
-                TruncateUpdater::new_in(max_bond_dim, svd_policy, execution.clone())
-            }
+            Some(execution) => TruncateUpdater::new_in(max_bond_dim, svd_policy, execution.clone()),
             None => TruncateUpdater::new(max_bond_dim, svd_policy),
         };
         apply_local_update_sweep(self, &plan, &mut updater)

--- a/crates/tensor4all-treetn/src/treetn/truncate.rs
+++ b/crates/tensor4all-treetn/src/treetn/truncate.rs
@@ -137,6 +137,46 @@ where
         V: Ord,
         <T::Index as IndexLike>::Id: Ord,
     {
+        self.truncate_impl_scoped(canonical_region, svd_policy, max_bond_dim, context_name, None)
+    }
+
+    /// Context-scoped truncation.
+    ///
+    /// Pre-canonicalization and the two-site SVD sweep run through the scoped
+    /// factorization paths, so all intermediates stay in `context`.
+    pub(crate) fn truncate_impl_in(
+        &mut self,
+        canonical_region: impl IntoIterator<Item = V>,
+        svd_policy: Option<SvdTruncationPolicy>,
+        max_bond_dim: Option<usize>,
+        context_name: &str,
+        context: &tensor4all_tensorbackend::ExecutionContext,
+    ) -> Result<()>
+    where
+        V: Ord,
+        <T::Index as IndexLike>::Id: Ord,
+    {
+        self.truncate_impl_scoped(
+            canonical_region,
+            svd_policy,
+            max_bond_dim,
+            context_name,
+            Some(context),
+        )
+    }
+
+    fn truncate_impl_scoped(
+        &mut self,
+        canonical_region: impl IntoIterator<Item = V>,
+        svd_policy: Option<SvdTruncationPolicy>,
+        max_bond_dim: Option<usize>,
+        context_name: &str,
+        context: Option<&tensor4all_tensorbackend::ExecutionContext>,
+    ) -> Result<()>
+    where
+        V: Ord,
+        <T::Index as IndexLike>::Id: Ord,
+    {
         // Validate before the empty-center no-op shortcut so a NaN policy or
         // `max_bond_dim == 0` is rejected on single-node and empty sweeps too.
         validate_svd_truncation_options(max_bond_dim, svd_policy)
@@ -168,11 +208,19 @@ where
         // Step 1: Canonicalize towards the center (required before truncation sweep)
         let canonicalize_options =
             CanonicalizationOptions::default().with_form(CanonicalForm::Unitary);
-        self.canonicalize_impl(
-            [center_node.clone()],
-            canonicalize_options.form,
-            &format!("{}: pre-canonicalize", context_name),
-        )?;
+        match context {
+            Some(execution) => self.canonicalize_impl_in(
+                [center_node.clone()],
+                canonicalize_options.form,
+                &format!("{}: pre-canonicalize", context_name),
+                execution,
+            )?,
+            None => self.canonicalize_impl(
+                [center_node.clone()],
+                canonicalize_options.form,
+                &format!("{}: pre-canonicalize", context_name),
+            )?,
+        }
 
         // Step 2: Generate sweep plan (nsite=2 for two-site truncation)
         let plan = LocalUpdateSweepPlan::from_treetn(self, &center_node, 2)
@@ -187,7 +235,12 @@ where
         }
 
         // Step 3: Apply truncation sweep
-        let mut updater = TruncateUpdater::new(max_bond_dim, svd_policy);
+        let mut updater = match context {
+            Some(execution) => {
+                TruncateUpdater::new_in(max_bond_dim, svd_policy, execution.clone())
+            }
+            None => TruncateUpdater::new(max_bond_dim, svd_policy),
+        };
         apply_local_update_sweep(self, &plan, &mut updater)
             .context(format!("{}: truncation sweep failed", context_name))?;
 

--- a/crates/tensor4all-treetn/tests/cuda_src_contraction.rs
+++ b/crates/tensor4all-treetn/tests/cuda_src_contraction.rs
@@ -464,14 +464,11 @@ fn cuda_src_c64_fixed_chain_probe() {
                 &cpu,
             )
             .unwrap();
-            let got: Vec<Complex64> = result
-                .download(&cuda)
-                .unwrap()
-                .to_dense()
-                .unwrap()
-                .to_vec()
-                .unwrap();
-            let want: Vec<Complex64> = reference.to_dense().unwrap().to_vec().unwrap();
+            let got_dense = result.download(&cuda).unwrap().to_dense().unwrap();
+            let want_dense = reference.to_dense().unwrap();
+            let got_dense = got_dense.permuteinds(want_dense.indices()).unwrap();
+            let got: Vec<Complex64> = got_dense.to_vec().unwrap();
+            let want: Vec<Complex64> = want_dense.to_vec().unwrap();
             assert_eq!(got.len(), want.len());
             let residual = got
                 .iter()

--- a/crates/tensor4all-treetn/tests/cuda_src_contraction.rs
+++ b/crates/tensor4all-treetn/tests/cuda_src_contraction.rs
@@ -1,0 +1,577 @@
+//! CUDA SRC residency and parity matrix (issue #720 PR4b).
+//!
+//! Fixed/adaptive x chain/star-tree x final_svd on/off, all on two
+//! same-context CUDA-resident trees: exact-context residency asserts plus
+//! whole-result parity against the explicit-CPU reference. Rejection paths
+//! (mixed host/CUDA, foreign contexts, legacy entry on resident inputs)
+//! fail before algorithm work begins.
+
+#![cfg(feature = "tenferro-cuda")]
+
+use std::sync::Arc;
+
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+use tenferro_cpu::CpuBackend;
+use tensor4all_core::{
+    CudaExecutionContext, DynIndex, ExecutionContext, IdxTensor, TensorConstructionLike,
+    TensorContractionLike,
+};
+use tensor4all_tensorbackend::CpuExecutionContext;
+use tensor4all_treetn::contraction::{
+    contract, contract_src_with_rng_in, ContractionOptions, SrcOptions,
+};
+use tensor4all_treetn::TreeTN;
+
+/// Rebuild a host tree inside an explicit CPU context, preserving index
+/// identities so topology reconnects. Supports f64 and Complex64 dense
+/// fixtures.
+fn scoped_cpu_copy(
+    tree: &TreeTN<IdxTensor, String>,
+    context: &ExecutionContext,
+) -> TreeTN<IdxTensor, String> {
+    use num_complex::Complex64;
+
+    let names = tree.node_names();
+    let tensors = names
+        .iter()
+        .map(|name| {
+            let node = tree.node_index(name).unwrap();
+            let tensor = tree.tensor(node).unwrap();
+            let indices = tensor.indices().to_vec();
+            if tensor.is_f64() {
+                <IdxTensor as TensorConstructionLike>::from_dense_in(
+                    context,
+                    indices,
+                    tensor.to_vec::<f64>().unwrap(),
+                )
+                .unwrap()
+            } else {
+                <IdxTensor as TensorConstructionLike>::from_dense_in(
+                    context,
+                    indices,
+                    tensor.to_vec::<Complex64>().unwrap(),
+                )
+                .unwrap()
+            }
+        })
+        .collect();
+    TreeTN::from_tensors(tensors, names).unwrap()
+}
+
+fn cuda_context() -> (Arc<CudaExecutionContext>, ExecutionContext) {
+    let cuda = Arc::new(CudaExecutionContext::new().expect("CUDA ordinal 0 must be available"));
+    let context = ExecutionContext::Cuda(Arc::clone(&cuda));
+    (cuda, context)
+}
+
+fn cpu_context() -> ExecutionContext {
+    ExecutionContext::Cpu(Arc::new(CpuExecutionContext::from_backend(
+        CpuBackend::new(),
+    )))
+}
+
+fn make_chain_pair() -> (TreeTN<IdxTensor, String>, TreeTN<IdxTensor, String>) {
+    let shared = (0..3).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+    let output_a = (0..3).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+    let output_b = (0..3).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+    let bonds_a = (0..2).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+    let bonds_b = (0..2).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+    let build = |bonds: &[DynIndex], outputs: &[DynIndex], num: Box<dyn Fn(usize) -> f64>| {
+        TreeTN::from_tensors(
+            vec![
+                IdxTensor::from_dense(
+                    vec![shared[0].clone(), outputs[0].clone(), bonds[0].clone()],
+                    (0..8).map(|x| num(x)).collect(),
+                )
+                .unwrap(),
+                IdxTensor::from_dense(
+                    vec![
+                        bonds[0].clone(),
+                        shared[1].clone(),
+                        outputs[1].clone(),
+                        bonds[1].clone(),
+                    ],
+                    (0..16).map(|x| num(x) / 3.0).collect(),
+                )
+                .unwrap(),
+                IdxTensor::from_dense(
+                    vec![bonds[1].clone(), shared[2].clone(), outputs[2].clone()],
+                    (0..8).map(|x| num(x) / 5.0).collect(),
+                )
+                .unwrap(),
+            ],
+            vec!["A".to_string(), "B".to_string(), "C".to_string()],
+        )
+        .unwrap()
+    };
+    (
+        build(&bonds_a, &output_a, Box::new(|x| x as f64 + 1.0)),
+        build(&bonds_b, &output_b, Box::new(|x| x as f64 + 2.0)),
+    )
+}
+
+fn make_star_pair() -> (TreeTN<IdxTensor, String>, TreeTN<IdxTensor, String>) {
+    let shared = [
+        DynIndex::new_dyn(2),
+        DynIndex::new_dyn(2),
+        DynIndex::new_dyn(2),
+    ];
+    let output_a = [
+        DynIndex::new_dyn(2),
+        DynIndex::new_dyn(2),
+        DynIndex::new_dyn(2),
+    ];
+    let output_b = [
+        DynIndex::new_dyn(2),
+        DynIndex::new_dyn(2),
+        DynIndex::new_dyn(2),
+    ];
+    let bonds_a = [DynIndex::new_dyn(2), DynIndex::new_dyn(2)];
+    let bonds_b = [DynIndex::new_dyn(2), DynIndex::new_dyn(2)];
+    let names = vec!["C".to_string(), "L".to_string(), "R".to_string()];
+    let build = |bonds: &[DynIndex; 2], outputs: &[DynIndex; 3], offset: f64| {
+        TreeTN::from_tensors(
+            vec![
+                IdxTensor::from_dense(
+                    vec![
+                        shared[0].clone(),
+                        outputs[0].clone(),
+                        bonds[0].clone(),
+                        bonds[1].clone(),
+                    ],
+                    (0..16).map(|i| offset + f64::from(i) / 10.0).collect(),
+                )
+                .unwrap(),
+                IdxTensor::from_dense(
+                    vec![shared[1].clone(), outputs[1].clone(), bonds[0].clone()],
+                    (0..8).map(|i| offset + f64::from(i) / 7.0).collect(),
+                )
+                .unwrap(),
+                IdxTensor::from_dense(
+                    vec![shared[2].clone(), outputs[2].clone(), bonds[1].clone()],
+                    (0..8).map(|i| offset + f64::from(i) / 6.0).collect(),
+                )
+                .unwrap(),
+            ],
+            names.clone(),
+        )
+        .unwrap()
+    };
+    (
+        build(&bonds_a, &output_a, 1.0),
+        build(&bonds_b, &output_b, 2.0),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_matrix_case(
+    name: &str,
+    tn_a: &TreeTN<IdxTensor, String>,
+    tn_b: &TreeTN<IdxTensor, String>,
+    center: &str,
+    options: ContractionOptions,
+    seed: u64,
+    tolerance: f64,
+) {
+    let (cuda, context) = cuda_context();
+    let cpu = cpu_context();
+
+    let resident_a = tn_a.upload_cuda(&cuda).unwrap();
+    let resident_b = tn_b.upload_cuda(&cuda).unwrap();
+    resident_a.validate_context(&context).unwrap();
+    resident_b.validate_context(&context).unwrap();
+
+    // CUDA run.
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let result = contract_src_with_rng_in(
+        &resident_a,
+        &resident_b,
+        &center.to_string(),
+        options.clone(),
+        &mut rng,
+        &context,
+    )
+    .unwrap_or_else(|error| panic!("{name}: CUDA SRC failed: {error:?}"));
+
+    // Residency: every output node belongs to the exact caller-owned context,
+    // and host reads fail without explicit download.
+    result.validate_context(&context).unwrap();
+    for node in result.node_indices() {
+        let tensor = result.tensor(node).unwrap();
+        assert!(
+            tensor.to_vec::<f64>().is_err(),
+            "{name}: node tensor is host-readable, residency lost"
+        );
+    }
+
+    // Explicit-CPU reference with identical seeds (same scoped algorithm
+    // family as the CUDA run; only the backend differs).
+    let cpu_a = scoped_cpu_copy(tn_a, &cpu);
+    let cpu_b = scoped_cpu_copy(tn_b, &cpu);
+    let mut cpu_rng = ChaCha8Rng::seed_from_u64(seed);
+    let reference = contract_src_with_rng_in(
+        &cpu_a,
+        &cpu_b,
+        &center.to_string(),
+        options,
+        &mut cpu_rng,
+        &cpu,
+    )
+    .unwrap_or_else(|error| panic!("{name}: CPU reference failed: {error:?}"));
+
+    // Whole-result parity on complete index order. Values are compared as
+    // host vectors (never combined across contexts); the downloaded tensor
+    // is permuted onto the reference index order first.
+    let got = result.download(&cuda).unwrap().to_dense().unwrap();
+    let want = reference.to_dense().unwrap();
+    let mut got_dims = got.dims();
+    let mut want_dims = want.dims();
+    got_dims.sort();
+    want_dims.sort();
+    assert_eq!(got_dims, want_dims, "{name}: dense shapes differ");
+    let got = got.permuteinds(want.indices()).unwrap();
+    assert_eq!(got.indices(), want.indices());
+    let got_values = got.to_vec::<f64>().unwrap();
+    let want_values = want.to_vec::<f64>().unwrap();
+    assert_eq!(got_values.len(), want_values.len());
+    let residual = got_values
+        .iter()
+        .zip(want_values.iter())
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0_f64, f64::max);
+    assert!(
+        residual < tolerance,
+        "{name}: CUDA/CPU parity residual {residual} exceeds {tolerance}"
+    );
+}
+
+fn fixed_options(final_svd: bool) -> ContractionOptions {
+    ContractionOptions::src()
+        .with_max_bond_dim(4)
+        .with_src_options(SrcOptions::fixed().with_final_svd(final_svd))
+}
+
+fn adaptive_options(final_svd: bool) -> ContractionOptions {
+    ContractionOptions::src()
+        .with_max_bond_dim(4)
+        .with_src_options(
+            SrcOptions::adaptive(1.0e-8, 4)
+                .with_min_rank(1)
+                .with_rank_increment(2)
+                .with_final_svd(final_svd),
+        )
+}
+
+#[test]
+#[ignore]
+fn cuda_src_fixed_chain_matches_cpu() {
+    let (tn_a, tn_b) = make_chain_pair();
+    run_matrix_case(
+        "fixed/chain/no-final-svd",
+        &tn_a,
+        &tn_b,
+        "C",
+        fixed_options(false),
+        11,
+        1e-9,
+    );
+    run_matrix_case(
+        "fixed/chain/final-svd",
+        &tn_a,
+        &tn_b,
+        "C",
+        fixed_options(true),
+        11,
+        1e-9,
+    );
+}
+
+#[test]
+#[ignore]
+fn cuda_src_adaptive_chain_matches_cpu() {
+    let (tn_a, tn_b) = make_chain_pair();
+    run_matrix_case(
+        "adaptive/chain/no-final-svd",
+        &tn_a,
+        &tn_b,
+        "C",
+        adaptive_options(false),
+        13,
+        1e-8,
+    );
+    run_matrix_case(
+        "adaptive/chain/final-svd",
+        &tn_a,
+        &tn_b,
+        "C",
+        adaptive_options(true),
+        13,
+        1e-8,
+    );
+}
+
+#[test]
+#[ignore]
+fn cuda_src_fixed_star_matches_cpu() {
+    let (tn_a, tn_b) = make_star_pair();
+    run_matrix_case(
+        "fixed/star/no-final-svd",
+        &tn_a,
+        &tn_b,
+        "C",
+        fixed_options(false),
+        17,
+        1e-9,
+    );
+    run_matrix_case(
+        "fixed/star/final-svd",
+        &tn_a,
+        &tn_b,
+        "C",
+        fixed_options(true),
+        17,
+        1e-9,
+    );
+}
+
+#[test]
+#[ignore]
+fn cuda_src_adaptive_star_matches_cpu() {
+    let (tn_a, tn_b) = make_star_pair();
+    run_matrix_case(
+        "adaptive/star/no-final-svd",
+        &tn_a,
+        &tn_b,
+        "C",
+        adaptive_options(false),
+        19,
+        1e-8,
+    );
+    run_matrix_case(
+        "adaptive/star/final-svd",
+        &tn_a,
+        &tn_b,
+        "C",
+        adaptive_options(true),
+        19,
+        1e-8,
+    );
+}
+
+#[test]
+#[ignore]
+fn cuda_src_rejects_mixed_and_foreign_inputs() {
+    let (cuda, context) = cuda_context();
+    let (tn_a, tn_b) = make_chain_pair();
+    let resident_b = tn_b.upload_cuda(&cuda).unwrap();
+    let options = fixed_options(false);
+
+    // Mixed host/CUDA fails before work.
+    let mut rng = ChaCha8Rng::seed_from_u64(23);
+    assert!(contract_src_with_rng_in(
+        &tn_a,
+        &resident_b,
+        &"C".to_string(),
+        options.clone(),
+        &mut rng,
+        &context
+    )
+    .is_err());
+
+    // Foreign CUDA context fails before work.
+    let foreign = ExecutionContext::Cuda(Arc::new(CudaExecutionContext::new().unwrap()));
+    let resident_a = tn_a.upload_cuda(&cuda).unwrap();
+    let mut rng = ChaCha8Rng::seed_from_u64(23);
+    assert!(contract_src_with_rng_in(
+        &resident_a,
+        &resident_b,
+        &"C".to_string(),
+        options.clone(),
+        &mut rng,
+        &foreign
+    )
+    .is_err());
+
+    // Legacy context-free entry rejects resident inputs.
+    assert!(contract(&resident_a, &resident_b, &"C".to_string(), options,).is_err());
+}
+
+#[test]
+#[ignore]
+fn cuda_src_c64_fixed_chain_probe() {
+    use num_complex::Complex64;
+
+    let (cuda, context) = cuda_context();
+    let cpu = cpu_context();
+    // Two-node C64 chain (mirrors the CPU complex fixture shape).
+    let shared = [DynIndex::new_dyn(2), DynIndex::new_dyn(2)];
+    let output_a = [DynIndex::new_dyn(2), DynIndex::new_dyn(2)];
+    let output_b = [DynIndex::new_dyn(2), DynIndex::new_dyn(2)];
+    let bond_a = DynIndex::new_dyn(2);
+    let bond_b = DynIndex::new_dyn(2);
+    let values = |offset: f64| {
+        (0..8)
+            .map(|i| Complex64::new(offset + f64::from(i), 0.25 * f64::from(i)))
+            .collect::<Vec<_>>()
+    };
+    let build = |bonds: &[DynIndex; 1], outputs: &[DynIndex; 2], offset: f64| {
+        TreeTN::from_tensors(
+            vec![
+                IdxTensor::from_dense(
+                    vec![shared[0].clone(), outputs[0].clone(), bonds[0].clone()],
+                    values(offset),
+                )
+                .unwrap(),
+                IdxTensor::from_dense(
+                    vec![bonds[0].clone(), shared[1].clone(), outputs[1].clone()],
+                    values(offset + 1.0),
+                )
+                .unwrap(),
+            ],
+            vec!["A".to_string(), "B".to_string()],
+        )
+        .unwrap()
+    };
+    let tn_a = build(&[bond_a], &output_a, 1.0);
+    let tn_b = build(&[bond_b], &output_b, 2.0);
+    let resident_a = tn_a.upload_cuda(&cuda).unwrap();
+    let resident_b = tn_b.upload_cuda(&cuda).unwrap();
+    let options = ContractionOptions::src()
+        .with_max_bond_dim(4)
+        .with_src_options(SrcOptions::fixed());
+    let mut rng = ChaCha8Rng::seed_from_u64(29);
+    let result = contract_src_with_rng_in(
+        &resident_a,
+        &resident_b,
+        &"B".to_string(),
+        options.clone(),
+        &mut rng,
+        &context,
+    );
+    match result {
+        Ok(result) => {
+            result.validate_context(&context).unwrap();
+            let cpu_a = scoped_cpu_copy(&tn_a, &cpu);
+            let cpu_b = scoped_cpu_copy(&tn_b, &cpu);
+            let mut cpu_rng = ChaCha8Rng::seed_from_u64(29);
+            let reference = contract_src_with_rng_in(
+                &cpu_a,
+                &cpu_b,
+                &"B".to_string(),
+                options,
+                &mut cpu_rng,
+                &cpu,
+            )
+            .unwrap();
+            let got: Vec<Complex64> = result
+                .download(&cuda)
+                .unwrap()
+                .to_dense()
+                .unwrap()
+                .to_vec()
+                .unwrap();
+            let want: Vec<Complex64> = reference.to_dense().unwrap().to_vec().unwrap();
+            assert_eq!(got.len(), want.len());
+            let residual = got
+                .iter()
+                .zip(want.iter())
+                .map(|(a, b)| (a - b).norm())
+                .fold(0.0_f64, f64::max);
+            println!("C64 chain CUDA/CPU parity residual: {residual:e}");
+            assert!(residual < 1e-9, "C64 parity residual {residual}");
+        }
+        Err(error) => {
+            panic!("C64 fixed CUDA SRC must be supported, got typed error: {error:?}");
+        }
+    }
+}
+
+/// Timing breakdown for the issue #720 evidence report: context setup,
+/// upload, warm-up, synchronized steady-state, and download are reported
+/// separately. Correctness/residency asserts stay outside the timed loops.
+#[test]
+#[ignore]
+fn cuda_src_timing_breakdown() {
+    use std::time::Instant;
+
+    const REPS: usize = 5;
+
+    for (name, options, seed) in [
+        ("fixed/chain", fixed_options(false), 11_u64),
+        ("adaptive/chain", adaptive_options(false), 13_u64),
+    ] {
+        let (tn_a, tn_b) = make_chain_pair();
+
+        let start = Instant::now();
+        let (cuda, context) = cuda_context();
+        let setup_ms = start.elapsed().as_secs_f64() * 1e3;
+
+        let start = Instant::now();
+        let resident_a = tn_a.upload_cuda(&cuda).unwrap();
+        let resident_b = tn_b.upload_cuda(&cuda).unwrap();
+        let upload_ms = start.elapsed().as_secs_f64() * 1e3;
+
+        // Warm-up (JIT + caches), discarded.
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let warm = contract_src_with_rng_in(
+            &resident_a,
+            &resident_b,
+            &"C".to_string(),
+            options.clone(),
+            &mut rng,
+            &context,
+        )
+        .unwrap();
+        cuda.synchronize().unwrap();
+        let warm_ms = start.elapsed().as_secs_f64() * 1e3 - upload_ms;
+        warm.validate_context(&context).unwrap();
+
+        // Synchronized steady-state.
+        let start = Instant::now();
+        for _ in 0..REPS {
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            let result = contract_src_with_rng_in(
+                &resident_a,
+                &resident_b,
+                &"C".to_string(),
+                options.clone(),
+                &mut rng,
+                &context,
+            )
+            .unwrap();
+            cuda.synchronize().unwrap();
+            result.validate_context(&context).unwrap();
+        }
+        let steady_ms = start.elapsed().as_secs_f64() * 1e3 / REPS as f64;
+
+        // Explicit result download.
+        let start = Instant::now();
+        let back = warm.download(&cuda).unwrap();
+        let _ = back.to_dense().unwrap();
+        let download_ms = start.elapsed().as_secs_f64() * 1e3;
+
+        // CPU steady-state reference (explicit context, same seeds).
+        let cpu = cpu_context();
+        let cpu_a = scoped_cpu_copy(&tn_a, &cpu);
+        let cpu_b = scoped_cpu_copy(&tn_b, &cpu);
+        let start = Instant::now();
+        for _ in 0..REPS {
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            let _ = contract_src_with_rng_in(
+                &cpu_a,
+                &cpu_b,
+                &"C".to_string(),
+                options.clone(),
+                &mut rng,
+                &cpu,
+            )
+            .unwrap();
+        }
+        let cpu_ms = start.elapsed().as_secs_f64() * 1e3 / REPS as f64;
+
+        println!(
+            "[{name}] setup={setup_ms:.1}ms upload={upload_ms:.1}ms warmup(first-run, incl. JIT)={warm_ms:.1}ms steady(CUDA,sync)={steady_ms:.2}ms download={download_ms:.1}ms cpu_steady={cpu_ms:.2}ms reps={REPS}"
+        );
+    }
+}

--- a/crates/tensor4all-treetn/tests/src_context_seam.rs
+++ b/crates/tensor4all-treetn/tests/src_context_seam.rs
@@ -1,0 +1,165 @@
+//! CPU tests for the PR4a context seam (issue #720).
+//!
+//! Explicit-CPU construction/validation/factorization routing, exercised
+//! generically through the `TensorLike` traits where SRC will use them.
+
+use std::sync::Arc;
+
+use tenferro_cpu::CpuBackend;
+use tensor4all_core::{
+    factorize_full_rank_in, factorize_in, Canonical, DynIndex, ExecutionContext, FactorizeAlg,
+    FactorizeOptions, IdxTensor, TensorConstructionLike, TensorFactorizationLike,
+};
+use tensor4all_tensorbackend::CpuExecutionContext;
+use tensor4all_treetn::TreeTN;
+
+fn cpu_context() -> ExecutionContext {
+    ExecutionContext::Cpu(Arc::new(CpuExecutionContext::from_backend(
+        CpuBackend::new(),
+    )))
+}
+
+#[test]
+fn generic_construction_and_validation_use_the_supplied_context() {
+    let context = cpu_context();
+    let index = DynIndex::new_dyn(2);
+
+    let dense = <IdxTensor as TensorConstructionLike>::from_dense_in(
+        &context,
+        vec![index.clone()],
+        vec![1.0_f64, 2.0],
+    )
+    .unwrap();
+    let ones =
+        <IdxTensor as TensorConstructionLike>::ones_in(&context, std::slice::from_ref(&index))
+            .unwrap();
+    assert_eq!(ones.to_vec::<f64>().unwrap(), vec![1.0, 1.0]);
+
+    dense.validate_context(&context).unwrap();
+    let foreign = cpu_context();
+    assert!(dense.validate_context(&foreign).is_err());
+
+    let tree = TreeTN::from_tensors(vec![dense], vec![0]).unwrap();
+    tree.validate_context(&context).unwrap();
+    assert!(tree.validate_context(&foreign).is_err());
+
+    // A host-built tree does not belong to an explicit context.
+    let host = IdxTensor::from_dense(vec![index], vec![1.0_f64, 2.0]).unwrap();
+    let host_tree = TreeTN::from_tensors(vec![host], vec![0]).unwrap();
+    assert!(host_tree.validate_context(&context).is_err());
+}
+
+#[test]
+fn factorize_in_matches_host_results_on_explicit_cpu() {
+    let context = cpu_context();
+    let i = DynIndex::new_dyn(6);
+    let j = DynIndex::new_dyn(4);
+    let data: Vec<f64> = (0..24)
+        .map(|k| {
+            let (r, c) = (k % 6, k / 6);
+            if r == c {
+                4.0 + r as f64
+            } else {
+                0.1 * (r + c) as f64
+            }
+        })
+        .collect();
+    let tensor = <IdxTensor as TensorConstructionLike>::from_dense_in(
+        &context,
+        vec![i.clone(), j.clone()],
+        data,
+    )
+    .unwrap();
+
+    // Truncated QR via generic options.
+    let scoped = factorize_in(
+        &tensor,
+        std::slice::from_ref(&i),
+        &FactorizeOptions::qr(),
+        &context,
+    )
+    .unwrap();
+    let host = tensor4all_core::factorize(
+        &tensor4all_core::IdxTensor::from_dense(
+            vec![i.clone(), j.clone()],
+            (0..24)
+                .map(|k| {
+                    let (r, c) = (k % 6, k / 6);
+                    if r == c {
+                        4.0 + r as f64
+                    } else {
+                        0.1 * (r + c) as f64
+                    }
+                })
+                .collect(),
+        )
+        .unwrap(),
+        std::slice::from_ref(&i),
+        &FactorizeOptions::qr(),
+    )
+    .unwrap();
+    assert_eq!(scoped.rank, host.rank);
+    scoped.left.validate_context(&context).unwrap();
+    scoped.right.validate_context(&context).unwrap();
+
+    // Full-rank SVD stays in context.
+    let full = factorize_full_rank_in(
+        &tensor,
+        std::slice::from_ref(&i),
+        FactorizeAlg::SVD,
+        Canonical::Left,
+        &context,
+    )
+    .unwrap();
+    full.left.validate_context(&context).unwrap();
+    full.right.validate_context(&context).unwrap();
+
+    // LU/CI have no scoped path.
+    assert!(factorize_in(
+        &tensor,
+        std::slice::from_ref(&i),
+        &FactorizeOptions::lu(),
+        &context
+    )
+    .is_err());
+
+    // Estimator + incremental batch route through the generic trait surface.
+    let r = scoped.right;
+    let estimate = r.src_error_estimate_in(&context).unwrap();
+    let expected = r.src_error_estimate().unwrap();
+    assert!((estimate.error - expected.error).abs() < 1e-12);
+
+    let batch = DynIndex::new_dyn(2);
+    let block = <IdxTensor as TensorConstructionLike>::from_dense_in(
+        &context,
+        vec![i.clone(), batch.clone()],
+        vec![1.0_f64; 12],
+    )
+    .unwrap();
+    let grown = IdxTensor::factorize_probe_batch_incremental_in(
+        None,
+        &block,
+        &batch,
+        std::slice::from_ref(&i),
+        &context,
+    )
+    .unwrap();
+    assert_eq!(grown.rank, 2);
+    grown.left.validate_context(&context).unwrap();
+}
+
+#[test]
+fn trait_defaults_reject_without_silent_fallback() {
+    // DefaultOnlyTensor-style check via IdxTensor host input + foreign context:
+    // validation must fail, never silently proceed.
+    let context = cpu_context();
+    let host = IdxTensor::from_dense(vec![DynIndex::new_dyn(1)], vec![1.0_f64]).unwrap();
+    assert!(host.validate_context(&context).is_err());
+    assert!(factorize_in(
+        &host,
+        &[DynIndex::new_dyn(1)],
+        &FactorizeOptions::qr(),
+        &context
+    )
+    .is_err());
+}

--- a/docs/book/src/guides/mpo-mpo-contraction.md
+++ b/docs/book/src/guides/mpo-mpo-contraction.md
@@ -365,6 +365,26 @@ single `L d^p chi^q` expression would hide the main trade-off. The Gaussian
 probes are reproducible through `SrcOptions::with_seed` and should be held
 fixed when comparing implementations.
 
+### Running SRC in an explicit execution context
+
+`contract_src_with_rng_in` accepts a caller-owned execution context and runs
+the same schedule against CUDA-resident trees: upload both inputs into one
+`CudaExecutionContext`, validate them, and pass the matching
+`ExecutionContext::Cuda` alongside a caller-seeded RNG. Every tensor the
+algorithm creates stays resident; only bounded decision payloads (singular
+values, norm vectors, stopping scalars) are read back explicitly, and the
+result validates against the exact caller-owned context. Host trees built for
+an explicit CPU context work the same way through `ExecutionContext::Cpu`.
+The context-free `contract`/`contract_src_with_rng` entries keep the
+CPU-global behavior for host inputs and reject resident inputs.
+
+When timing CUDA SRC, report context setup, explicit input upload, probe/cap
+construction transfer, warm-up/JIT, synchronized steady-state, decision
+synchronization, and explicit result download separately: on small problems
+the transfers dominate and a single end-to-end number hides the steady-state
+cost. No CUDA performance claims are made here; the committed benchmark
+runner remains the CPU gate.
+
 ## 6. Summary and comparison
 
 | method | FLOPs (leading) | passes | peak memory | truncation quality |

--- a/scripts/library-panics-baseline.json
+++ b/scripts/library-panics-baseline.json
@@ -1,5 +1,5 @@
 [
-  "crates/tensor4all-core/src/defaults/idx_tensor.rs:7114:debug_assert_eq",
+  "crates/tensor4all-core/src/defaults/idx_tensor.rs:7199:debug_assert_eq",
   "crates/tensor4all-core/src/matrixlu.rs:741:debug_assert_eq",
   "crates/tensor4all-core/src/matrixluci/source.rs:103:assert",
   "crates/tensor4all-core/src/matrixluci/source.rs:108:assert_eq",

--- a/scripts/library-panics-baseline.json
+++ b/scripts/library-panics-baseline.json
@@ -1,5 +1,5 @@
 [
-  "crates/tensor4all-core/src/defaults/idx_tensor.rs:7199:debug_assert_eq",
+  "crates/tensor4all-core/src/defaults/idx_tensor.rs:7211:debug_assert_eq",
   "crates/tensor4all-core/src/matrixlu.rs:741:debug_assert_eq",
   "crates/tensor4all-core/src/matrixluci/source.rs:103:assert",
   "crates/tensor4all-core/src/matrixluci/source.rs:108:assert_eq",


### PR DESCRIPTION
Implements **PR4** of `docs/design/context-scoped-src-contraction.md` for #720: the canonical Rust SRC entry executes against one caller-owned execution context, and every tensor it creates is placement/context coherent.

## What

**New public entry:** `contract_src_with_rng_in(tn_a, tn_b, center, options, rng, context)` — validates both complete input trees against `context` *before* RNG advancement or contraction (mixed host/CUDA and foreign CUDA contexts fail at the boundary with the offending node identified), then runs the unified chain/rooted-tree schedule.

**In-place migration (no scheduling duplication):** chain/tree/probe scheduling functions take a required `&ExecutionContext`. Context-free `T::from_dense`/`T::ones` and unscoped factorization no longer occur in production SRC files. Legacy `contract`/`contract_src_with_rng` inject the process-global CPU context (CPU-global compatibility boundary, bitwise-identical numerics — all 500 treetn + 444 core tests pass unchanged) and reject resident inputs with a typed error.

**Shared seams added along the way** (each needed by the migration, each CPU-tested):
- Trait defaults + `IdxTensor` overrides: `from_dense_in`/`ones_in`/`validate_context` (construction), `factorize_in`/`factorize_full_rank_in`/`factorize` (QR/SVD scoped; LU/CI typed errors), `scale_in`/`norm_in` (scoped scalar arithmetic), `TreeTN::validate_context`.
- `truncate_impl_in` / `canonicalize_impl_in` / `sweep_edge_full_rank_in` / `TruncateUpdater::new_in` (scalar-leaf sweep included via scoped norm transfer).
- Core resident routing: eager N-ary einsum for all-resident sets, plan-based pairwise for resident structured/diagonal pairs, common-runtime wraps for native/structured results, `slice_axis`-based `select_indices`.
- `tensor4all_tensorbackend::{default_cpu_execution_context, ExecutionContext::is_global_default_cpu}` (global-compat boundary helpers).
- Global-CPU callers keep exact legacy numerics via two contained compat branches (host `IncrementalQr` path, scalar-norm transfer); everything else uses scoped primitives.

## Verification (all green)

- `cargo fmt --check`; `cargo clippy --workspace --all-targets` with `-D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc`
- core lib 444, treetn lib 501 (incl. new scalar-leaf sweep test, bitwise vs legacy), core doctests 316, treetn doctests 143 (incl. new `_in` doctests), mdBook guide tests pass, `xtask api-dump` inventory verified, repository-rules review pass, panic audit clean (no new lib panic paths; baseline line-shift updated)
- A100 CUDA matrix (`tenferro` pin `007e3bb`), all with exact-context residency asserts + whole-result parity vs explicit-CPU reference: **f64 fixed/adaptive x chain/star-tree x final_svd on/off** (8 cases, tolerances 1e-9/1e-8), **C64 fixed chain** (1.6e-11; complex QR phase conventions differ, so parity is reconstruction-based), mixed/foreign/legacy-entry rejections fail before work
- New tests: `treetn/tests/cuda_src_contraction.rs` (7 GPU-gated), `treetn/tests/src_context_seam.rs` (3 CPU), core `cuda_context_factorization.rs` (+scale/norm), `context_foundation.rs` (+readback)

## Timing evidence (A100, 3-site fixtures, no performance claims)

`[fixed/chain] setup=197.1ms upload=363.7ms warmup(incl. JIT)=325.1ms steady(CUDA,sync)=6.65ms download=3.7ms cpu_steady=5.75ms`
`[adaptive/chain] setup=0.0ms(cached) upload=227.5ms warmup=441.7ms steady(CUDA,sync)=15.83ms download=0.7ms cpu_steady=17.87ms`
Small-problem transfers dominate; the benchmark guide now documents the separated reporting methodology.

## Review gate

- Pre-implementation design verdict: `reviewer-flash` **Correct-to-implement** (recorded in design doc, covers PR4 scope).
- Post-diff: three narrow `reviewer-flash` rounds (core routing / sweeps+seam / scheduling+tests): all **Correct-to-merge**, 0 blocking. Two findings fixed during review (scalar-leaf sweep rejected explicit CPU → implemented scoped norm transfer with bitwise-legacy test; plus minors), each fix re-verified Correct-to-merge.

## Coverage attestation

New branches (scoped variants, resident routing, compat branches, entry validation) are exercised by the new CPU/doctest/CUDA tests above. Host paths remain covered by the pre-existing suites (all passing, bitwise parity asserted). No thresholds changed.

## Docs

- `contraction.rs` module docs: new "SRC execution contexts" section.
- Benchmark guide (`mpo-mpo-contraction.md`): new "explicit execution context" subsection with CUDA timing methodology; no performance claims.

## Follow-ups (not in this slice)

- Device-side rank guard + dependent-block test for resident incremental QR (documented limitation, carried from PR3).
- Transfer-counter instrumentation ("no unclassified transfer" proof) for the full algorithm.
- C64 adaptive + larger-scale CUDA parity/performance matrix.
- `IdxTensor::scale` global-scalar sibling bug → #623 (generic arithmetic threading).

Closes #720.
