### PR TITLE
docs: shorten agent rules and add PERFORMANCE_TIPS.md audit catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ benchmarks/results/*.h5
 !CONTRIBUTING.md
 !AGENTS.md
 !CLAUDE.md
+!PERFORMANCE_TIPS.md
 
 # Private documentation (not committed)
 privatedoc/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,33 +1,30 @@
 # Agent Guidelines for tensor4all-rs
 
-Before acting, read the latest shared tensor4all agent rules from the
-[`tensor4all-agent-rules`](https://github.com/tensor4all/tensor4all-agent-rules)
-repository. Start from:
+Before acting, read the shared tensor4all agent rules, starting from
+`https://github.com/tensor4all/tensor4all-agent-rules/blob/main/rules/index.md`
+(offline fallback: `../tensor4all-agent-rules/rules/index.md`). Load only the
+common, Rust, performance, numerical, docs, or benchmark rule files relevant to
+the task. If neither is available, continue from the rules in this file and
+state so when creating a PR.
 
-- `https://github.com/tensor4all/tensor4all-agent-rules/blob/main/rules/index.md`
-
-If internet access is unavailable or the remote cannot be resolved, use the
-sibling checkout:
-
-- `../tensor4all-agent-rules/rules/index.md`
-
-Load only the common, Rust, performance, numerical, docs, or benchmark rule
-files relevant to the task. If neither online access nor the sibling checkout
-is available, continue from the rules embedded in this file and state the shared
-rules were unavailable when creating a PR.
-
-Then read `README.md` and `REPOSITORY_RULES.md` before starting work.
+Then read `README.md` and `REPOSITORY_RULES.md`. Read `PERFORMANCE_TIPS.md`
+(performance audit catalog) during performance-sensitive implementation (TT
+evaluation, interpolation, caches, contraction hot paths) and when reviewing
+any PR touching those areas; `skills/audit-performance/` launches that audit.
 
 ## Development Stage
 
-**Early development** - no backward compatibility required. Remove deprecated code immediately.
+**Early development**: no backward compatibility. Remove deprecated code
+immediately.
 
 ## General Guidelines
 
-- Use same language as past conversations (Japanese if previous was Japanese)
-- Source code and docs in English
-- Each crate in `crates/` is independent with own `Cargo.toml`, `src/`, `tests/`
-- **Bug fixing**: When a bug is discovered, always check related files for similar bugs and propose to the user to inspect them
+- Reply in the language of the conversation (Japanese if it was Japanese).
+  Source code and docs are English.
+- Each crate in `crates/` is independent with its own `Cargo.toml`, `src/`,
+  `tests/`.
+- **Bug fixing**: when a bug is found, check related files for similar bugs and
+  propose inspecting them to the user.
 
 ### API Reference (Check First)
 
@@ -35,100 +32,96 @@ Then read `README.md` and `REPOSITORY_RULES.md` before starting work.
 cargo run -p xtask --release -- api-dump
 ```
 
-This generates a complete, temporary inventory under `target/api-dump/` and
-verifies that every public crate under `crates/` appears exactly once. The
-output is ignored and must never be committed or edited manually. Read the
-relevant `target/api-dump/*.md` file before source files; only read source when
-that API inventory is insufficient.
+Generates a temporary inventory under `target/api-dump/` (ignored; never commit
+or hand-edit) and verifies every public crate under `crates/` appears exactly
+once. Read the relevant `target/api-dump/*.md` before source; read source only
+when the inventory is insufficient.
 
 ## Context-Efficient Exploration
 
-- Use Task tool with `subagent_type=Explore` for open-ended exploration
-- Use Grep for structure: `pub fn`, `impl.*for`, `^pub (struct|enum|type)`
-- Read specific lines with `offset`/`limit` parameters
-- Prefer API docs over full source files
+- Task tool with `subagent_type=Explore` for open-ended exploration.
+- Grep for structure: `pub fn`, `impl.*for`, `^pub (struct|enum|type)`.
+- Read specific lines with `offset`/`limit`; prefer API docs over full source.
 
 ## Code Style
 
-`cargo fmt` for formatting, `cargo clippy` for linting. Avoid `unwrap()`/`expect()` in library code.
-
-**Always run `cargo fmt --all` before committing changes.**
+`cargo fmt` and `cargo clippy`. Avoid `unwrap()`/`expect()` in library code.
+**Always run `cargo fmt --all` before committing.**
 
 ## Documentation Requirements
 
 ### Rustdoc Standards
 
-Every public type, trait, and function **must** have doc comments with the following:
+Every public type, trait, and function **must** have doc comments:
 
-**Types (struct/enum/trait):**
-- Summary: what it represents, when to use it (1-2 sentences)
-- Related types: relationship to similar types (e.g., "`TensorTrain` is the simple chain version; `TreeTN` is the general tree version")
-- `# Examples` section with runnable code and assertions
-
-**Functions/methods:**
-- Summary: what it does (1 sentence)
-- Arguments: meaning, constraints, typical values for each parameter (especially for `Options` types)
-- Returns: what is returned, how to use it
-- `# Panics` or `# Errors`: under what conditions it fails
-- `# Examples` section with runnable code and assertions
-
-**Options/Config types (critical for usability):**
-- Each field: meaning, recommended values, and default behavior
-- Field relationships and trade-offs (e.g., `rtol` vs `max_bond_dim`)
-- "When in doubt" defaults
+- **Types**: 1-2 sentence summary (what, when to use); relationship to similar
+  types (e.g. "`TensorTrain` is the simple chain version; `TreeTN` is the
+  general tree version"); `# Examples` with runnable asserted code.
+- **Functions/methods**: 1 sentence summary; arguments (meaning, constraints,
+  typical values, especially for `Options` types); returns (what is returned,
+  how to use it); `# Panics`/`# Errors` (under what conditions it fails);
+  `# Examples` with runnable asserted code.
+- **Options/Config types**: each field's meaning, recommended values, default
+  behavior; field relationships and trade-offs (e.g. `rtol` vs
+  `max_bond_dim`); "when in doubt" defaults.
 
 ### Code Example Rules
 
-- All doc examples **must** be runnable (`ignore` and `no_run` attributes are **prohibited**)
-- All doc examples **must** include assertions verifying correctness (not just compilation/execution)
-  - Use `assert!`, `assert_eq!`, `approx::assert_abs_diff_eq!`, etc.
-  - Weak smoke checks such as non-zero, non-empty, finite, shape-only, or
-    "rank is positive" are not enough unless that exact property is the
-    documented behavior. Prefer checking numerical values against known
-    answers, algebraic identities, reconstruction error, or structural
-    invariants that would catch an incorrect implementation.
-- mdBook guide code blocks follow the same rules: runnable with assertions
-- mdBook code blocks use hidden lines (`# ` prefix) for `use` statements and `fn main()` wrappers
+- All doc examples **must** be runnable (`ignore` and `no_run` are
+  **prohibited**) and **must** assert correctness (`assert!`, `assert_eq!`,
+  `approx::assert_abs_diff_eq!`, ...). Non-zero, non-empty, finite,
+  shape-only, or positive-rank checks are insufficient unless that property is
+  the documented behavior; check known values, algebraic identities,
+  reconstruction error, or structural invariants.
+- mdBook guide code blocks follow the same rules, with hidden lines (`# `
+  prefix) for `use` statements and `fn main()` wrappers.
 
 ### CI Verification
 
-- `cargo test --doc --release --workspace` must pass (rustdoc examples)
-- `./scripts/test-mdbook.sh` must pass (mdBook guide examples; raw `mdbook test docs/book` does not receive the resolved `--extern` flags that the guide snippets need)
+- `cargo test --doc --release --workspace` must pass.
+- `./scripts/test-mdbook.sh` must pass (raw `mdbook test docs/book` lacks the
+  resolved `--extern` flags the guide snippets need).
 
 ### Public Surface Drift
 
 - `README.md`, rustdoc, examples, and `skills/use-tensor4all-rs/` must not
-  claim more than the current public surface actually provides.
-- When changing public APIs, documented capabilities, or user-facing examples, check for stale names, stale capability claims, and references to removed paths or workflows.
-- Keep documentation slightly behind reality if validation is incomplete; do not advertise partially landed surfaces as stable or fully supported.
+  claim more than the current public surface provides.
+- When changing public APIs, documented capabilities, or user-facing examples,
+  check for stale names, stale capability claims, and references to removed
+  paths or workflows.
+- Keep documentation slightly behind reality if validation is incomplete; do
+  not advertise partially landed surfaces as stable.
 
 ### Online Tutorial Synchronization
 
-- The live online tutorials are in `docs/book/src/tutorials/`.
-- Runnable tutorial demos live in `docs/tutorial-code/src/bin/` with shared helpers in `docs/tutorial-code/src/`.
-- When changing public APIs, tutorial code, generated tutorial CSV/PNG artifacts, or examples quoted by the online tutorials, update the live mdBook tutorial page in the same branch.
-- Treat `docs/tutorial-code/docs/tutorials/` as legacy/reference material unless this policy is changed explicitly.
+- Live tutorials: `docs/book/src/tutorials/`. Runnable demos:
+  `docs/tutorial-code/src/bin/`, shared helpers in `docs/tutorial-code/src/`.
+- When changing public APIs, tutorial code, generated tutorial CSV/PNG
+  artifacts, or examples quoted by the tutorials, update the live mdBook
+  tutorial page in the same branch.
+- `docs/tutorial-code/docs/tutorials/` is legacy/reference material unless this
+  policy is changed explicitly.
 
 ## Error Handling
 
-- `anyhow` for internal error handling and context
-- `thiserror` for public API error types
+- `anyhow` for internal errors and context; `thiserror` for public API error
+  types.
 
 ### C API Error Handling
 
-The C API (`tensor4all-capi`) preserves error details through
-`t4a_last_error_message`. See `docs/CAPI_DESIGN.md` for the detailed ABI rules.
+`tensor4all-capi` preserves error details through `t4a_last_error_message`; ABI
+rules in `docs/CAPI_DESIGN.md`.
 
-- Fallible C API functions return `enum t4a_status_code`, not a bare `int`
-  or generic `StatusCode` typedef.
-- Use `run_catching`, `unwrap_catch`, `capi_error`, and `err_status` so
-  `Err(e)` values and panic payloads reach `t4a_last_error_message`.
-- **Do not add new `catch_unwind` / `Err(_) => T4A_INTERNAL_ERROR` patterns**
-  without preserving error messages.
-- Ordinary release builds omit Rust debug information. When debugging through
-  Tensor4all.jl or the C API requires source-level Rust backtraces, build with
-  `cargo build --profile release-debug -p tensor4all-capi` and set
-  `RUST_BACKTRACE=1` when running the caller.
+- Fallible C API functions return `enum t4a_status_code`, not a bare `int` or
+  generic `StatusCode` typedef.
+- Use `run_catching`, `unwrap_catch`, `capi_error`, and `err_status` so `Err(e)`
+  values and panic payloads reach `t4a_last_error_message`.
+- **No new `catch_unwind` / `Err(_) => T4A_INTERNAL_ERROR` patterns** that drop
+  error messages.
+- Release builds omit Rust debug info. For source-level backtraces through
+  Tensor4all.jl or the C API, build with
+  `cargo build --profile release-debug -p tensor4all-capi` and run the caller
+  with `RUST_BACKTRACE=1`.
 
 ## Testing
 
@@ -138,26 +131,35 @@ cargo nextest run --release --test test_name     # Specific test
 cargo nextest run --release -p crate_name        # Single crate
 ```
 
-**Always use `--release` mode for tests** to avoid excessive execution time in debug builds.
+**Always use `--release` for tests**; debug builds are too slow.
 
-- Private functions: `#[cfg(test)]` module in source file
-- Integration tests: `tests/` directory
-- Dense whole-result comparisons: avoid per-element re-contraction loops in tests. Materialize once to a dense tensor/matrix, then compare via tensor subtraction and `maxabs()`. `IdxTensor` subtraction aligns indices by index semantics, so explicit axis reordering is usually unnecessary.
-- **Test tolerance changes**: When relaxing test tolerances (unit tests, codecov targets, etc.), always seek explicit user approval before making changes.
-- **Dense whole-result comparisons**: When comparing full tensors/operators in tests, do not recompute contractions element-by-element. Materialize once to a dense tensor/matrix, then compare via tensor subtraction and `maxabs()`. `IdxTensor` subtraction aligns indices by index semantics, so explicit axis reordering is usually unnecessary.
+- Private functions: `#[cfg(test)]` module in the source file. Integration
+  tests: `tests/`.
+- **Dense whole-result comparisons**: do not recompute contractions
+  element-by-element. Materialize once to a dense tensor/matrix, then compare
+  via tensor subtraction and `maxabs()`. `IdxTensor` subtraction aligns indices
+  by semantics, so explicit axis reordering is usually unnecessary.
+- **Test tolerance changes** (unit tests, codecov targets, ...) require explicit
+  user approval.
 
 ### Coverage and Path Exercise
 
-- Each distinct control-flow path (error branches, layout variants, boundary conditions) needs a test. Happy-path only is insufficient.
-- When removing code, check whether the removed tests were the sole exerciser of any shared helper; add replacement coverage if so.
-- Before pushing a deletion PR, attest in the PR body that the removed code paths were reviewed for coverage impact (shared agent rules `common/docs-and-tests.md`: coverage is CI-owned, the local pre-PR gate is attestation-based). The CI coverage job is the authoritative measurement; a local llvm-cov run is optional:
+- Every distinct control-flow path (error branches, layout variants, boundary
+  conditions) needs a test; happy-path only is insufficient.
+- When removing code, check whether the removed tests were the sole exerciser
+  of a shared helper and add replacement coverage.
+- Before pushing a deletion PR, attest in the PR body that removed code paths
+  were reviewed for coverage impact (shared rules `common/docs-and-tests.md`:
+  coverage is CI-owned, the local gate is attestation-based). CI coverage is
+  authoritative; a local run is optional:
 
 ```bash
 cargo llvm-cov --release --workspace --exclude tensor4all-hdf5 --json --output-path coverage.json
 python3 scripts/check-coverage.py coverage.json
 ```
 
-Fix drops by adding tests, not by lowering thresholds (threshold changes need explicit approval).
+Fix drops by adding tests, not by lowering thresholds (threshold changes need
+explicit approval).
 
 ## API Design
 
@@ -165,28 +167,28 @@ Only make functions `pub` when truly public API.
 
 ### Layering and Maintainability
 
-**Respect crate boundaries and abstraction layers.**
+**Respect crate boundaries and abstraction layers**, in library and test code
+alike.
 
-- **Never access low-level APIs or internal data structures from downstream crates.** Use high-level public methods instead of directly manipulating internal representations.
-- **Use high-level APIs.** If downstream code needs low-level access, create appropriate high-level APIs rather than exposing internal details.
-- **Prefer type-generic Rust APIs.** If a public Rust library API can be expressed generically, do not introduce scalar-specific entry points such as `*_f64` / `*_c64`. Add or use a generic API instead, and prefer the generic form in library code, tests, examples, and docs. This rule does not apply to the C API / FFI boundary, where scalar-specific names may be appropriate.
-- **Examples:**
-  - Instead of `match scalar { AnyScalar::F64(x) => ... }`, use `scalar.real()`, `scalar.is_complex()`, `scalar.is_zero()`
-  - Instead of `AnyScalar::F64(1.0)`, use `AnyScalar::new_real(1.0)`
-  - Instead of `AnyScalar::C64(z)`, use `AnyScalar::new_complex(re, im)`
+- **Never access low-level APIs or internal data structures from downstream
+  crates.** If downstream code needs low-level access, add a high-level API
+  instead of exposing internals.
+- **Prefer type-generic Rust APIs.** No scalar-specific entry points such as
+  `*_f64` / `*_c64` when a generic form is possible; prefer the generic form in
+  library code, tests, examples, and docs. The C API / FFI boundary is exempt.
+- Examples: `scalar.real()`, `scalar.is_complex()`, `scalar.is_zero()` instead
+  of `match scalar { AnyScalar::F64(x) => ... }`; `AnyScalar::new_real(1.0)`
+  instead of `AnyScalar::F64(1.0)`; `AnyScalar::new_complex(re, im)` instead
+  of `AnyScalar::C64(z)`.
 
-**This applies to both library code and test code.** Tests should also use public APIs to maintain consistency and reduce maintenance burden when internal representations change.
-
-**No ad hoc fixes:**
-
-- Do not add ad hoc fixes that violate DRY, KISS, or layering.
-- Do not introduce compatibility shims, duplicated implementations, or downstream reach-through into lower-level internals when a higher-level seam should exist instead.
-- If a needed behavior does not fit the current abstraction cleanly, add or refine the appropriate seam instead of patching around it locally.
+**No ad hoc fixes:** nothing that violates DRY, KISS, or layering; no
+compatibility shims, duplicated implementations, or downstream reach-through
+where a higher-level seam should exist. If a behavior does not fit the current
+abstraction, add or refine the seam.
 
 ### Code Deduplication
 
-- **Avoid duplicate test code.** Use macros, functions, or generic functions to share test logic.
-- **Example pattern for testing f64/Complex64:**
+Avoid duplicate test code: share via macros, functions, or generics.
 
 ```rust
 fn test_op_generic<T: Scalar + From<f64>>() { /* test */ }
