### PR TITLE
Guard rank in CUDA-resident incremental SRC QR

### DIFF
--- a/crates/tensor4all-core/src/defaults/idx_tensor.rs
+++ b/crates/tensor4all-core/src/defaults/idx_tensor.rs
@@ -5827,7 +5827,7 @@ impl TensorFactorizationLike for IdxTensor {
                 left_inds,
             );
         }
-        Self::resident_probe_batch_qr(previous, batch_tensor, batch_index, left_inds)
+        Self::resident_probe_batch_qr(previous, batch_tensor, batch_index, left_inds, context)
     }
 
     fn src_error_estimate(
@@ -5909,6 +5909,7 @@ impl IdxTensor {
         batch_tensor: &IdxTensor,
         batch_index: &DynIndex,
         left_inds: &[DynIndex],
+        context: &ExecutionContext,
     ) -> std::result::Result<FactorizeResult<IdxTensor>, FactorizeError> {
         use crate::defaults::idx_tensor::unfold_split_inner;
 
@@ -5973,11 +5974,51 @@ impl IdxTensor {
                 anyhow::Error::new(error).context("resident probe batch QR failed"),
             )
         })?;
-        let rank = q_full.shape().get(1).copied().ok_or_else(|| {
+        let full_rank = q_full.shape().get(1).copied().ok_or_else(|| {
             FactorizeError::ComputationError(anyhow::anyhow!(
                 "resident probe batch Q factor is not rank-2"
             ))
         })?;
+        let appended_norm = batch_tensor
+            .norm_in(context)
+            .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+        let tolerance = 32.0 * f64::EPSILON * m.max(b) as f64 * appended_norm.max(1.0);
+        let mut rank = 0;
+        for diagonal in 0..full_rank {
+            let scalar = r_full
+                .slice_axis(0, diagonal..diagonal + 1)
+                .and_then(|value| value.slice_axis(1, diagonal..diagonal + 1))
+                .and_then(|value| value.reshape(&[1]))
+                .map_err(|error| {
+                    FactorizeError::ComputationError(
+                        anyhow::Error::new(error).context("resident QR rank guard failed"),
+                    )
+                })?;
+            let scalar = Self::from_inner(vec![DynIndex::new_dyn(1)], scalar)
+                .map_err(FactorizeError::ComputationError)?;
+            let value = scalar
+                .read_decision_data(context)
+                .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?[0]
+                .abs();
+            if !value.is_finite() || value <= tolerance {
+                break;
+            }
+            rank += 1;
+        }
+        if let Some(previous) = previous {
+            if rank < previous.rank {
+                return Err(FactorizeError::ComputationError(anyhow::anyhow!(
+                    "resident SRC QR rank decreased from {} to {rank}",
+                    previous.rank
+                )));
+            }
+        }
+        let q_full = q_full
+            .slice_axis(1, 0..rank)
+            .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+        let r_full = r_full
+            .slice_axis(0, 0..rank)
+            .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
         let cap = DynIndex::new_bond(rank)
             .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
         let batch = DynIndex::new_link(total_width)

--- a/crates/tensor4all-core/tests/cuda_context_factorization.rs
+++ b/crates/tensor4all-core/tests/cuda_context_factorization.rs
@@ -346,6 +346,46 @@ fn probe_cuda_incremental_probe_batch_matches_host() {
 }
 
 #[test]
+fn probe_cuda_incremental_probe_batch_drops_dependent_columns() {
+    use tensor4all_core::{
+        DynIndex, ExecutionContext, IdxTensor, IndexLike, TensorFactorizationLike,
+    };
+
+    let cuda = Arc::new(CudaExecutionContext::new().unwrap());
+    let context = ExecutionContext::Cuda(Arc::clone(&cuda));
+    let row = DynIndex::new_dyn(4);
+    let block_a = DynIndex::new_dyn(1);
+    let block_b = DynIndex::new_dyn(1);
+    let values = vec![1.0, 2.0, 3.0, 4.0];
+    let host_a = IdxTensor::from_dense(vec![row.clone(), block_a.clone()], values.clone()).unwrap();
+    let host_b = IdxTensor::from_dense(vec![row.clone(), block_b.clone()], values).unwrap();
+    let resident_a = host_a.upload_cuda(&cuda).unwrap();
+    let resident_b = host_b.upload_cuda(&cuda).unwrap();
+
+    let first = IdxTensor::factorize_probe_batch_incremental_in(
+        None,
+        &resident_a,
+        &block_a,
+        std::slice::from_ref(&row),
+        &context,
+    )
+    .unwrap();
+    let grown = IdxTensor::factorize_probe_batch_incremental_in(
+        Some(&first),
+        &resident_b,
+        &block_b,
+        std::slice::from_ref(&row),
+        &context,
+    )
+    .unwrap();
+    assert_eq!(first.rank, 1);
+    assert_eq!(grown.rank, 1);
+    assert_eq!(grown.right.indices()[1].dim(), 2);
+    assert!(grown.left.validate_context(&context).is_ok());
+    assert!(grown.right.validate_context(&context).is_ok());
+}
+
+#[test]
 fn cuda_scale_and_norm_in_match_cpu() {
     use tensor4all_core::{DynIndex, ExecutionContext, IdxTensor};
 

--- a/crates/tensor4all-treetn/tests/src_context_seam.rs
+++ b/crates/tensor4all-treetn/tests/src_context_seam.rs
@@ -144,7 +144,7 @@ fn factorize_in_matches_host_results_on_explicit_cpu() {
         &context,
     )
     .unwrap();
-    assert_eq!(grown.rank, 2);
+    assert_eq!(grown.rank, 1);
     grown.left.validate_context(&context).unwrap();
 }
 

--- a/scripts/library-panics-baseline.json
+++ b/scripts/library-panics-baseline.json
@@ -1,5 +1,5 @@
 [
-  "crates/tensor4all-core/src/defaults/idx_tensor.rs:7211:debug_assert_eq",
+  "crates/tensor4all-core/src/defaults/idx_tensor.rs:7252:debug_assert_eq",
   "crates/tensor4all-core/src/matrixlu.rs:741:debug_assert_eq",
   "crates/tensor4all-core/src/matrixluci/source.rs:103:assert",
   "crates/tensor4all-core/src/matrixluci/source.rs:108:assert_eq",


### PR DESCRIPTION
Implements the documented PR5 follow-up for #720: resident incremental QR now applies a rank guard to dependent probe columns without a full host round-trip.

## Changes

- Keeps QR and rank computation in the owning CUDA runtime.
- Reads back only the R diagonal (one bounded scalar per candidate column) for the rank decision.
- Truncates Q/R to the detected rank while preserving the full batch width in R.
- Rejects rank decreases relative to the previous incremental factor.
- Adds a CUDA-gated regression test with a duplicate dependent probe column, checking rank and context residency.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p tensor4all-core --release --lib`
- `cargo test -p tensor4all-core --release --features tenferro-cuda --test cuda_context_factorization -- --include-ignored`

Closes #720.
