### PR TITLE
Use upstream RRQR for resident SRC probes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,10 +86,10 @@ ndarray = "0.17"
 quanticsgrids = { git = "https://github.com/tensor4all/quanticsgrids-rs", rev = "8214b72" }
 hdf5-rt = { git = "https://github.com/tensor4all/hdf5-rt", default-features = false }
 hataori = { git = "https://github.com/shinaoka/hataori-rs.git", rev = "59d0ccd6b403e285b7e716a8ae6d12d851da13b1", default-features = false }
-tenferro = { package = "tenferro-runtime", git = "https://github.com/tensor4all/tenferro-rs.git", rev = "007e3bb6c1187a2569d237b2bc6e6ad486f2b4f4", default-features = false }
-tenferro-ad = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "007e3bb6c1187a2569d237b2bc6e6ad486f2b4f4", default-features = false }
-tenferro-cpu = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "007e3bb6c1187a2569d237b2bc6e6ad486f2b4f4", default-features = false }
-tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "007e3bb6c1187a2569d237b2bc6e6ad486f2b4f4", default-features = false }
-tenferro-linalg = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "007e3bb6c1187a2569d237b2bc6e6ad486f2b4f4", default-features = false }
-tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "007e3bb6c1187a2569d237b2bc6e6ad486f2b4f4", default-features = false }
-tenferro-gpu = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "007e3bb6c1187a2569d237b2bc6e6ad486f2b4f4", default-features = false }
+tenferro = { package = "tenferro-runtime", git = "https://github.com/tensor4all/tenferro-rs.git", rev = "0457a2ed0aeea21b14f4297f7f4731e09b3a0507", default-features = false }
+tenferro-ad = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "0457a2ed0aeea21b14f4297f7f4731e09b3a0507", default-features = false }
+tenferro-cpu = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "0457a2ed0aeea21b14f4297f7f4731e09b3a0507", default-features = false }
+tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "0457a2ed0aeea21b14f4297f7f4731e09b3a0507", default-features = false }
+tenferro-linalg = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "0457a2ed0aeea21b14f4297f7f4731e09b3a0507", default-features = false }
+tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "0457a2ed0aeea21b14f4297f7f4731e09b3a0507", default-features = false }
+tenferro-gpu = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "0457a2ed0aeea21b14f4297f7f4731e09b3a0507", default-features = false }

--- a/crates/tensor4all-core/src/defaults/idx_tensor.rs
+++ b/crates/tensor4all-core/src/defaults/idx_tensor.rs
@@ -19,14 +19,17 @@ use tenferro::{
 };
 use tenferro_ad::{extension::adopt_untracked_eager_value, EagerRuntime, EagerTensor};
 use tenferro_einsum::{EagerEinsumExt, EinsumSubscripts};
-use tenferro_linalg::EagerTensorLinalgExt;
+use tenferro_linalg::{EagerTensorLinalgExt, RankRevealingQrOptions};
 use tensor4all_tensorbackend::{
     contract_native_tensor, default_eager_ctx, dense_native_tensor_from_col_major,
     dense_native_tensor_from_col_major_owned, diag_native_tensor_from_col_major,
     native_tensor_primal_to_diag, storage_payload_native_read_input, storage_to_native_tensor,
     ExecutionContext, NativeTensorReadInput, TensorElement,
 };
-use tensor4all_tensorbackend::{src_error_estimate as backend_src_error_estimate, Matrix};
+use tensor4all_tensorbackend::{
+    src_error_estimate as backend_src_error_estimate,
+    src_error_estimate_general as backend_src_error_estimate_general, Matrix,
+};
 use tensor4all_tensorbackend::{IncrementalQr, IncrementalQrScalar};
 use tensor4all_tensorbackend::{Storage, StorageKind};
 
@@ -5881,29 +5884,61 @@ impl TensorFactorizationLike for IdxTensor {
         if matches!(context, ExecutionContext::Cuda(_)) {
             return self.resident_src_error_estimate(context);
         }
-        #[cfg(not(feature = "tenferro-cuda"))]
-        let _ = context;
-        TensorFactorizationLike::src_error_estimate(self)
+        if context.is_global_default_cpu() {
+            return TensorFactorizationLike::src_error_estimate(self);
+        }
+        self.host_src_error_estimate_general()
     }
 }
 
 impl IdxTensor {
-    /// Resident batch-native probe factorization by full thin-QR recompute.
+    /// Evaluate the SRC estimator for an explicit CPU context's restored factor.
+    fn host_src_error_estimate_general(
+        &self,
+    ) -> std::result::Result<tensor4all_tensorbackend::SrcErrorEstimate, FactorizeError> {
+        let indices = self.indices();
+        if indices.len() != 2 {
+            return Err(FactorizeError::ComputationError(anyhow::anyhow!(
+                "SRC QR factor must have rank 2, got {}",
+                indices.len()
+            )));
+        }
+        let nrows = indices[0].dim();
+        let ncols = indices[1].dim();
+        let result = if self.is_f64() {
+            let matrix = Matrix::from_col_major_vec(
+                nrows,
+                ncols,
+                self.to_vec::<f64>()
+                    .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?,
+            );
+            backend_src_error_estimate_general(&matrix)
+        } else if self.is_c64() {
+            let matrix = Matrix::from_col_major_vec(
+                nrows,
+                ncols,
+                self.to_vec::<Complex64>()
+                    .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?,
+            );
+            backend_src_error_estimate_general(&matrix)
+        } else {
+            return Err(FactorizeError::UnsupportedStorage(
+                "SRC adaptive estimation currently supports f64 and Complex64 QR factors",
+            ));
+        };
+        result.map_err(|error| FactorizeError::ComputationError(anyhow::anyhow!(error)))
+    }
+
+    /// Resident batch-native probe factorization by full RRQR recompute.
     ///
     /// Reconstructs the full sketch block `[Q_prev R_prev, A_new]` with resident
-    /// matmul/concatenation and runs one thin QR in the owning runtime. This
-    /// replaces the host `IncrementalQr` block update without any host
-    /// round-trip: no `IncrementalQrState` is stored, so the adaptive estimator
-    /// solves the full triangular system at each growth step. The recomputed
-    /// factor spans the same column space as the incremental update.
-    ///
-    /// Unlike the host block update, this recompute is not rank-revealing:
-    /// linearly dependent appended columns are retained, so a rank-deficient
-    /// (but not row-saturated) block reports a larger rank than the host path
-    /// and a square R where the host path yields a non-square one. Appended
-    /// SRC probe blocks are iid random draws, for which dependence is
-    /// measure-zero; a device-side rank guard plus a dependent-block test is a
-    /// tracked follow-up, not part of this primitive.
+    /// matmul/concatenation and runs column-pivoted rank-revealing QR in the
+    /// owning runtime. Only the scalar rank metadata is explicitly read back;
+    /// matrix payloads and permutation metadata remain resident. The returned
+    /// right factor is projected back into original sketch-column order, so
+    /// `left * right` reconstructs the unpermuted sketch. Since that right
+    /// factor is not generally triangular, the adaptive estimator uses a
+    /// general solve of the small square sketch factor.
     fn resident_probe_batch_qr(
         previous: Option<&FactorizeResult<IdxTensor>>,
         batch_tensor: &IdxTensor,
@@ -5969,56 +6004,45 @@ impl IdxTensor {
                 "resident sketch factor is not rank-2"
             ))
         })?;