@@ -199,52 +201,50 @@ fn test_op_c64() { test_op_generic::<Complex64>(); }
 
 ### Dense Layout And Linear Algebra
 
-- Dense flat-buffer APIs use **column-major** linearization. New public
-  constructors, exports, examples, FFI contracts, and docs must state or
-  preserve column-major semantics.
-- Do not add row-major compatibility shims or hidden row-major round-trips in
-  library code. If external data is naturally row-shaped, convert privately at
-  that explicit boundary.
-- Reuse `tensor4all-tensorbackend::Matrix` for dense matrix values crossing crate
-  boundaries. Do not introduce duplicate public matrix containers in downstream
-  crates.
+- Dense flat-buffer APIs are **column-major**. New public constructors,
+  exports, examples, FFI contracts, and docs must state or preserve this.
+- No row-major compatibility shims or hidden round-trips in library code;
+  convert row-shaped external data privately at that explicit boundary.
+- Reuse `tensor4all-tensorbackend::Matrix` for dense matrices crossing crate
+  boundaries; no duplicate public matrix containers downstream.
 - Use tenferro-backed `tensor4all-tensorbackend` / existing tensor4all
-  abstractions for SVD, QR, einsum, and dense tensor linear algebra instead of
-  local reimplementations.
+  abstractions for SVD, QR, einsum, and dense linear algebra, not local
+  reimplementations.
 - Canonical integrations supply a configured `CpuBackend` to
   `tensor4all_tensorbackend::CpuExecutionContext`; legacy convenience APIs may