-        let (q_full, r_full) = full_inner.qr().map_err(|error| {
-            FactorizeError::ComputationError(
-                anyhow::Error::new(error).context("resident probe batch QR failed"),
-            )
-        })?;
-        let full_rank = q_full.shape().get(1).copied().ok_or_else(|| {
-            FactorizeError::ComputationError(anyhow::anyhow!(
-                "resident probe batch Q factor is not rank-2"
-            ))
-        })?;
-        let appended_norm = batch_tensor
-            .norm_in(context)
-            .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
-        let tolerance = 32.0 * f64::EPSILON * m.max(b) as f64 * appended_norm.max(1.0);
-        let mut rank = 0;
-        for diagonal in 0..full_rank {
-            let scalar = r_full
-                .slice_axis(0, diagonal..diagonal + 1)
-                .and_then(|value| value.slice_axis(1, diagonal..diagonal + 1))
-                .and_then(|value| value.reshape(&[1]))
-                .map_err(|error| {
-                    FactorizeError::ComputationError(
-                        anyhow::Error::new(error).context("resident QR rank guard failed"),
-                    )
-                })?;
-            let scalar = Self::from_inner(vec![DynIndex::new_dyn(1)], scalar)
-                .map_err(FactorizeError::ComputationError)?;
-            let value = scalar
-                .read_decision_data(context)
-                .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?[0]
-                .abs();
-            if !value.is_finite() || value <= tolerance {
-                break;
-            }
-            rank += 1;
+        let rank_tolerance = 32.0 * f64::EPSILON * m.max(total_width) as f64;
+        let decomposition = full_inner
+            .rank_revealing_qr(RankRevealingQrOptions::default().rtol(rank_tolerance))
+            .map_err(|error| {
+                FactorizeError::ComputationError(
+                    anyhow::Error::new(error).context("resident probe batch RRQR failed"),
+                )
+            })?;
+        let rank = Self::read_resident_rank(&decomposition.rank, context)?;
+        let maximum_rank = m.min(total_width);
+        if rank > maximum_rank {
+            return Err(FactorizeError::ComputationError(anyhow::anyhow!(
+                "resident RRQR returned rank {rank}, exceeding maximum {maximum_rank}"
+            )));
         }
         if let Some(previous) = previous {
             if rank < previous.rank {
                 return Err(FactorizeError::ComputationError(anyhow::anyhow!(
-                    "resident SRC QR rank decreased from {} to {rank}",
+                    "resident SRC RRQR rank decreased from {} to {rank}",
                     previous.rank
                 )));
             }
         }
-        let q_full = q_full
+        let q_full = decomposition
+            .q
             .slice_axis(1, 0..rank)
             .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
-        let r_full = r_full
-            .slice_axis(0, 0..rank)
+        // RRQR factors the pivoted sketch A[:, permutation]. Restore the
+        // original sketch-column order without reading permutation metadata:
+        // Q_rank^H A computes the equivalent right factor entirely resident.
+        let q_adjoint = q_full
+            .transpose(&[1, 0])
+            .and_then(|transposed| transposed.conj())
             .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+        let r_full = q_adjoint.matmul(&full_inner).map_err(|error| {
+            FactorizeError::ComputationError(
+                anyhow::Error::new(error).context("resident RRQR right-factor restoration failed"),
+            )
+        })?;
         let cap = DynIndex::new_bond(rank)
             .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
         let batch = DynIndex::new_link(total_width)
@@ -6089,21 +6113,19 @@ impl IdxTensor {
                 "SRC device estimator requires a CUDA execution context"
             )));
         };
-        // Adjoint R^H of the upper-triangular R is lower-triangular.
+        // RRQR restores original sketch-column order, so the factor is square
+        // but not generally triangular. Solve its adjoint as a general system.
         let adjoint = inner
             .transpose(&[1, 0])
             .and_then(|transposed| transposed.conj())
             .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
         let identity = Self::resident_identity(cuda, nrows, inner.dtype())?;
-        // Solve R^H X = I for X = R^{-†}.
-        let solved = adjoint
-            .triangular_solve(&identity, true, true, false, false)
-            .map_err(|error| {
-                FactorizeError::ComputationError(
-                    anyhow::Error::new(error)
-                        .context("SRC inverse-adjoint triangular solve failed"),
-                )
-            })?;
+        // Solve F^H X = I for X = F^{-†}.
+        let solved = adjoint.solve(&identity).map_err(|error| {
+            FactorizeError::ComputationError(
+                anyhow::Error::new(error).context("SRC inverse-adjoint general solve failed"),
+            )
+        })?;
         let column_sums = solved
             .abs()
             .and_then(|magnitudes| magnitudes.reduce_sum_squares(&[0]))
@@ -6118,6 +6140,52 @@ impl IdxTensor {
         Self::src_estimate_from_decision_scalars(&column_norms_sq, total_norm_sq[0], ncols)
             .map(|(error, norm)| SrcErrorEstimate { error, norm })
             .map_err(FactorizeError::ComputationError)
+    }
+
+    /// Read the scalar integer rank returned by RRQR through its owning context.
+    fn read_resident_rank(
+        rank: &EagerTensor,
+        context: &ExecutionContext,
+    ) -> std::result::Result<usize, FactorizeError> {
+        if !rank.shape().is_empty() {
+            return Err(FactorizeError::ComputationError(anyhow::anyhow!(
+                "resident RRQR rank metadata has shape {:?}, expected []",
+                rank.shape()
+            )));
+        }
+        let resident = rank.to_tensor().map_err(|error| {
+            FactorizeError::ComputationError(
+                anyhow::Error::new(error).context("resident RRQR rank materialization failed"),
+            )
+        })?;
+        #[cfg(feature = "tenferro-cuda")]
+        let host = match context {
+            ExecutionContext::Cpu(_) => resident,
+            ExecutionContext::Cuda(cuda) => cuda.download(&resident).map_err(|error| {
+                FactorizeError::ComputationError(
+                    anyhow::Error::new(error).context("resident RRQR rank download failed"),
+                )
+            })?,
+        };
+        #[cfg(not(feature = "tenferro-cuda"))]
+        let host = match context {
+            ExecutionContext::Cpu(_) => resident,
+        };
+        let values = host.as_slice::<i64>().map_err(|error| {
+            FactorizeError::ComputationError(
+                anyhow::Error::new(error).context("resident RRQR rank decode failed"),
+            )
+        })?;
+        let value = *values.first().ok_or_else(|| {
+            FactorizeError::ComputationError(anyhow::anyhow!(
+                "resident RRQR rank metadata is empty"
+            ))
+        })?;
+        usize::try_from(value).map_err(|error| {
+            FactorizeError::ComputationError(
+                anyhow::Error::new(error).context("resident RRQR rank is negative"),
+            )
+        })
     }
 
     /// Build an `n x n` identity in the operand's owning runtime.

--- a/crates/tensor4all-core/tests/cuda_context_factorization.rs
+++ b/crates/tensor4all-core/tests/cuda_context_factorization.rs
@@ -386,6 +386,118 @@ fn probe_cuda_incremental_probe_batch_drops_dependent_columns() {
 }
 
 #[test]