-  use `with_default_backend` behind the `global-defaults` feature. Do not create
+  use `with_default_backend` behind the `global-defaults` feature. Never create
   an unconfigured fallback backend in downstream operation code.
 - `Tensor3Ops::slice_site`, `Tensor4Ops::slice_site`, and dense/full-tensor
   exports return column-major flat data.
 
 ## C API & Language Bindings
 
-See `docs/CAPI_DESIGN.md` for C API patterns. Bindings: [Tensor4all.jl](https://github.com/tensor4all/Tensor4all.jl) (separate repo). The C API is the binding boundary; see `docs/CAPI_DESIGN.md`.
+The C API is the binding boundary; patterns in `docs/CAPI_DESIGN.md`. Bindings:
+[Tensor4all.jl](https://github.com/tensor4all/Tensor4all.jl) (separate repo).
 
-Truncation tolerance: support both `cutoff` (ITensors) and `rtol` (tensor4all-rs). Conversion: `rtol = √cutoff`.
+Truncation tolerance: support both `cutoff` (ITensors) and `rtol`
+(tensor4all-rs); `rtol = √cutoff`.
 
 ### Cross-repo development with Tensor4all.jl
 
-When a Tensor4all.jl feature requires new C API functions:
+When a Tensor4all.jl feature needs new C API functions:
 
-1. Develop both sides locally. Tensor4all.jl's `deps/build.jl` can use a local
+1. Develop both sides locally; Tensor4all.jl's `deps/build.jl` uses a local
    Rust build via `TENSOR4ALL_RS_PATH`.
 2. Test both sides locally until all tests pass.
 3. Create and merge the tensor4all-rs PR **first**.
-4. Then update the pin hash in Tensor4all.jl `deps/build.jl` to the merged
-   commit on remote and create the Tensor4all.jl PR.
+4. Update the pin hash in Tensor4all.jl `deps/build.jl` to the merged remote
+   commit and create the Tensor4all.jl PR.
 
-Issue templates are in `.github/ISSUE_TEMPLATE/`. Feature requests from
-Tensor4all.jl should link the related Julia-side issue.
+Issue templates: `.github/ISSUE_TEMPLATE/`. Feature requests from Tensor4all.jl
+link the related Julia-side issue.
 
 ## Dependencies
 
 - Prefer existing tensor4all core/tcicore/simplett abstractions and
-  tenferro-backed `tensor4all-tensorbackend` operations for arrays and linear
-  algebra. Add direct array/linalg dependencies only when the established
-  abstraction is genuinely insufficient.
-- SVD singular values: `s[[0, i]]` not `s[[i, i]]`
+  tenferro-backed `tensor4all-tensorbackend` for arrays and linear algebra. Add
+  direct array/linalg dependencies only when those are genuinely insufficient.
+- SVD singular values: `s[[0, i]]`, not `s[[i, i]]`.
 
 ## Git Workflow
 
@@ -252,18 +252,17 @@ Tensor4all.jl should link the related Julia-side issue.
 
 ### Base Branch Synchronization
 
-- At the start of work, run `git fetch origin` and branch from `origin/main`
-  rather than a stale local `main`.
-- Before treating PR checks as final, fetch `origin` and verify that the PR
-  branch contains the current `origin/main`.
-- If a PR is behind `main`, update the PR branch from `origin/main` before
-  relying on checks, enabling auto-merge, or declaring it ready to merge.
-- After updating from `origin/main`, re-monitor CI; earlier green checks do not
-  prove the synchronized branch is green.
+- Start work with `git fetch origin` and branch from `origin/main`, not a stale
+  local `main`.
+- Before treating PR checks as final, fetch `origin` and verify the PR branch
+  contains current `origin/main`. If behind, update from `origin/main` before
+  relying on checks, enabling auto-merge, or declaring it ready.
+- After updating, re-monitor CI; earlier green checks do not cover the
+  synchronized branch.
 
 ### Pre-PR Checks (matches CI)
 
-Run before pushing. CI runs the same checks, but local = faster feedback:
+Run before pushing.
 
 ```bash
 cargo fmt --all                        # Auto-fix formatting
@@ -279,46 +278,45 @@ cargo doc --workspace --no-deps        # Build rustdoc
 ### Repository Rules Review Bot
 
 `.github/workflows/review_bot.yml` reviews every PR diff against
-`REPOSITORY_RULES.md`. It runs from the trusted base revision and treats PR
-contents as data: the PR head is fetched for `git diff` only, never checked out
-or executed. Findings post as a single updating PR comment; only
-`block`-severity findings fail the check.
+`REPOSITORY_RULES.md` and `PERFORMANCE_TIPS.md` from the trusted base
+revision; the PR head is fetched for `git diff` only, never checked out or
+executed. Findings post as one updating PR comment; only `block`-severity
+findings fail the check.
 
-Preview the review locally before pushing:
+Preview locally before pushing:
 
 ```bash
 python3 scripts/repository-rules-review.py --base main --worktree --dry-run
 python3 scripts/test-repository-rules-review.py   # the script's own tests
 ```
 
-Drop `--dry-run` to include the LLM pass; it needs `DEEPSEEK_API_KEY` in the
-environment or in a repo-root `.env` (`pip install -r scripts/requirements-dev.txt`).
-
-The system prompt lives in `ai/prompts/repository-rules-review.md`. Three
-deterministic checks run before the LLM and independently of it:
+Drop `--dry-run` for the LLM pass; it needs `DEEPSEEK_API_KEY` in the
+environment or a repo-root `.env` (`pip install -r scripts/requirements-dev.txt`).
+System prompt: `ai/prompts/repository-rules-review.md`. Three deterministic
+checks run before and independently of the LLM:
 
 | Check | Rule | Baseline |
 |-------|------|----------|
-| Secret-shaped text in added lines | — | Blocks the upload before anything reaches the API |
+| Secret-shaped text in added lines | (none) | Blocks the upload before anything reaches the API |
 | New direct `tenferro-*` dependency outside `tensor4all-tensorbackend` | Dense Layout And Linear Algebra | #566 Phase 3 backlog: core, tcicore, simplett, treetci |
 | Added `ignore` / `no_run` doctest fence | Documentation Examples | #566 Phase 1 backlog: 2 `no_run` sites |
 
-Both rule checks are delta-scoped: they reject new violations without failing on
-the recorded backlog. The tenferro check parses Cargo.toml table context, so
-`tenferro-*` **feature** names are not mistaken for dependencies, and
-`dev-dependencies` are out of scope.
+Both rule checks are delta-scoped: new violations fail, the recorded backlog
+does not. The tenferro check parses Cargo.toml table context, so `tenferro-*`
+**feature** names are not mistaken for dependencies and `dev-dependencies` are
+out of scope.
 
-Maintainer escape hatches, both requiring the `maintain`/`admin` role and
-reapplication after the latest push:
+Maintainer escape hatches (`maintain`/`admin` role, reapply after the latest
+push):
 
 | Label | Effect |
 |-------|--------|
 | `rules-review:no-llm` | Skips the LLM pass; deterministic checks still run |
 | `rules-review:waive` | Waives the review entirely |
 
-When adding a `## ` section to `REPOSITORY_RULES.md`, also route it in
-`SECTION_TRIGGERS` (or `ALWAYS_SECTIONS` / `HUMAN_ONLY_SECTIONS`); an unrouted
-section is never shown to the reviewer, and
+When adding a `## ` section to `REPOSITORY_RULES.md` or `PERFORMANCE_TIPS.md`,
+route it in `SECTION_TRIGGERS` (or `ALWAYS_SECTIONS` / `HUMAN_ONLY_SECTIONS`);
+an unrouted section is never shown to the reviewer and
 `test_every_rule_section_is_reachable` fails.
 
 | Change Type | Workflow |
@@ -347,25 +345,24 @@ gh run view <RUN_ID> --log-failed
 
 ### New Public Crate Checklist
 
-Before creating a PR that adds a public workspace crate, complete every
-applicable item below. Mark an item not applicable explicitly in the PR body
-rather than silently omitting it.
+Before a PR that adds a public workspace crate, complete every applicable item;
+mark inapplicable items explicitly in the PR body.
 
 - [ ] Add the crate to the workspace and the root `README.md` crate map.
 - [ ] Add the crate and its primary use cases to `llms.txt` with a direct link
       to the most useful guide for a new user or coding agent.
-- [ ] Update `docs/book/src/architecture.md`, including the layer diagram,
-      crate table, and goal-to-crate selection table where applicable.
+- [ ] Update `docs/book/src/architecture.md` (layer diagram, crate table,
+      goal-to-crate selection table).
 - [ ] Add or update an mdBook guide and register it in
       `docs/book/src/SUMMARY.md`.
-- [ ] Link the new guide from related existing guides so that users do not need
-      to know the new crate name in advance.
+- [ ] Link the new guide from related guides so users need not know the crate
+      name in advance.
 - [ ] Add a crate `README.md` or an equally clear docs.rs landing page.
-- [ ] Provide a runnable, asserted example that exercises the crate's primary
+- [ ] Provide a runnable, asserted example exercising the crate's primary
       nontrivial code path; a degenerate shortcut or smoke test is not enough.
 - [ ] Remove developer-local absolute paths and references to inaccessible
       design material from committed documentation.
 - [ ] Run workspace doctests and `./scripts/test-mdbook.sh`.
 
-For every PR, verify that the root `README.md` remains accurate, including the
-project structure and examples.
+For every PR, verify the root `README.md` remains accurate, including project
+structure and examples.

--- a/PERFORMANCE_TIPS.md
+++ b/PERFORMANCE_TIPS.md
@@ -1,0 +1,146 @@
+# Performance Audit Catalog
+
+Failure modes where tensor4all-rs code is correct but wastefully slow because
+the obvious API was used instead of the right one. Read it during
+performance-sensitive implementation (TT evaluation, interpolation, caches,
+contraction hot paths) and in every review touching those areas. Findings are
+rule violations, not measured regressions: a fix still follows the measurement
+discipline of the shared rules. Generic performance rules live in
+`tensor4all-agent-rules` `rules/common/performance.md` and
+`rules/rust/performance.md`; this file does not repeat them. Dense
+materialization, index identity, and layout rules live in
+`REPOSITORY_RULES.md` and `AGENTS.md`.
+
+Ported from Tensor4all.jl `rules/tensor4all-usage-audit.md` (FM1 to FM12).
+
+## Audit procedure
+
+1. Scope: the pending diff by default; `full` or a path means every `.rs` file
+   under it. Skip generated code and `target/`.
+2. Run each section's "Detect" grep over the scope. Hits are candidates, not
+   findings.
+3. Read each candidate in context. Keep only sites on a path repeated over many
+   index sets, sweeps, or calls where the "Fix" API applies. Record justified
+   exceptions.
+4. Classify each finding by section. Check that the proposed fix is not itself a
+   violation (for example, replacing a pointwise loop with `to_dense()`).
+5. Report `file:line`, violated section, evidence, remediation; most severe
+   first. Do not edit code; do not claim a speedup without measurement.
+
+## Pointwise TT Readout In A Loop
+
+Contract: repeated `evaluate(&idx)` on a tensor train recomputes the full
+left-to-right contraction per point. Any path that evaluates one TT at many
+indices shares left/right environments. Incident: Tensor4all.jl ReFrequenTT,
+2026-09-01, batch readout was 1353x faster at rank 31.
+
+Detect: `rg -n '\.evaluate\(' crates` inside `for`, `map`, or `iter` over
+index sets; `QuanticsTensorCI2::evaluate` in a loop.
+
+Fix: `tensor4all_simplett::TTCache` (`TTCache::new(&tt)`, then
+`evaluate_many(&indices, split)`), or `evaluate_left`/`evaluate_right` for
+one-sided scans. Trees: `tensor4all_treetn::TreeTNCachedEvaluator` with
+`evaluate_batched`. For `QuanticsTensorCI2`, wrap `tensor_train()` in a
+`TTCache`.
+
+## Uncached Target Function Across Sweeps
+
+Contract: TCI sweeps re-request the same function values across pivot searches
+and runs. An expensive target passed raw to `crossinterpolate2` or
+`quanticscrossinterpolate` recomputes them; related runs with separate caches
+recompute across runs.
+
+Detect: `rg -n 'crossinterpolate2\(|quanticscrossinterpolate\(' crates`; check
+whether the closure calls a raw function or a `CachedFunction`.
+
+Fix: `tensor4all_core::CachedFunction::new(f, &local_dims)` and `eval`; share
+one instance across related runs; inspect `num_evals`, `num_cache_hits`,
+`cache_hit_ratio`.
+
+## Wrapper That Disables Batching
+
+Contract: batch entry points exist but fire only when the caller hands them the
+batch. `tensor4all_tensorci::crossinterpolate2` takes `batched_f: Option<B>`;
+`tensor4all_treetci::crossinterpolate2` takes `F: Fn(GlobalIndexBatch) ->
+Result<Vec<T>>`; `CachedFunction::with_batch` and `eval_batch` exist. A closure
+`|idx| cf.eval(idx)` or a per-element loop inside the batch closure silently
+turns batching into pointwise evaluation.
+
+Detect: `rg -n 'crossinterpolate2\([^)]*None' crates`; batch closures whose
+body loops `.eval(` or `.evaluate(`; `CachedFunction` values captured by a
+plain `Fn(&[usize])` closure.
+
+Fix: pass a batch function; inside batch closures call `eval_batch` or
+`evaluate_many`; add behavior by wrapping the batch path, not by closing over
+the pointwise one.
+
+## Full Quantics Grid Sweeps
+
+Contract: a quantics grid has `2^R` points; iterating all of them in a
+production or validation path defeats the representation. Bounded sampled
+checks or structural checks replace exhaustive sweeps.
+
+Detect: `rg -n '1usize << |1 << r|pow\(2|2usize\.pow|iproduct!|grid\.len\(\)'
+crates` inside loops that evaluate a TT or grid function.
+
+Fix: random sampled points via `ChaCha8Rng`, batch readout of a bounded index
+set (`TTCache::evaluate_many`), or a structural invariant. Keep exhaustive
+sweeps to tests with small `R`.
+
+## Per-Call Reconstruction Inside Loops
+
+Contract: grids, TCIs, caches, evaluators, and backends are built once and
+reused. Construction inside a loop or per-point helper pays constant overhead
+per call and gives a zero cache hit rate.
+
+Detect: `rg -n 'TTCache::new\(|CachedFunction::new\(|TreeTNCachedEvaluator::new\(|DiscretizedGrid::|InherentDiscreteGrid::|CpuExecutionContext::from_backend\(|with_default_backend\('
+crates` inside `for`, `map`, or closures called per point.
+
+Fix: hoist construction out of the loop; reuse a `CachedEvaluatorPlan` via
+`TreeTNCachedEvaluator::with_plan` when tensors change but topology does not;
+build one `CpuExecutionContext::from_backend` and reuse it, as `AGENTS.md`
+requires.
+
+## Owned Vector Cache Keys
+
+Contract: a persistent cache keyed by `Vec<usize>` hashes and compares the
+whole vector on every lookup and clones it on every insert. Multi-indices are
+encoded as mixed-radix flat integers with width chosen from the index space.
+
+Detect: `rg -n 'HashMap<Vec<usize>|HashMap<MultiIndex|BTreeMap<Vec<usize>'
+crates` on long-lived caches.
+
+Fix: `CachedFunction` (`u64`, `u128`, then `U256`/`U512`/`U1024` via the
+`CacheKey` trait, `with_key_type` to force a width) or `TTCache`, which encode
+keys internally. Do not hand-roll a multi-index cache.
+
+## Silent Slow-Path Fallback
+
+Contract: a fast path (batch readout, structured op, backend call) that falls
+back to pointwise or dense behavior on error hides the failure and pins
+production on the slow path.
+
+Detect: `rg -n 'unwrap_or_else\(|Err\(_\) =>|if let Err\(_\)' crates` where the
+fallback branch re-implements the operation pointwise or densely; feature-gated
+fallbacks with no log.
+
+Fix: return the typed error, or route to a named reference path (`*_dense`,
+`*_reference`) that the caller opts into and that logs the degradation.
+
+## Unpinned Timing Claims
+
+Contract: timing comparisons without pinned thread counts are irreproducible
+(oversubscription, drift). Every quoted number states its thread settings.
+
+Detect: `rg -n 'Instant::now\(|criterion|cargo bench' crates benchmarks`
+without the thread environment.
+
+Fix: run as in `benchmarks/README.md` (`RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1
+OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1`), record thread
+counts for scaling runs, and follow the Evidence rules in
+`rules/common/performance.md`.
+
+Not ported: FM4 (dense materialization) is `REPOSITORY_RULES.md` "No Hidden
+Dense Materialization In Production Paths"; FM8 to FM10 (grid conventions,
+FFI memory order, tolerance semantics) are convention rules in `AGENTS.md`
+and `skills/use-tensor4all-rs/`.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ validated in CI. Longer runnable examples live in the
 
 A portable [Agent Skill](skills/use-tensor4all-rs/SKILL.md) teaches compatible
 coding agents the crate map, common workflows, and tensor4all-rs conventions.
+The companion [`audit-performance`](skills/audit-performance/SKILL.md) skill
+runs the static performance audit defined in `PERFORMANCE_TIPS.md`.
 Install and update it with:
 
 ```bash

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -6,243 +6,224 @@
 > `AGENTS.md` (URL + sibling checkout `../tensor4all-agent-rules/rules/`).**
 >
 > The sections below are the **tensor4all-rs-specific residue only**. Public
-> surface, error handling, testing/coverage, performance, layering/dedup,
-> dense layout, C API ABI, dependencies, and graph/cache policy are covered by
-> the shared rules (see the shared `rules/index.md`); do not duplicate them
-> here — extend the shared repo instead and keep this file minimal.
+> surface, error handling, testing/coverage, performance, layering/dedup, dense
+> layout, C API ABI, dependencies, and graph/cache policy are covered by the
+> shared rules (see the shared `rules/index.md`); do not duplicate them here.
+> Extend the shared repo instead and keep this file minimal.
 
 ## Public Boundary Safety Audits
 
-- User-reachable Rust, tensor-network, C API, and language-binding-facing paths
-  must validate input-derived shape, rank, axis, index, dtype/scalar kind,
-  topology, truncation, and layout configuration before no-op shortcuts,
-  allocation, backend calls, pointer use, or FFI calls.
+- User-reachable Rust, tensor-network, C API, and binding-facing paths validate
+  input-derived shape, rank, axis, index, dtype/scalar kind, topology,
+  truncation, and layout configuration before no-op shortcuts, allocation,
+  backend calls, pointer use, or FFI calls.
 - Shape products, dense element counts, byte lengths, strides, offsets, bond
-  products, launch sizes, and FFI dimensions must use checked arithmetic before
+  products, launch sizes, and FFI dimensions use checked arithmetic before
   conversion to `usize`, `i32`, `u32`, pointer offsets, or allocation sizes.
-- Publicly reachable library paths must not turn invalid user input into
-  `panic`, `unwrap`, `expect`, unchecked indexing, poisoned-lock unwraps, or
-  debug-only assertions. Return a crate-local typed error or a C API status with
-  preserved diagnostic context instead.
-- Validate fast paths and zero-size returns with the same scrutiny as the main
-  path. A shortcut must not skip rank, index identity, scalar kind, topology, or
-  layout checks that would reject invalid input on the full path.
-- Repeated validation shared by Rust, C API, Julia/Python bindings, dense,
+- Publicly reachable library paths never turn invalid user input into `panic`,
+  `unwrap`, `expect`, unchecked indexing, poisoned-lock unwraps, or debug-only
+  assertions. Return a crate-local typed error or a C API status with preserved
+  diagnostic context.
+- Fast paths and zero-size returns get the same scrutiny as the main path: a
+  shortcut must not skip rank, index identity, scalar kind, topology, or layout
+  checks the full path would apply.
+- Validation shared by Rust, C API, Julia/Python bindings, dense,
   tensor-network, or scalar-specific wrappers should live in shared helpers or
   prepared metadata types. Do not duplicate hand-written checks when a helper
-  can enforce the contract before unsafe or performance-sensitive code.
-- Validation helpers should return typed prepared metadata when downstream code
-  would otherwise repeat rank-minus-one, axis ordering, shape-product, site role,
-  edge role, or index mapping calculations.
-- Parallel operation surfaces must keep validation and scalar-promotion
-  semantics in parity. A bug in one of Rust/C API, f64/Complex64, dense/TN, or
-  MPS/MPO-like wrappers should trigger a nearby audit of the corresponding
-  surfaces.
-- When a bug exposes a public API design mismatch, fix the canonical contract
-  at its owner. API compatibility is not a goal in this early-development
+  can enforce the contract before unsafe or performance-sensitive code. Helpers
+  should return typed prepared metadata when downstream code would otherwise
+  repeat rank-minus-one, axis ordering, shape-product, site role, edge role, or
+  index mapping calculations.
+- Parallel operation surfaces keep validation and scalar-promotion semantics in
+  parity. A bug in one of Rust/C API, f64/Complex64, dense/TN, or MPS/MPO-like
+  wrappers should trigger a nearby audit of the corresponding surfaces.
+- When a bug exposes a public API design mismatch, fix the canonical contract at
+  its owner. API compatibility is not a goal in this early-development
   repository unless the task explicitly requires a compatibility window.
 
 ## Base Branch Synchronization
 
-- Start new work from the current remote base, not from a stale local checkout:
-  run `git fetch origin` and create feature branches or worktrees from
-  `origin/main`.
-- Before treating PR checks as final, fetch `origin` and verify that the PR
-  branch contains the current `origin/main`.
-- If GitHub reports the PR as behind the base branch, update the PR branch from
-  `origin/main` before relying on checks, enabling auto-merge, or declaring the
-  PR ready to merge.
-- After any `origin/main` synchronization, rerun or re-monitor CI. Green checks
-  from before the synchronization are not sufficient.
+- Start work from the current remote base: `git fetch origin`, then branch or
+  create worktrees from `origin/main`, never a stale local checkout.
+- Before treating PR checks as final, fetch `origin` and verify the PR branch
+  contains current `origin/main`. If GitHub reports the PR behind the base,
+  update from `origin/main` before relying on checks, enabling auto-merge, or
+  declaring it ready.
+- After any `origin/main` synchronization, rerun or re-monitor CI; earlier
+  green checks are insufficient.
 
 ## No Hidden Dense Materialization In Production Paths
 
-- Production algorithms must not silently materialize a full dense tensor whose
+- Production algorithms never silently materialize a full dense tensor whose
   memory or time scales as the product of unconstrained site or external index
   dimensions.
-- Scalable public paths such as tensor-network contraction, operator apply,
-  truncation, fitting, C API entry points, and language-binding-facing APIs
-  must avoid hidden calls to full-network dense materialization methods such as
-  `contract_to_tensor()` or `to_dense()` unless the API is explicitly a dense
-  or reference API.
-- Dense/reference implementations are allowed only when they are explicitly
-  named as dense, reference, or debug behavior; documented as
-  O(product of index dimensions) in memory/time; excluded from default or
-  production method dispatch; and covered by small-size tests only.
-- Method names must match semantics. For MPO/MPS or `LinearOperator`
-  application, `naive` means local exact tensor-network contraction, not full
-  dense materialization, unless the API name and documentation explicitly say
-  dense/reference.
+- Scalable public paths (tensor-network contraction, operator apply,
+  truncation, fitting, C API entry points, binding-facing APIs) avoid hidden
+  calls to full-network materialization such as `contract_to_tensor()` or
+  `to_dense()` unless the API is explicitly dense or reference.
+- Dense/reference implementations are allowed only when explicitly named as
+  dense, reference, or debug; documented as O(product of index dimensions) in
+  memory/time; excluded from default or production dispatch; and covered by
+  small-size tests only.
+- Method names match semantics. For MPO/MPS or `LinearOperator` application,
+  `naive` means local exact tensor-network contraction, not dense
+  materialization, unless the name and docs explicitly say dense/reference.
 - If dense materialization is unavoidable for a debugging or reference path,
   prefer an explicit size guard or caller-supplied limit such as
   `max_dense_elements`.
 - When adding or changing contraction/application code, check whether any path
-  can call `contract_to_tensor()`, `to_dense()`, or equivalent full
-  materialization. If yes, justify that the path is explicitly dense/reference
-  or replace it with a local tensor-network algorithm.
-- Do not replace known structured tensors with dense tensors in production
-  paths when the structure is semantically required or already available. This
-  includes identity, diagonal, Kronecker delta, copy, one-hot, selector, and
-  bridge tensors used only to preserve topology or route bond spaces.
-- A tensor that is mathematically a delta/copy/identity must use the appropriate
-  compact structured representation when one exists, for example diagonal/copy
-  storage or structured axis classes. If only a dense constructor exists, add or
-  refine the structured core API first, or reject the unbounded production path.
+  can call `contract_to_tensor()`, `to_dense()`, or equivalent. If so, justify
+  that the path is explicitly dense/reference or replace it with a local
+  tensor-network algorithm.
+- Do not replace structured tensors with dense tensors in production paths when
+  the structure is semantically required or already available: identity,
+  diagonal, Kronecker delta, copy, one-hot, selector, and bridge tensors used to
+  preserve topology or route bond spaces.
+- A tensor that is mathematically a delta/copy/identity uses the compact
+  structured representation when one exists (diagonal/copy storage, structured
+  axis classes). If only a dense constructor exists, add or refine the
+  structured core API first, or reject the unbounded production path.
 - Topology-preserving helper tensors must not introduce hidden dense
   `bond_dim^2`, `bond_dim^k`, or site-product payloads. Dimension-1 structural
-  links are acceptable; nontrivial bridge deltas must preserve compact
-  diagonal/copy structure or remain behind an explicit dense/reference guard.
-- Tests for delta/copy/identity paths should check both numerical behavior and
-  representation behavior where possible, such as `is_diag()`, `storage_kind()`,
-  payload dimensions, axis classes, or a regression whose intended algorithm is
-  cheap but accidental dense storage would fail.
+  links are fine; nontrivial bridge deltas keep compact diagonal/copy structure
+  or stay behind an explicit dense/reference guard.
+- Tests for delta/copy/identity paths should check representation as well as
+  numerics where possible: `is_diag()`, `storage_kind()`, payload dimensions, axis
+  classes, or a regression that is cheap for the intended algorithm but fails
+  under accidental dense storage.
 
 ## Tensor Network Test Comparisons
 
-- Randomized algorithms must provide both a high-level deterministic seed API
-  and a low-level API that accepts a caller-owned `&mut R` where
-  `R: rand::Rng + ?Sized`. The high-level API must delegate to the low-level
-  implementation, and the low-level implementation must consume the supplied
-  stream directly rather than deriving a seed for a hidden RNG.
-- Seed-based production entry points must use an explicitly named RNG algorithm,
-  not `StdRng`, so dependency upgrades do not silently change the stream.
-- Tests of randomized algorithms must use `ChaCha8Rng` with an explicit seed.
-  Do not use `StdRng`, `thread_rng`, or an implicit entropy source in those tests.
-- Small reference tests may materialize dense tensors. Materialize each full
-  result once, subtract tensors, and compare the whole result with `maxabs()`.
-  Do not compare by re-contracting or re-evaluating every element one by one.
-- Long-TT or long-TreeTN regression tests must be sized so accidental dense
-  materialization would fail quickly, but the intended tensor-network algorithm
-  remains cheap.
-- Long tensor-network tests must not use comparison helpers that dense-materialize
-  internally. In particular, do not call `maxabs()` on a TT/TN type unless that
-  specific implementation is known to be scalable.
-- For long TT/TN equality checks, prefer scalable comparisons:
-  - direct-sum difference such as `tt1 - tt2` or `axpby(1, tt1, -1, tt2)`,
-    followed by a tensor-network norm;
-  - sampled `evaluate()` checks at fixed multi-indices;
-  - structural invariants such as node count, site indices, and bounded bond
-    dimensions.
-- Do not compress a difference TT/TN before using it as an exact test residual;
-  compression would make the comparison itself approximate.
-- When using norm-based approximate equality, report the residual explicitly,
-  for example `diff.norm() / reference.norm()`, so failures are diagnosable.
+- Randomized algorithms provide both a high-level deterministic seed API and a
+  low-level API taking a caller-owned `&mut R` where `R: rand::Rng + ?Sized`.
+  The high-level API delegates to the low-level one, which consumes the
+  supplied stream directly rather than deriving a seed for a hidden RNG.
+- Seed-based production entry points use an explicitly named RNG algorithm, not
+  `StdRng`, so dependency upgrades do not silently change the stream.
+- Tests of randomized algorithms use `ChaCha8Rng` with an explicit seed, never
+  `StdRng`, `thread_rng`, or implicit entropy.
+- Small reference tests may materialize dense tensors: materialize each full
+  result once, subtract, and compare the whole result with `maxabs()`. Never
+  compare by re-contracting or re-evaluating element by element.
+- Long-TT or long-TreeTN regression tests are sized so accidental dense
+  materialization fails quickly while the intended algorithm stays cheap.
+- Long tensor-network tests must not use comparison helpers that
+  dense-materialize internally; do not call `maxabs()` on a TT/TN type unless
+  that implementation is known to be scalable.
+- For long TT/TN equality, prefer scalable comparisons: direct-sum difference
+  (`tt1 - tt2` or `axpby(1, tt1, -1, tt2)`) followed by a tensor-network norm;
+  sampled `evaluate()` at fixed multi-indices; structural invariants such as
+  node count, site indices, and bounded bond dimensions.
+- Do not compress a difference TT/TN before using it as an exact test residual.
+- With norm-based approximate equality, report the residual explicitly, e.g.
+  `diff.norm() / reference.norm()`.
 
 ## Online Tutorial Synchronization
 
-- `docs/book/src/tutorials/` is the live source for online tutorial prose.
-- `docs/tutorial-code/src/bin/` and `docs/tutorial-code/src/` are the runnable
-  source for tutorial demos and shared tutorial helpers.
+- `docs/book/src/tutorials/` is the live source for tutorial prose;
+  `docs/tutorial-code/src/bin/` and `docs/tutorial-code/src/` are the runnable
+  source for demos and shared helpers.
 - Any change to tutorial APIs, tutorial code, generated tutorial artifacts, or
-  public APIs used by tutorials must check and update the corresponding live
-  mdBook page before the branch is complete.
-- Non-trivial guide snippets should have an executable source of truth, such as
-  a checked example, tutorial binary, doctest, or test. If Markdown must copy a
+  public APIs used by tutorials updates the corresponding live mdBook page
+  before the branch is complete.
+- Non-trivial guide snippets should have an executable source of truth
+  (checked example, tutorial binary, doctest, or test). If Markdown must copy a
   snippet by hand, add or update a sync/extraction check when practical.
-- Diagrams in `README.md`, mdBook, and `docs/design/` are part of the documented
-  surface. Crate names, layer assignments, dependency direction, and public
-  entry points shown in diagrams must match the current implementation.
-- Legacy markdown under `docs/tutorial-code/docs/tutorials/` must not be treated
-  as the online source of truth.
+- Diagrams in `README.md`, mdBook, and `docs/design/` are documented surface:
+  crate names, layer assignments, dependency direction, and public entry points
+  must match the implementation.
+- Legacy markdown under `docs/tutorial-code/docs/tutorials/` is not the online
+  source of truth.
 
 ## Work Logs And Design Records
 
-- Nontrivial refactors, cleanup streams, AI-assisted implementation batches, and
-  changes that make explicit design tradeoffs should leave a curated work log
-  under `docs/worklogs/`.
-- A work log should record the session summary, code and documents read,
-  reference implementations considered, decisions made, alternatives rejected or
-  deferred, verification performed, and remaining risks.
-- Work logs are reviewer-facing decision records, not raw transcripts and not
-  implementation plans. Keep them concise enough to review but specific enough
-  that later work can understand the selected abstraction, split, public API, or
-  deferral.
-- When a PR establishes or changes durable design intent, update the appropriate
-  document under `docs/design/` in the same PR. Use work logs for session-level
-  rationale and design docs for decisions future implementation should follow.
-- When an audit finding is a false positive because of an intentional invariant,
-  record the evidence in the issue, PR body, work log, nearby source comment, or
-  source-contract test. Do not simply skip it and leave future reviewers to
-  rediscover the same non-bug.
+- Nontrivial refactors, cleanup streams, AI-assisted implementation batches,
+  and changes with explicit design tradeoffs should leave a curated work log
+  under `docs/worklogs/`. A work log should record: session summary, code and
+  documents read, reference implementations considered, decisions,
+  alternatives rejected or deferred, verification performed, remaining risks.
+- Work logs are reviewer-facing decision records, not transcripts or
+  implementation plans: concise enough to review, specific enough that later
+  work understands the selected abstraction, split, public API, or deferral.
+- When a PR establishes or changes durable design intent, update the relevant
+  `docs/design/` document in the same PR. Work logs hold session-level
+  rationale; design docs hold decisions future implementation should follow.
+- When an audit finding is a false positive because of an intentional
+  invariant, record the evidence in the issue, PR body, work log, nearby source
+  comment, or source-contract test so future reviewers do not rediscover it.
 
 ## Differentiability And AD Preservation
 
 - Production tensor, tensor-network, linear algebra, and solver paths should
-  preserve automatic differentiation metadata whenever the underlying backend
-  and operation can do so.
-- Unless there is a documented reason not to, dense tensor operations should go
-  through `tensor4all-tensorbackend` or existing tensor4all abstractions that
-  preserve tenferro AD metadata. Avoid bypassing the backend with local dense
-  loops, native-tensor extraction, host scalar conversion, or detached
-  reference implementations.
+  preserve automatic differentiation metadata whenever the backend and
+  operation allow.
+- Unless documented otherwise, dense tensor operations should go through
+  `tensor4all-tensorbackend` or existing tensor4all abstractions that preserve
+  tenferro AD metadata. Avoid bypassing the backend with local dense loops,
+  native-tensor extraction, host scalar conversion, or detached reference
+  implementations.
 - Do not unnecessarily detach tensors, convert differentiable values through
   plain Rust scalars, force `.real()`/real-only projections, or round-trip
-  through dense/reference paths in a way that discards AD metadata.
-- When an operation must cross a non-differentiable boundary, such as a scalar
-  control-flow decision, diagnostic conversion, FFI boundary, unsupported
-  backend routine, or intentionally native/reference implementation, keep that
-  boundary explicit in the code and documentation.
+  through dense/reference paths in ways that discard AD metadata.
+- Where an operation must cross a non-differentiable boundary (scalar
+  control-flow decision, diagnostic conversion, FFI, unsupported backend
+  routine, intentionally native/reference implementation), keep that boundary
+  explicit in code and documentation.
 - Prefer backend-provided differentiable primitives for contraction, einsum,
-  SVD, QR, eigensolvers, exponentials, and scalar operations. If a required
-  primitive is missing, add or refine the appropriate backend/core API instead
-  of silently implementing a detached local workaround.
-- Tests that claim AD support must include oracle or finite-difference
-  coverage. Tests for algorithms that are not yet AD-supported should still
-  avoid unnecessary AD metadata loss along intermediate tensor paths.
+  SVD, QR, eigensolvers, exponentials, and scalar operations. If one is
+  missing, add or refine the backend/core API instead of a detached local
+  workaround.
+- Tests claiming AD support include oracle or finite-difference coverage. Tests
+  for algorithms not yet AD-supported should still avoid unnecessary AD
+  metadata loss along intermediate tensor paths.
 
 ## Index Identity Semantics
 
-- Do not use `index.id()` alone to decide whether two indices are the same
-  index object. Full index equality must be used for identity comparisons so
-  same-ID indices with different prime levels, tags, directions, or other
-  metadata remain distinct.
-- Maps and sets that represent index identity must be keyed by the full index
-  value, not by `IndexLike::Id`.
+- Never use `index.id()` alone to decide whether two indices are the same
+  object. Identity comparisons use full index equality so same-ID indices with
+  different prime levels, tags, directions, or other metadata remain distinct.
+- Maps and sets representing index identity are keyed by the full index value,
+  not `IndexLike::Id`.
 - Public and internal APIs that select a concrete tensor leg, TreeTN site,
   edge, topology assignment, replacement target, split/fuse target, or
-  restructure target must accept the full `Index` value, not an index ID. Shape
-  APIs around index identity so callers can pass the index they mean.
-- C API and language-binding-facing APIs must follow the same rule: accept
-  `Index` handles for concrete index selection, expose full-index
-  equality/hash helpers when bindings need map keys, and do not expose ID-only
-  constructors, selectors, or identity getters as public API.
-- Pure ID comparisons are allowed only inside implementation details that are
-  explicitly about logical-site lookup, compatibility, or contraction pairing.
-  Do not expose ID-based public APIs for selecting concrete indices. If a
-  temporary internal ID map is unavoidable, name the local variable to make the
-  ID-based semantics explicit, such as `logical_site_ids` or
-  `contraction_pair_ids`, and reject ambiguous same-ID inputs instead of
-  choosing one silently.
+  restructure target accept the full `Index` value, not an ID.
+- C API and binding-facing APIs follow the same rule: accept `Index` handles
+  for concrete selection, expose full-index equality/hash helpers when bindings
+  need map keys, and expose no ID-only constructors, selectors, or identity
+  getters.
+- Pure ID comparisons are allowed only inside implementation details explicitly
+  about logical-site lookup, compatibility, or contraction pairing. If a
+  temporary internal ID map is unavoidable, name it to make the semantics
+  explicit (`logical_site_ids`, `contraction_pair_ids`) and reject ambiguous
+  same-ID inputs instead of choosing one silently.
 - When changing tensor, TreeTN, contraction, direct-sum, replacement, or
   reindexing code, add a regression test with same-ID indices that differ by
   prime level or tags.
 
 ## Unsafe Code Boundary
 
-- `unsafe` belongs in FFI, backend, storage, or other leaf modules that own the
-  low-level invariant. Do not introduce `unsafe` in high-level tensor-network,
-  interpolation, graph/topology, transform, or AD-preserving algorithm code
-  when the correct fix is a lower-level helper.
-- Count and review `unsafe` by location and purpose, not by raw text search.
+- `unsafe` belongs in FFI, backend, storage, or other leaf modules owning the
+  low-level invariant, never in high-level tensor-network, interpolation,
+  graph/topology, transform, or AD-preserving algorithm code when the correct
+  fix is a lower-level helper.
+- Count and review `unsafe` by location and purpose, not raw text search.
   Generated code, comments, tests, and existing backend/FFI seams should be
   separated from production algorithmic code when auditing risk.
-- Each new `unsafe` block must have a nearby `// SAFETY:` comment explaining the
+- Each new `unsafe` block has a nearby `// SAFETY:` comment explaining the
   validation or ownership invariant that makes it sound.
-- Boundary-condition tests or source-contract tests should cover new unsafe
+- Boundary-condition or source-contract tests should cover new unsafe
   indexing, raw pointer, FFI, or backend-native view construction paths.
 
 ## File Organization
 
-- Keep source files focused, but do not split files solely to reduce line count.
-  Treat roughly 1000 lines as a soft review trigger, not a mechanical limit.
+- Keep source files focused, but never split solely to reduce line count.
+  Roughly 1000 lines is a soft review trigger, not a limit.
 - Split only along clear behavior, abstraction, feature, ownership, or
-  public/private API boundaries such as validation, planning, execution,
-  topology, contraction, solver, C API bridge, backend glue, or cache ownership.
-- Avoid arbitrary `part1`/`part2` splits and tiny files that force readers to
-  chase one concept across many modules.
-- Use line count to decide where to inspect first. Use responsibility, change
-  frequency, public/private API boundaries, and human navigation to decide
-  whether and how to split.
+  public/private API boundaries: validation, planning, execution, topology,
+  contraction, solver, C API bridge, backend glue, cache ownership. No
+  `part1`/`part2` splits and no tiny files that scatter one concept.
+- Line count decides where to inspect first; responsibility, change frequency,
+  API boundaries, and human navigation decide whether and how to split.
 
 ## Language Bindings
 

--- a/scripts/repository-rules-review.py
+++ b/scripts/repository-rules-review.py
@@ -37,6 +37,7 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 RULES_PATH = ROOT / "REPOSITORY_RULES.md"
+TIPS_PATH = ROOT / "PERFORMANCE_TIPS.md"
 PROMPT_PATH = ROOT / "ai" / "prompts" / "repository-rules-review.md"
 PROMPT_VERSION = "1"
 DEFAULT_MODEL = "deepseek-v4-pro"
@@ -159,7 +160,20 @@ ALWAYS_SECTIONS = frozenset(
 # Synchronization" is a git-workflow protocol -- nothing inside a diff can
 # satisfy or violate it, so showing it to a diff-scoped reviewer only invites
 # invented findings.
-HUMAN_ONLY_SECTIONS = frozenset({"Base Branch Synchronization"})
+# "Audit procedure" (PERFORMANCE_TIPS.md) instructs the auditor; a diff cannot
+# violate it.
+HUMAN_ONLY_SECTIONS = frozenset({"Base Branch Synchronization", "Audit procedure"})
+
+PERFORMANCE_SECTIONS = (
+    "Pointwise TT Readout In A Loop",
+    "Uncached Target Function Across Sweeps",
+    "Wrapper That Disables Batching",
+    "Full Quantics Grid Sweeps",
+    "Per-Call Reconstruction Inside Loops",
+    "Owned Vector Cache Keys",
+    "Silent Slow-Path Fallback",
+    "Unpinned Timing Claims",
+)
 
 SECTION_TRIGGERS: tuple[tuple[re.Pattern[str], frozenset[str]], ...] = (
     (
@@ -212,6 +226,15 @@ SECTION_TRIGGERS: tuple[tuple[re.Pattern[str], frozenset[str]], ...] = (
                 "Tensor Network Test Comparisons",
             }
         ),
+    ),
+    # PERFORMANCE_TIPS.md sections: TT evaluation, TCI, caches, contraction.
+    (
+        re.compile(
+            r"tensor4all-(?:tensorci|treetci|quanticstci|aci|treeaci|simplett"
+            r"|treetn|partitionedtt|partitionedtreetn)|evaluat|cache|contract"
+            r"|benchmarks/"
+        ),
+        frozenset(PERFORMANCE_SECTIONS),
     ),
     (
         re.compile(
@@ -453,8 +476,10 @@ def configure_dotenv(*, explicit: Path | None, skip: bool) -> None:
     load_dotenv(path, override=False)
 
 
-def parse_repository_rules_sections(path: Path = RULES_PATH) -> dict[str, str]:
-    text = path.read_text(encoding="utf-8")
+def parse_repository_rules_sections(
+    paths: tuple[Path, ...] = (RULES_PATH, TIPS_PATH),
+) -> dict[str, str]:
+    text = "\n".join(path.read_text(encoding="utf-8") for path in paths)
     sections: dict[str, str] = {}
     current_title: str | None = None
     current_lines: list[str] = []
@@ -1508,9 +1533,10 @@ def main(argv: list[str] | None = None) -> int:
 
     configure_dotenv(explicit=args.dotenv, skip=args.no_dotenv)
 
-    if not RULES_PATH.is_file():
-        print(f"Missing rules file: {RULES_PATH}", file=sys.stderr)
-        return 1
+    for rules_path in (RULES_PATH, TIPS_PATH):
+        if not rules_path.is_file():
+            print(f"Missing rules file: {rules_path}", file=sys.stderr)
+            return 1
     if not PROMPT_PATH.is_file():
         print(f"Missing prompt file: {PROMPT_PATH}", file=sys.stderr)
         return 1

--- a/skills/audit-performance/SKILL.md
+++ b/skills/audit-performance/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: audit-performance
+description: "Use when reviewing or auditing tensor4all-rs code for performance rule violations: before merging changes that touch tensor-train evaluation, interpolation, caches, or contraction hot paths, when a workload is unexpectedly slow, or when scanning the repository for latent performance anti-patterns. Static audit that reports violations of PERFORMANCE_TIPS.md with file and line and never claims a speedup or slowdown without measurement."
+license: MIT
+---
+
+# Audit performance
+
+Thin launcher with no rule content. The canonical contracts, failure-mode
+catalog, and audit procedure live in
+[`PERFORMANCE_TIPS.md`](../../PERFORMANCE_TIPS.md).
+
+1. Read `PERFORMANCE_TIPS.md` in full.
+2. Follow its audit procedure. Pass any argument (`full` or a path) as the
+   scope; with no argument, audit the pending diff.
+3. Report each finding as `file:line`, violated section, evidence,
+   remediation. Findings are rule violations, not measured regressions; do not
+   claim a speedup or slowdown without measurement.


### PR DESCRIPTION
## Summary

- Shorten `AGENTS.md` and `REPOSITORY_RULES.md` without changing rules. Duplicated bullets and verbose phrasing are removed; every heading, rule, and should/must distinction is preserved, and all `REPOSITORY_RULES.md` section headings are unchanged so review-bot routing is unaffected.
- Add `PERFORMANCE_TIPS.md`, a static performance audit catalog ported from the Tensor4all.jl batch-evaluation audit and expressed in tensor4all-rs API terms (`TTCache`, `CachedFunction`, `TreeTNCachedEvaluator`, batched `crossinterpolate2`, and so on). Each section carries Detect and Fix hints and the file opens with an audit procedure.
- Add the thin `skills/audit-performance` launcher, which reads `PERFORMANCE_TIPS.md` and reports rule violations with file and line without claiming measured speedups.
- Route the catalog sections through `scripts/repository-rules-review.py` and point `AGENTS.md` and `README.md` at the new file for performance-sensitive implementation and review.

| File | Before | After |
| --- | --- | --- |
| `AGENTS.md` | 17979 bytes | 15480 bytes |
| `REPOSITORY_RULES.md` | 15161 bytes | 13716 bytes |
| `PERFORMANCE_TIPS.md` | new | 6829 bytes |

## Verification

- `scripts/test-repository-rules-review.py`: 90 tests passed.
- `scripts/repository-rules-review.py --base origin/main --head HEAD --dry-run`: pass.
- Every Rust API name cited in `PERFORMANCE_TIPS.md` was checked against the current crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