+fn probe_cuda_rrqr_drops_interspersed_dependence_and_restores_column_order() {
+    use tensor4all_core::{
+        DynIndex, ExecutionContext, IdxTensor, TensorContractionLike, TensorFactorizationLike,
+    };
+
+    let cuda = Arc::new(CudaExecutionContext::new().unwrap());
+    let context = ExecutionContext::Cuda(Arc::clone(&cuda));
+    let row = DynIndex::new_dyn(4);
+    let batch = DynIndex::new_dyn(5);
+    let values = vec![
+        1.0_f64, 0.0, 0.0, 0.0, // independent
+        0.0, 1.0, 0.0, 0.0, // independent
+        2.0, 0.0, 0.0, 0.0, // interspersed dependence
+        0.0, 0.0, 1.0, 0.0, // independent after dependence
+        1.0, 1.0, 1.0, 0.0, // dependent combination
+    ];
+    let host = IdxTensor::from_dense(vec![row.clone(), batch.clone()], values.clone()).unwrap();
+    let resident = host.upload_cuda(&cuda).unwrap();
+    let factor = IdxTensor::factorize_probe_batch_incremental_in(
+        None,
+        &resident,
+        &batch,
+        std::slice::from_ref(&row),
+        &context,
+    )
+    .unwrap();
+
+    assert_eq!(factor.rank, 3);
+    factor.left.validate_context(&context).unwrap();
+    factor.right.validate_context(&context).unwrap();
+    let reconstructed = factor
+        .left
+        .contract_pair(&factor.right)
+        .unwrap()
+        .download(&cuda)
+        .unwrap();
+    let got = reconstructed.to_vec::<f64>().unwrap();
+    let residual = got
+        .iter()
+        .zip(&values)
+        .map(|(actual, expected)| (actual - expected).abs())
+        .fold(0.0_f64, f64::max);
+    assert!(residual < 1.0e-9, "CUDA RRQR residual {residual}");
+}
+
+#[test]
+fn probe_cuda_complex_rrqr_supports_adaptive_square_estimator() {
+    use num_complex::Complex64;
+    use tensor4all_core::{
+        DynIndex, ExecutionContext, IdxTensor, TensorContractionLike, TensorFactorizationLike,
+    };
+
+    let cuda = Arc::new(CudaExecutionContext::new().unwrap());
+    let context = ExecutionContext::Cuda(Arc::clone(&cuda));
+    let row = DynIndex::new_dyn(3);
+    let batch = DynIndex::new_dyn(3);
+    let values = vec![
+        Complex64::new(1.0, 1.0),
+        Complex64::new(0.0, 0.0),
+        Complex64::new(0.0, 0.0),
+        Complex64::new(0.0, 0.0),
+        Complex64::new(4.0, -1.0),
+        Complex64::new(0.0, 0.0),
+        Complex64::new(0.5, 0.0),
+        Complex64::new(0.25, 0.5),
+        Complex64::new(2.0, 0.0),
+    ];
+    let host = IdxTensor::from_dense(vec![row.clone(), batch.clone()], values.clone()).unwrap();
+    let resident = host.upload_cuda(&cuda).unwrap();
+    let factor = IdxTensor::factorize_probe_batch_incremental_in(
+        None,
+        &resident,
+        &batch,
+        std::slice::from_ref(&row),
+        &context,
+    )
+    .unwrap();
+
+    assert_eq!(factor.rank, 3);
+    let reconstructed = factor
+        .left
+        .contract_pair(&factor.right)
+        .unwrap()
+        .download(&cuda)
+        .unwrap();
+    let got = reconstructed.to_vec::<Complex64>().unwrap();
+    let residual = got
+        .iter()
+        .zip(&values)
+        .map(|(actual, expected)| (*actual - *expected).norm())
+        .fold(0.0_f64, f64::max);
+    assert!(residual < 1.0e-9, "CUDA complex RRQR residual {residual}");
+    let estimate = factor.right.src_error_estimate_in(&context).unwrap();
+    let cpu = ExecutionContext::Cpu(Arc::new(
+        tensor4all_tensorbackend::CpuExecutionContext::from_backend(tenferro_cpu::CpuBackend::new()),
+    ));
+    let cpu_sketch =
+        IdxTensor::from_dense_in(&cpu, vec![row.clone(), batch.clone()], values).unwrap();
+    let cpu_factor = IdxTensor::factorize_probe_batch_incremental_in(
+        None,
+        &cpu_sketch,
+        &batch,
+        std::slice::from_ref(&row),
+        &cpu,
+    )
+    .unwrap();
+    let expected = cpu_factor.right.src_error_estimate_in(&cpu).unwrap();
+    assert!((estimate.error - expected.error).abs() < 1.0e-10);
+    assert!((estimate.norm - expected.norm).abs() < 1.0e-10);
+}
+
+#[test]
 fn cuda_scale_and_norm_in_match_cpu() {
     use tensor4all_core::{DynIndex, ExecutionContext, IdxTensor};
 

--- a/crates/tensor4all-core/tests/resident_rrqr.rs
+++ b/crates/tensor4all-core/tests/resident_rrqr.rs
@@ -1,0 +1,122 @@
+use num_complex::Complex64;
+use std::sync::Arc;
+use tenferro_cpu::CpuBackend;
+use tensor4all_core::{
+    DynIndex, ExecutionContext, IdxTensor, IndexLike, TensorContractionLike,
+    TensorFactorizationLike,
+};
+use tensor4all_tensorbackend::CpuExecutionContext;
+
+#[test]
+fn resident_probe_factorization_uses_upstream_rrqr_and_rank_only_readback() {
+    let source = include_str!("../src/defaults/idx_tensor.rs");
+    let start = source
+        .find("    fn resident_probe_batch_qr(")
+        .expect("resident RRQR function");
+    let end = source[start..]
+        .find("    fn resident_src_error_estimate(")
+        .map(|offset| start + offset)
+        .expect("next resident SRC function");
+    let section = &source[start..end];
+    assert!(section.contains(".rank_revealing_qr("));
+    assert!(!section.contains(".qr()"));
+    assert_eq!(section.matches("read_resident_rank(").count(), 1);
+    assert!(!section.contains("read_decision_data("));
+    assert!(!section.contains("column_permutation.to_tensor"));
+}
+
+fn explicit_cpu_context() -> ExecutionContext {
+    ExecutionContext::Cpu(Arc::new(CpuExecutionContext::from_backend(
+        CpuBackend::new(),
+    )))
+}
+
+#[test]
+fn explicit_cpu_rrqr_drops_interspersed_dependent_columns_and_restores_order() {
+    let context = explicit_cpu_context();
+    let row = DynIndex::new_dyn(4);
+    let batch = DynIndex::new_dyn(5);
+    // Columns 0, 1, and 3 are independent; column 2 is interspersed
+    // dependence and column 4 is their linear combination.
+    let values = vec![
+        1.0_f64, 0.0, 0.0, 0.0, // column 0
+        0.0, 1.0, 0.0, 0.0, // column 1
+        2.0, 0.0, 0.0, 0.0, // column 2
+        0.0, 0.0, 1.0, 0.0, // column 3
+        1.0, 1.0, 1.0, 0.0, // column 4
+    ];
+    for scale in [1.0e-100, 1.0, 1.0e100] {
+        let scaled = values.iter().map(|value| value * scale).collect::<Vec<_>>();
+        let sketch =
+            IdxTensor::from_dense_in(&context, vec![row.clone(), batch.clone()], scaled.clone())
+                .unwrap();
+
+        let factor = IdxTensor::factorize_probe_batch_incremental_in(
+            None,
+            &sketch,
+            &batch,
+            std::slice::from_ref(&row),
+            &context,
+        )
+        .unwrap();
+
+        assert_eq!(factor.rank, 3, "scale {scale:e}");
+        assert_eq!(factor.left.indices()[1].dim(), 3);
+        assert_eq!(factor.right.indices()[1].dim(), 5);
+        let reconstruction = factor.left.contract_pair(&factor.right).unwrap();
+        let got = reconstruction.to_vec::<f64>().unwrap();
+        let relative_residual = got
+            .iter()
+            .zip(&scaled)
+            .map(|(actual, expected)| (actual - expected).abs() / scale)
+            .fold(0.0_f64, f64::max);
+        assert!(
+            relative_residual < 1.0e-12,
+            "RRQR relative residual {relative_residual} at scale {scale:e}"
+        );
+    }
+}
+
+#[test]
+fn explicit_cpu_complex_rrqr_restores_order_and_supports_square_estimator() {
+    let context = explicit_cpu_context();
+    let row = DynIndex::new_dyn(3);
+    let batch = DynIndex::new_dyn(3);
+    // Column norms force a non-identity pivot while the original factor remains
+    // full rank and therefore eligible for the SRC square-factor estimator.
+    let values = vec![
+        Complex64::new(1.0, 1.0),
+        Complex64::new(0.0, 0.0),
+        Complex64::new(0.0, 0.0),
+        Complex64::new(0.0, 0.0),
+        Complex64::new(4.0, -1.0),
+        Complex64::new(0.0, 0.0),
+        Complex64::new(0.5, 0.0),
+        Complex64::new(0.25, 0.5),
+        Complex64::new(2.0, 0.0),
+    ];
+    let sketch =
+        IdxTensor::from_dense_in(&context, vec![row.clone(), batch.clone()], values.clone())
+            .unwrap();
+    let factor = IdxTensor::factorize_probe_batch_incremental_in(
+        None,
+        &sketch,
+        &batch,
+        std::slice::from_ref(&row),
+        &context,
+    )
+    .unwrap();
+
+    assert_eq!(factor.rank, 3);
+    let reconstruction = factor.left.contract_pair(&factor.right).unwrap();
+    let got = reconstruction.to_vec::<Complex64>().unwrap();
+    let residual = got
+        .iter()
+        .zip(&values)
+        .map(|(actual, expected)| (*actual - *expected).norm())
+        .fold(0.0_f64, f64::max);
+    assert!(residual < 1.0e-12, "complex RRQR residual {residual}");
+    let estimate = factor.right.src_error_estimate_in(&context).unwrap();
+    assert!(estimate.error.is_finite() && estimate.error > 0.0);
+    assert!(estimate.norm.is_finite() && estimate.norm > 0.0);
+}

--- a/crates/tensor4all-tensorbackend/src/backend.rs
+++ b/crates/tensor4all-tensorbackend/src/backend.rs
@@ -393,8 +393,9 @@ pub struct SrcErrorEstimate {
 ///
 /// # Errors
 ///
-/// Returns [`BackendLinalgError`] when `r` is empty, non-square, singular, or
-/// contains non-finite values, or when the backend triangular solve fails.
+/// Returns [`BackendLinalgError`] when `r` is empty, non-square,
+/// non-triangular, singular, or contains non-finite values, or when the backend
+/// triangular solve fails.
 ///
 /// # Examples
 ///
@@ -414,6 +415,68 @@ where
 {
     let inverse_adjoint = src_inverse_adjoint(r)?;
     src_error_estimate_from_inverse_adjoint(r, &inverse_adjoint)
+}
+
+/// Compute the Appendix C SRC estimates from a general square sketch factor.
+///
+/// This variant is equivalent to [`src_error_estimate`] but uses a general
+/// solve for factors whose columns have been restored from pivoted QR order.
+/// The matrix is a small SRC sketch factor, not a full tensor materialization.
+///
+/// # Errors
+///
+/// Returns [`BackendLinalgError`] when `factor` is empty, non-square, singular,
+/// contains non-finite values, or when the configured general solve fails.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_tensorbackend::{src_error_estimate_general, Matrix};
+///
+/// let factor = Matrix::from_col_major_vec(2, 2, vec![0.0_f64, 3.0, 2.0, 1.0]);
+/// let estimate = src_error_estimate_general(&factor).unwrap();
+/// assert!(estimate.error.is_finite());
+/// assert!((estimate.norm - (14.0_f64 / 2.0).sqrt()).abs() < 1.0e-12);
+/// ```
+pub fn src_error_estimate_general<T>(
+    factor: &Matrix<T>,
+) -> std::result::Result<SrcErrorEstimate, BackendLinalgError>
+where
+    T: MatrixSolveScalar + ComplexFloat,
+{
+    let nrows = factor.nrows();
+    let ncols = factor.ncols();
+    if nrows != ncols {
+        return Err(BackendLinalgError::from(anyhow!(
+            "SRC estimator requires a square factor, got {nrows}x{ncols}"
+        )));
+    }
+    if nrows == 0 {
+        return Err(BackendLinalgError::from(anyhow!(
+            "SRC estimator requires a non-empty factor"
+        )));
+    }
+    if factor
+        .as_col_major_slice()
+        .iter()
+        .any(|value| !value.matrix_abs_sq().is_finite())
+    {
+        return Err(BackendLinalgError::from(anyhow!(
+            "SRC estimator requires finite entries in its factor"
+        )));
+    }
+    let mut adjoint = Matrix::zeros(nrows, ncols);
+    let mut identity = Matrix::zeros(nrows, ncols);
+    for col in 0..ncols {
+        for row in 0..nrows {
+            adjoint[[row, col]] = factor[[col, row]].conj();
+        }
+        identity[[col, col]] = T::one();
+    }
+    let inverse_adjoint = solve_matrix(&adjoint, &identity).map_err(|error| {
+        BackendLinalgError::from(anyhow!("SRC inverse-adjoint general solve failed: {error}"))
+    })?;
+    src_error_estimate_from_inverse_adjoint(factor, &inverse_adjoint)
 }
 
 /// Compute the inverse adjoint `R^{-†}` used by the Appendix C estimator.
@@ -454,6 +517,13 @@ where
                 "SRC estimator requires a finite, nonzero diagonal in R at ({col}, {col})"
             )));
         }
+        for row in col + 1..nrows {
+            if r[[row, col]].matrix_abs_sq() != 0.0 {
+                return Err(BackendLinalgError::from(anyhow!(
+                    "SRC triangular estimator requires upper-triangular R; entry ({row}, {col}) is nonzero"
+                )));
+            }
+        }
     }
 
     let mut adjoint = Matrix::zeros(nrows, ncols);
@@ -486,7 +556,7 @@ pub(crate) fn src_error_estimate_from_inverse_adjoint<T>(
     inverse_adjoint: &Matrix<T>,
 ) -> std::result::Result<SrcErrorEstimate, BackendLinalgError>
 where
-    T: MatrixTriangularSolveScalar + ComplexFloat,
+    T: crate::matrix::MatrixScalar + ComplexFloat,
 {
     let nrows = r.nrows();
     let ncols = r.ncols();

--- a/crates/tensor4all-tensorbackend/src/backend/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/backend/tests/mod.rs
@@ -49,6 +49,66 @@ fn src_error_estimate_rejects_singular_and_non_square_r() {
     let non_square = Matrix::from_col_major_vec(2, 3, vec![1.0_f64, 0.0, 0.0, 1.0, 0.0, 0.0]);
     let shape_error = src_error_estimate(&non_square).unwrap_err();
     assert!(shape_error.to_string().contains("square"));
+
+    let non_triangular = Matrix::from_col_major_vec(2, 2, vec![1.0_f64, 1.0, 0.0, 1.0]);
+    let triangular_error = src_error_estimate(&non_triangular).unwrap_err();
+    assert!(triangular_error.to_string().contains("upper-triangular"));
+}
+
+#[test]
+fn src_error_estimate_general_accepts_column_restored_factors() {
+    let triangular = Matrix::from_col_major_vec(2, 2, vec![2.0_f64, 0.0, 1.0, 3.0]);
+    let restored = Matrix::from_col_major_vec(2, 2, vec![1.0_f64, 3.0, 2.0, 0.0]);
+    let expected = src_error_estimate(&triangular).unwrap();
+    let actual = src_error_estimate_general(&restored).unwrap();
+    assert!((actual.error - expected.error).abs() < 1.0e-12);
+    assert!((actual.norm - expected.norm).abs() < 1.0e-12);
+
+    let triangular_complex = Matrix::from_col_major_vec(
+        2,
+        2,
+        vec![
+            Complex64::new(2.0, 0.0),
+            Complex64::zero(),
+            Complex64::new(1.0, 2.0),
+            Complex64::new(3.0, -1.0),
+        ],
+    );
+    let restored_complex = Matrix::from_col_major_vec(
+        2,
+        2,
+        vec![
+            Complex64::new(1.0, 2.0),
+            Complex64::new(3.0, -1.0),
+            Complex64::new(2.0, 0.0),
+            Complex64::zero(),
+        ],
+    );
+    let expected = src_error_estimate(&triangular_complex).unwrap();
+    let actual = src_error_estimate_general(&restored_complex).unwrap();
+    assert!((actual.error - expected.error).abs() < 1.0e-12);
+    assert!((actual.norm - expected.norm).abs() < 1.0e-12);
+}
+
+#[test]
+fn src_error_estimate_general_rejects_invalid_factors() {
+    let empty = Matrix::<f64>::zeros(0, 0);
+    assert!(src_error_estimate_general(&empty)
+        .unwrap_err()
+        .to_string()
+        .contains("non-empty"));
+    let non_square = Matrix::from_col_major_vec(1, 2, vec![1.0_f64, 2.0]);
+    assert!(src_error_estimate_general(&non_square)
+        .unwrap_err()
+        .to_string()
+        .contains("square"));
+    let singular = Matrix::from_col_major_vec(2, 2, vec![1.0_f64, 2.0, 2.0, 4.0]);
+    assert!(src_error_estimate_general(&singular).is_err());
+    let non_finite = Matrix::from_col_major_vec(1, 1, vec![f64::NAN]);
+    assert!(src_error_estimate_general(&non_finite)
+        .unwrap_err()
+        .to_string()
+        .contains("finite"));
 }
 
 #[test]

--- a/crates/tensor4all-tensorbackend/src/lib.rs
+++ b/crates/tensor4all-tensorbackend/src/lib.rs
@@ -48,10 +48,10 @@ pub use any_scalar::BackendScalar;
 #[cfg(feature = "global-defaults")]
 pub use backend::{
     full_piv_lu_backend, full_piv_lu_matrix, qr_backend, solve_backend, solve_matrix,
-    solve_matrix_owned, src_error_estimate, svd_backend, triangular_solve_backend,
-    triangular_solve_matrix, triangular_solve_matrix_owned, BackendLinalgError,
-    BackendLinalgScalar, FullPivLuMatrixResult, FullPivLuResult, FullPivLuScalar,
-    MatrixSolveScalar, MatrixTriangularSolveScalar, SrcErrorEstimate, SvdResult,
+    solve_matrix_owned, src_error_estimate, src_error_estimate_general, svd_backend,
+    triangular_solve_backend, triangular_solve_matrix, triangular_solve_matrix_owned,
+    BackendLinalgError, BackendLinalgScalar, FullPivLuMatrixResult, FullPivLuResult,
+    FullPivLuScalar, MatrixSolveScalar, MatrixTriangularSolveScalar, SrcErrorEstimate, SvdResult,
 };
 #[cfg(feature = "global-defaults")]
 pub use context::{

--- a/crates/tensor4all-treetn/tests/cuda_src_contraction.rs
+++ b/crates/tensor4all-treetn/tests/cuda_src_contraction.rs
@@ -399,7 +399,7 @@ fn cuda_src_rejects_mixed_and_foreign_inputs() {
 
 #[test]
 #[ignore]
-fn cuda_src_c64_fixed_chain_probe() {
+fn cuda_src_c64_fixed_and_adaptive_chain_probe() {
     use num_complex::Complex64;
 
     let (cuda, context) = cuda_context();
@@ -437,50 +437,62 @@ fn cuda_src_c64_fixed_chain_probe() {
     let tn_b = build(&[bond_b], &output_b, 2.0);
     let resident_a = tn_a.upload_cuda(&cuda).unwrap();
     let resident_b = tn_b.upload_cuda(&cuda).unwrap();
-    let options = ContractionOptions::src()
-        .with_max_bond_dim(4)
-        .with_src_options(SrcOptions::fixed());
-    let mut rng = ChaCha8Rng::seed_from_u64(29);
-    let result = contract_src_with_rng_in(
-        &resident_a,
-        &resident_b,
-        &"B".to_string(),
-        options.clone(),
-        &mut rng,
-        &context,
-    );
-    match result {
-        Ok(result) => {
-            result.validate_context(&context).unwrap();
-            let cpu_a = scoped_cpu_copy(&tn_a, &cpu);
-            let cpu_b = scoped_cpu_copy(&tn_b, &cpu);
-            let mut cpu_rng = ChaCha8Rng::seed_from_u64(29);
-            let reference = contract_src_with_rng_in(
-                &cpu_a,
-                &cpu_b,
-                &"B".to_string(),
-                options,
-                &mut cpu_rng,
-                &cpu,
-            )
-            .unwrap();
-            let got_dense = result.download(&cuda).unwrap().to_dense().unwrap();
-            let want_dense = reference.to_dense().unwrap();
-            let got_dense = got_dense.permuteinds(want_dense.indices()).unwrap();
-            let got: Vec<Complex64> = got_dense.to_vec().unwrap();
-            let want: Vec<Complex64> = want_dense.to_vec().unwrap();
-            assert_eq!(got.len(), want.len());
-            let residual = got
-                .iter()
-                .zip(want.iter())
-                .map(|(a, b)| (a - b).norm())
-                .fold(0.0_f64, f64::max);
-            println!("C64 chain CUDA/CPU parity residual: {residual:e}");
-            assert!(residual < 1e-9, "C64 parity residual {residual}");
-        }
-        Err(error) => {
-            panic!("C64 fixed CUDA SRC must be supported, got typed error: {error:?}");
-        }
+    for (mode, options, seed) in [
+        (
+            "fixed",
+            ContractionOptions::src()
+                .with_max_bond_dim(4)
+                .with_src_options(SrcOptions::fixed()),
+            29_u64,
+        ),
+        (
+            "adaptive",
+            ContractionOptions::src()
+                .with_max_bond_dim(4)
+                .with_src_options(
+                    SrcOptions::adaptive(1.0e-8, 4)
+                        .with_min_rank(1)
+                        .with_rank_increment(2),
+                ),
+            31_u64,
+        ),
+    ] {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let result = contract_src_with_rng_in(
+            &resident_a,
+            &resident_b,
+            &"B".to_string(),
+            options.clone(),
+            &mut rng,
+            &context,
+        )
+        .unwrap_or_else(|error| panic!("C64 {mode} CUDA SRC failed: {error:?}"));
+        result.validate_context(&context).unwrap();
+        let cpu_a = scoped_cpu_copy(&tn_a, &cpu);
+        let cpu_b = scoped_cpu_copy(&tn_b, &cpu);
+        let mut cpu_rng = ChaCha8Rng::seed_from_u64(seed);
+        let reference = contract_src_with_rng_in(
+            &cpu_a,
+            &cpu_b,
+            &"B".to_string(),
+            options,
+            &mut cpu_rng,
+            &cpu,
+        )
+        .unwrap_or_else(|error| panic!("C64 {mode} CPU SRC failed: {error:?}"));
+        let got_dense = result.download(&cuda).unwrap().to_dense().unwrap();
+        let want_dense = reference.to_dense().unwrap();
+        let got_dense = got_dense.permuteinds(want_dense.indices()).unwrap();
+        let got: Vec<Complex64> = got_dense.to_vec().unwrap();
+        let want: Vec<Complex64> = want_dense.to_vec().unwrap();
+        assert_eq!(got.len(), want.len());
+        let residual = got
+            .iter()
+            .zip(want.iter())
+            .map(|(a, b)| (a - b).norm())
+            .fold(0.0_f64, f64::max);
+        println!("C64 {mode} chain CUDA/CPU parity residual: {residual:e}");
+        assert!(residual < 1e-8, "C64 {mode} parity residual {residual}");
     }
 }
 

--- a/docs/design/context-scoped-src-contraction.md
+++ b/docs/design/context-scoped-src-contraction.md
@@ -10,12 +10,12 @@ process-global CPU eager runtime. Combining the resulting tensors with inputs
 uploaded into a caller-selected `CudaExecutionContext` therefore crosses both
 placement and eager-runtime identities.
 
-On an NVIDIA A100, same-context CUDA pairwise contraction succeeds, while the
-first general SRC contraction reaches a CPU extension and fails because its
-operand is device-resident. CUDA eager QR/SVD also fail on the current pin even
-though current tenferro direct CUDA-session QR/SVD kernels pass. The upstream
-prerequisite is the separately reviewed placement-aware eager extension
-dispatch design in tenferro.
+The original NVIDIA A100 baseline reached a CPU extension from general SRC and
+failed on a device-resident operand. The merged context-aware execution phases
+removed that fallback. The final rank-revealing follow-up pins tenferro commit
+`0457a2ed0aeea21b14f4297f7f4731e09b3a0507`, whose eager extension provides
+fixed-output, traced-compatible RRQR on CPU-faer, CPU-BLAS/LAPACK, and native
+CUDA.
 
 ## Invariants
 
@@ -95,7 +95,7 @@ checked without using them.
 Make the factorization operations required by SRC context-aware before changing
 SRC itself:
 
-- QR, including incremental probe QR;
+- QR and column-pivoted RRQR for incremental probe factorization;
 - SVD and device-resident slicing/truncation;
 - the Appendix-C adaptive SRC error estimate;
 - final-SVD factor absorption.
@@ -111,9 +111,10 @@ singular-value vector on host to choose rank. Current
 CUDA SRC.
 
 Replace the adaptive estimator's CPU fallback with eager operations in the
-same runtime: form `R†`, solve the triangular system there, compute norm terms
-there, and read back only the bounded scalar/vector decision payload needed by
-Rust control flow. SVD factors and slicing remain resident; only singular
+same runtime: form the sketch factor's adjoint, solve the small square general
+system there (the factor is restored from RRQR pivot order and is not generally
+triangular), compute norm terms there, and read back only the bounded
+scalar/vector decision payload needed by Rust control flow. SVD factors and slicing remain resident; only singular
 values needed for rank selection/public diagnostics cross the explicit
 `read_decision_data` boundary. Validate results after each factorization and
 slice.
@@ -168,6 +169,7 @@ or results.
 
 Decision readbacks are a separate category and are limited to:
 
+- the scalar I64 rank returned by RRQR (permutation metadata stays resident);
 - singular values needed to choose/return retained rank;
 - final scalar estimates required by adaptive stopping.
 
@@ -245,8 +247,25 @@ than adding local compatibility shims.
 - A process-global CUDA registry or thread-local current device.
 - Migrating every tensor4all algorithm to explicit contexts in #720; the seam
   is reusable and #623 owns subsequent entry-point migrations.
-- Changing tolerances, AD rules, structured-storage semantics, or index
-  equality.
+- Changing AD rules, structured-storage semantics, or index equality.
+
+## Rank-revealing QR follow-up
+
+The transitional resident rank guard inspected successive diagonal entries of
+non-pivoted QR and therefore could miss independent columns after an
+interspersed dependent column. The follow-up replaces that loop with upstream
+column-pivoted RRQR. Its scale-invariant SRC policy is
+`rtol = 32 * f64::EPSILON * max(rows, columns)` and `atol = 0`; rank is the
+strict leading RRQR diagonal prefix defined by tenferro. Only the scalar rank
+is explicitly synchronized to host control flow.
+
+RRQR returns `A[:, permutation] = Q R`. To retain the tensor4all factorization
+contract without downloading permutation metadata, tensor4all computes
+`right = Q_rank^H A` in the owning context. This restores the original sketch
+column order. The resulting square right factor is generally non-triangular,
+so the Appendix-C estimator uses a general solve for this small sketch matrix;
+the legacy global-CPU `IncrementalQr` path and its triangular update remain
+unchanged.
 
 ## Review and verification gates
 

--- a/docs/worklogs/2026-09-05-resident-src-rrqr-integration.md
+++ b/docs/worklogs/2026-09-05-resident-src-rrqr-integration.md
@@ -1,0 +1,71 @@
+# Resident SRC RRQR integration
+
+## Summary
+
+Replaces tensor4all's transitional non-pivoted resident QR diagonal guard with
+tenferro's merged traced-compatible rank-revealing QR. All seven tenferro git
+dependencies are pinned to merged commit
+`0457a2ed0aeea21b14f4297f7f4731e09b3a0507`.
+
+## Code and documents reviewed
+
+- `docs/design/context-scoped-src-contraction.md`
+- tenferro `docs/design/rank-revealing-qr.md` and the merged RRQR public API
+- `IdxTensor::factorize_probe_batch_incremental_in`,
+  `resident_probe_batch_qr`, and `resident_src_error_estimate`
+- `tensor4all-tensorbackend` Appendix-C estimator and matrix solve APIs
+- chain/tree adaptive SRC factorization callers and CPU/CUDA integration tests
+
+## Decisions
+
+- Explicit contexts use upstream RRQR with
+  `rtol = 32 * f64::EPSILON * max(rows, columns)` and `atol = 0`.
+  This is scale-invariant and detects independent columns after interspersed
+  dependence. The process-global CPU compatibility path remains unchanged.
+- Only RRQR's scalar I64 rank is read through the caller-owned context.
+  Q, R, permutation, and matrix payloads remain resident; permutation is never
+  downloaded.
+- Since tenferro defines `A[:, permutation] = Q R`, tensor4all restores its
+  original-column reconstruction contract as `right = Q_rank^H A`, entirely in
+  the owning runtime.
+- The restored square factor is not generally triangular. A separate
+  `src_error_estimate_general` uses the existing configured general matrix
+  solve for host factors, while the CUDA estimator switches from triangular to
+  general eager solve. The old triangular helper remains intact for
+  `IncrementalQr` and its hot path and now explicitly rejects non-triangular
+  input instead of silently applying triangular-solve semantics.
+
+## Rejected alternatives
+
+- Keeping the diagonal-prefix heuristic: fails for interspersed dependence.
+- Downloading permutation metadata and reordering on CPU: violates residency
+  and the rank-only readback contract.
+- Returning pivoted sketch-column order: breaks `left * right` reconstruction
+  semantics and CPU/CUDA reference parity.
+- Fixed maximum rank plus masks: changes variable bond dimensions and is not
+  required by RRQR's fixed output shapes.
+
+## Verification performed
+
+- Explicit CPU-faer and system-BLAS resident RRQR tests: real interspersed
+  dependence, complex reconstruction, square estimator, and source contract.
+- General estimator tests: real/complex column-restored factors plus empty,
+  non-square, singular, and non-finite errors.
+- CUDA hardware: complete context-factorization suite; real interspersed
+  dependence; complex reconstruction and adaptive square estimator; complete
+  fixed/adaptive chain/star/final-SVD SRC matrix; mixed/foreign rejection.
+- CPU SRC-focused suite and context-seam tests.
+
+## Review gate
+
+- Design basis: `docs/design/context-scoped-src-contraction.md` plus tenferro's
+  independently approved `docs/design/rank-revealing-qr.md`.
+- Post-diff reviewer: `reviewer-flash` (DeepSeek family, read-only).
+- Verdict: **Correct-to-merge**, no blocking findings. Follow-up review notes
+  were fixed: legacy/global estimator routing was kept on the original
+  triangular helper, complex CUDA estimator gained direct CPU numerical
+  parity, and the triangular helper now rejects non-triangular factors. The
+  final delta verdict was **APPROVE**, no blocking findings.
+
+Full repository formatting, lint, doctest, mdBook, API inventory, repository
+rules, coverage-impact, and CI/PR evidence are recorded before merge.

--- a/scripts/library-panics-baseline.json
+++ b/scripts/library-panics-baseline.json
@@ -1,5 +1,5 @@
 [
-  "crates/tensor4all-core/src/defaults/idx_tensor.rs:7252:debug_assert_eq",
+  "crates/tensor4all-core/src/defaults/idx_tensor.rs:7320:debug_assert_eq",
   "crates/tensor4all-core/src/matrixlu.rs:741:debug_assert_eq",
   "crates/tensor4all-core/src/matrixluci/source.rs:103:assert",
   "crates/tensor4all-core/src/matrixluci/source.rs:108:assert_eq",


### PR DESCRIPTION
## Summary

- pin all seven tenferro dependencies to merged RRQR commit `0457a2ed0aeea21b14f4297f7f4731e09b3a0507`
- replace the transitional resident non-pivoted diagonal rank guard with upstream column-pivoted RRQR
- read back only RRQR's scalar I64 rank; keep Q/R/permutation and payloads resident
- restore original sketch-column order as `Q_rank^H A` in the owning context
- add a general small-square-factor Appendix-C estimator for restored factors while preserving the legacy global-CPU triangular path
- cover interspersed dependence, scale invariance, complex factors, and C64 adaptive CUDA SRC

## Design and review

Design: `docs/design/context-scoped-src-contraction.md` and upstream tenferro `docs/design/rank-revealing-qr.md`.
Worklog: `docs/worklogs/2026-09-05-resident-src-rrqr-integration.md`.

Post-diff review: `reviewer-flash` (DeepSeek family, read-only), **Correct-to-merge**, no blocking findings. All review notes were fixed and re-reviewed; final verdict **APPROVE**.

## Verification

- `cargo fmt --all -- --check`
- workspace clippy with warnings/missing-doc lints denied
- `cargo nextest run --cargo-profile ci --workspace --exclude tensor4all-hdf5`: **3324 passed, 20 skipped**
- HDF5 CI-profile tests: **57 passed, 4 ignored**
- workspace CI-profile doctests: **1010 passed**
- `cargo doc --workspace --no-deps`
- `./scripts/test-mdbook.sh`
- `cargo run -p xtask --release -- api-dump`
- repository rules deterministic review: pass; script self-tests **90 passed**
- public-error-docs: pass
- CPU-faer resident RRQR integration: **3 passed**
- system-BLAS resident RRQR integration (OpenBLAS link): **3 passed**
- CUDA context factorization hardware suite: **8 passed**
- CUDA SRC hardware matrix: **7 passed**, including fixed/adaptive chain/star, final-SVD on/off, and C64 fixed+adaptive

## Coverage impact

Reviewed all removed local-heuristic branches and replacement paths. New tests exercise upstream RRQR routing, scalar rank decoding, real/complex reconstruction, interspersed dependence, extreme scaling, general-estimator acceptance and empty/non-square/singular/non-finite rejection, triangular misuse rejection, CUDA residency, complex CPU/CUDA estimator parity, and end-to-end adaptive SRC. No threshold changes.

Closes the remaining rank-revealing follow-up to #720.
