### PR TITLE
perf(treeaci): fix resource limits and branched Guard cost

### DIFF
--- a/crates/tensor4all-aci/src/global_guard.rs
+++ b/crates/tensor4all-aci/src/global_guard.rs
@@ -118,7 +118,7 @@ where
             start,
             options.nsweeps_global_search,
             threshold,
-            |points: &[Vec<usize>]| -> crate::Result<Vec<f64>> {
+            |scan_site: Option<usize>, points: &[Vec<usize>]| -> crate::Result<Vec<f64>> {
                 let n_points = points.len();
                 // The walk hands us the current pivot with one site varied,
                 // so every candidate shares all coordinates except that site.
@@ -127,16 +127,12 @@ where
                 // scans) instead of re-deriving it per candidate; this is
                 // what keeps a walk at O(chi^2 * dim) per site scan rather
                 // than O(n_sites * chi^2) per point.
-                let split = if n_points < 2 {
-                    None
-                } else {
-                    (0..n_sites)
-                        .find(|&site| {
-                            let first = points[0][site];
-                            points[1..].iter().any(|point| point[site] != first)
-                        })
-                        .map(|site| site + 1)
-                };
+                //
+                // The walk now declares that site instead of leaving it to be
+                // recovered from the batch, which a batch of one point cannot
+                // support: the seed evaluation has no scan site and every
+                // site scan has exactly one.
+                let split = scan_site.map(|site| site + 1);
                 let input_len =
                     n_inputs
                         .checked_mul(n_points)

--- a/crates/tensor4all-core/src/floating_zone.rs
+++ b/crates/tensor4all-core/src/floating_zone.rs
@@ -29,9 +29,14 @@ use crate::MultiIndex;
 /// * `early_stop_tol` - Stop walking once the maximum error exceeds this
 ///   value; the caller has found a significantly wrong point.
 /// * `eval_batch` - Evaluates the error magnitude `|f - tt|` at a batch of
-///   multi-indices. Called once per site per sweep with that site's
-///   `local_dims[site]` candidate points (the current pivot with the site
-///   coordinate varied), so callers can batch shared contractions.
+///   multi-indices. It is called once for the starting point with a scan site
+///   of `None`, and then once per site per sweep with `Some(site)` and that
+///   site's `local_dims[site] - 1` *other* candidate points: the candidate
+///   equal to the current pivot is not re-evaluated, because the walk already
+///   knows its error from the step that moved there. The scan site is passed
+///   so that a caller whose evaluator exploits scan structure can declare it
+///   rather than infer it from the batch, which a single-point batch cannot
+///   support.
 ///
 /// # Returns
 ///
@@ -41,8 +46,37 @@ use crate::MultiIndex;
 ///
 /// # Errors
 ///
-/// Propagates the error returned by `eval_batch` unchanged — typically an
+/// Propagates the error returned by `eval_batch` unchanged - typically an
 /// operation failure or an index mismatch from the underlying evaluator.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::floating_zone_walk;
+///
+/// // A separable error surface whose maximum is the all-last-coordinate
+/// // point, so a greedy coordinate walk must find it exactly.
+/// let local_dims = [3usize, 4, 2];
+/// let error_at = |point: &Vec<usize>| point.iter().map(|&c| c as f64).sum::<f64>();
+/// let mut evaluated = 0usize;
+/// let (pivot, error) = floating_zone_walk::<_, std::convert::Infallible>(
+///     &local_dims,
+///     &vec![0usize, 0, 0],
+///     16,
+///     f64::INFINITY,
+///     |_site, points| {
+///         evaluated += points.len();
+///         Ok(points.iter().map(error_at).collect())
+///     },
+/// )?;
+///
+/// assert_eq!(pivot, vec![2, 3, 1]);
+/// assert_eq!(error, 6.0);
+/// // One point for the start, then `local_dims[site] - 1` per site scan: the
+/// // coordinate the pivot already holds is never re-evaluated.
+/// assert_eq!(evaluated, 1 + 2 * ((3 - 1) + (4 - 1) + (2 - 1)));
+/// # Ok::<(), std::convert::Infallible>(())
+/// ```
 pub fn floating_zone_walk<E, Err>(
     local_dims: &[usize],
     init_p: &MultiIndex,
@@ -51,38 +85,66 @@ pub fn floating_zone_walk<E, Err>(
     mut eval_batch: E,
 ) -> std::result::Result<(MultiIndex, f64), Err>
 where
-    E: FnMut(&[MultiIndex]) -> std::result::Result<Vec<f64>, Err>,
+    E: FnMut(Option<usize>, &[MultiIndex]) -> std::result::Result<Vec<f64>, Err>,
 {
     let n = local_dims.len();
 
     let mut pivot = init_p.clone();
 
-    // Initial error at the starting point.
-    let start_errors = eval_batch(&[pivot.clone()])?;
+    // Initial error at the starting point. This also seeds `pivot_error`,
+    // which is what lets every site scan below skip the candidate the pivot
+    // already holds.
+    let start_errors = eval_batch(None, &[pivot.clone()])?;
     let mut max_error = start_errors.first().copied().unwrap_or(0.0);
+    let mut pivot_error = max_error;
 
     for _ in 0..max_sweeps {
         let prev_max_error = max_error;
         for ipos in 0..n {
-            // Candidate points: every value at this site, the rest fixed at
-            // the current pivot (updated greedily within this sweep).
-            let mut points = Vec::with_capacity(local_dims[ipos]);
+            // Candidate points: every value at this site except the one the
+            // pivot already holds, the rest fixed at the current pivot
+            // (updated greedily within this sweep). The skipped candidate is
+            // the current pivot itself, whose error is `pivot_error`.
+            let held = pivot[ipos];
+            let mut points = Vec::with_capacity(local_dims[ipos].saturating_sub(1));
             for value in 0..local_dims[ipos] {
+                if value == held {
+                    continue;
+                }
                 let mut point = pivot.clone();
                 point[ipos] = value;
                 points.push(point);
             }
-            let errors = eval_batch(&points)?;
+            let errors = if points.is_empty() {
+                Vec::new()
+            } else {
+                eval_batch(Some(ipos), &points)?
+            };
 
-            let mut best_local_idx = pivot[ipos];
+            // Fold in value order, with the held candidate's known error in
+            // its own place, so the greedy choice is the one the full batch
+            // would have made.
+            let mut best_local_idx = held;
             let mut best_local_error = 0.0f64;
-            for (value, &error) in errors.iter().enumerate() {
+            let mut evaluated = errors.iter();
+            for value in 0..local_dims[ipos] {
+                let error = if value == held {
+                    pivot_error
+                } else {
+                    match evaluated.next() {
+                        Some(&error) => error,
+                        None => break,
+                    }
+                };
                 if error > best_local_error {
                     best_local_error = error;
                     best_local_idx = value;
                 }
             }
             pivot[ipos] = best_local_idx;
+            // The pivot is now the winning candidate of this scan, so its
+            // error is that candidate's error.
+            pivot_error = best_local_error;
             max_error = max_error.max(best_local_error);
         }
 
@@ -92,4 +154,154 @@ where
     }
 
     Ok((pivot, max_error))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::floating_zone_walk;
+
+    /// The reference implementation this walk replaces: every candidate at a
+    /// site is evaluated, including the one the pivot already holds.
+    fn full_batch_walk(
+        local_dims: &[usize],
+        init_p: &[usize],
+        max_sweeps: usize,
+        early_stop_tol: f64,
+        error_at: &dyn Fn(&[usize]) -> f64,
+    ) -> (Vec<usize>, f64, usize) {
+        let mut pivot = init_p.to_vec();
+        let mut evaluated = 1usize;
+        let mut max_error = error_at(&pivot);
+        for _ in 0..max_sweeps {
+            let previous = max_error;
+            for site in 0..local_dims.len() {
+                let mut best_index = pivot[site];
+                let mut best_error = 0.0f64;
+                for value in 0..local_dims[site] {
+                    let mut point = pivot.clone();
+                    point[site] = value;
+                    evaluated += 1;
+                    let error = error_at(&point);
+                    if error > best_error {
+                        best_error = error;
+                        best_index = value;
+                    }
+                }
+                pivot[site] = best_index;
+                max_error = max_error.max(best_error);
+            }
+            if max_error == previous || max_error > early_stop_tol {
+                break;
+            }
+        }
+        (pivot, max_error, evaluated)
+    }
+
+    fn rough_error(point: &[usize]) -> f64 {
+        let mut value = 0.0;
+        for (site, &coordinate) in point.iter().enumerate() {
+            value += ((site as f64 + 1.7) * (coordinate as f64 + 0.3)).sin();
+        }
+        value.abs()
+    }
+
+    /// Skipping the held candidate must not change the trajectory, the pivot,
+    /// or the reported error, only the number of points evaluated.
+    #[test]
+    fn skipping_the_held_candidate_matches_the_full_batch_walk() {
+        for local_dims in [
+            vec![2usize, 2, 2, 2, 2],
+            vec![3usize, 2, 4],
+            vec![2usize, 5, 3, 2],
+        ] {
+            for start in [
+                vec![0usize; local_dims.len()],
+                vec![1usize; local_dims.len()],
+            ] {
+                let start: Vec<usize> = start
+                    .iter()
+                    .zip(&local_dims)
+                    .map(|(&coordinate, &dim)| coordinate % dim)
+                    .collect();
+                let (expected_pivot, expected_error, full_points) =
+                    full_batch_walk(&local_dims, &start, 8, f64::INFINITY, &rough_error);
+
+                let mut evaluated = 0usize;
+                let mut scan_sites = Vec::new();
+                let (pivot, error) = floating_zone_walk::<_, std::convert::Infallible>(
+                    &local_dims,
+                    &start,
+                    8,
+                    f64::INFINITY,
+                    |site, points| {
+                        scan_sites.push(site);
+                        evaluated += points.len();
+                        Ok(points.iter().map(|point| rough_error(point)).collect())
+                    },
+                )
+                .unwrap();
+
+                assert_eq!(pivot, expected_pivot);
+                assert_eq!(error, expected_error);
+                assert!(
+                    evaluated < full_points,
+                    "the skip must evaluate fewer points: {evaluated} against {full_points}"
+                );
+                // Every scan declares its site, and only the seed does not.
+                assert_eq!(scan_sites.first().copied(), Some(None));
+                assert!(scan_sites[1..].iter().all(Option::is_some));
+                // Every batch a scan asks for excludes exactly one candidate.
+                let sweeps = (scan_sites.len() - 1) / local_dims.len();
+                let per_sweep: usize = local_dims.iter().map(|dim| dim - 1).sum();
+                assert_eq!(evaluated, 1 + sweeps * per_sweep);
+            }
+        }
+    }
+
+    /// A site of local dimension one has no other candidate, so its scan asks
+    /// for nothing at all and the pivot keeps its only value.
+    #[test]
+    fn a_singleton_site_is_never_evaluated() {
+        let local_dims = [1usize, 2];
+        let mut batches = Vec::new();
+        let (pivot, error) = floating_zone_walk::<_, std::convert::Infallible>(
+            &local_dims,
+            &vec![0usize, 0],
+            4,
+            f64::INFINITY,
+            |site, points| {
+                batches.push((site, points.len()));
+                Ok(points.iter().map(|point| point[1] as f64).collect())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(pivot, vec![0, 1]);
+        assert_eq!(error, 1.0);
+        assert!(!batches.contains(&(Some(0), 1)));
+        assert!(batches.contains(&(Some(1), 1)));
+    }
+
+    /// The error the seed call reports is the pivot's own error, so a start
+    /// that is already the maximum is not lost by the first scan.
+    #[test]
+    fn a_maximal_start_is_kept() {
+        let local_dims = [2usize, 2];
+        let (pivot, error) = floating_zone_walk::<_, std::convert::Infallible>(
+            &local_dims,
+            &vec![1usize, 1],
+            4,
+            f64::INFINITY,
+            |_site, points| {
+                Ok(points
+                    .iter()
+                    .map(|point| if point == &vec![1usize, 1] { 5.0 } else { 1.0 })
+                    .collect())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(pivot, vec![1, 1]);
+        assert_eq!(error, 5.0);
+    }
 }

--- a/crates/tensor4all-tensorci/src/globalsearch.rs
+++ b/crates/tensor4all-tensorci/src/globalsearch.rs
@@ -216,9 +216,11 @@ where
         &init_p,
         max_sweeps,
         early_stop_tol,
-        |points: &[MultiIndex]| {
+        |_scan_site: Option<usize>, points: &[MultiIndex]| {
             // Batch-evaluate the tensor train once per site scan; `f` is
-            // evaluated pointwise (no batch API in this signature).
+            // evaluated pointwise (no batch API in this signature). The scan
+            // site is unused here: this evaluator has no scan-structured fast
+            // path to declare it to.
             let tt_values = tt_cache
                 .evaluate_many(points, None)
                 .map_err(TCIError::SimpleTensorTrain)?;

--- a/crates/tensor4all-treeaci/src/frames.rs
+++ b/crates/tensor4all-treeaci/src/frames.rs
@@ -157,20 +157,28 @@ fn grouped_gemm_descriptor_bytes(incoming_dims: &[usize]) -> Result<usize> {
         })
 }
 
-/// Whether `elements` scalars plus `extra_bytes` of metadata fit the
-/// configured working-byte budget, without raising an error.
+/// Whether `elements` scalars plus `extra_bytes` of metadata fit what is left
+/// of the working-byte budget after `reserved_bytes`, without raising an
+/// error.
 ///
 /// The arbitrary-degree routing contract needs to *choose* a route rather
 /// than reject a request, so an overflowing or over-budget estimate reports
 /// `false` here and the caller falls back to the scalar path.
+///
+/// `reserved_bytes` is what the *caller's* own live buffers already claim for
+/// the duration of the call, so the route chosen here is affordable in the
+/// aggregate and not merely in isolation; see
+/// [`InputFrameStore::candidate_frames_for_edge`].
 fn frame_working_elements_fit<T: TreeAciScalar, V: TreeAciNode>(
     problem: &PreparedTreeProblem<V>,
     elements: usize,
     extra_bytes: usize,
+    reserved_bytes: usize,
 ) -> bool {
     elements
         .checked_mul(size_of::<T>())
         .and_then(|bytes| bytes.checked_add(extra_bytes))
+        .and_then(|bytes| bytes.checked_add(reserved_bytes))
         .is_some_and(|bytes| bytes <= problem.max_working_bytes)
 }
 
@@ -1221,11 +1229,18 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
     /// [`Self::candidate_frames_for_edge`] will actually take: the batched
     /// kernel's live buffers for one and two incoming components, and for
     /// three or more the batched charge when the complete Cartesian cross
-    /// fits `max_working_bytes` and the per-candidate scalar charge when it
-    /// does not (see
+    /// fits the budget left after `reserved_bytes`, and the per-candidate
+    /// scalar charge when it does not (see
     /// [`Self::candidate_frames_for_edge_multi_incoming`]'s routing
     /// contract). This keeps the local update's pre-flight budget and the
     /// kernel's own routing decision from disagreeing.
+    ///
+    /// # Arguments
+    ///
+    /// * `reserved_bytes` - what the caller's own live buffers claim for the
+    ///   duration of the candidate-frame call, and therefore what is *not*
+    ///   available to the batched route. Pass the same value to
+    ///   [`Self::candidate_frames_for_edge`], or the two will disagree.
     ///
     /// # Errors
     ///
@@ -1238,6 +1253,7 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
         input: usize,
         directed_edge: DirectedEdgeId,
         candidate_sets: &CandidateSets,
+        reserved_bytes: usize,
     ) -> Result<usize> {
         let directed =
             problem
@@ -1337,6 +1353,7 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
                                         problem,
                                         *elements,
                                         descriptor_bytes,
+                                        reserved_bytes,
                                     )
                                 },
                             )
@@ -1416,6 +1433,25 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
     /// this path's cache semantics identical to the scalar
     /// [`Self::candidate_frame`] path it replaces for other workloads or
     /// call patterns where reuse may still occur.
+    /// Candidate frames for one directed edge, packed bond-major.
+    ///
+    /// # Arguments
+    ///
+    /// * `reserved_bytes` - bytes of `max_working_bytes` the caller's own live
+    ///   buffers hold for the duration of this call. An arbitrary-degree edge
+    ///   routes to its batched kernel only when that kernel's live buffers fit
+    ///   the budget that remains, so a caller already holding most of the
+    ///   budget gets the cheaper-in-memory scalar route instead of an
+    ///   aggregate overrun. Pass `0` when nothing else is live. The same value
+    ///   must reach
+    ///   [`Self::enumerated_candidate_frame_scratch_elements`], which is what
+    ///   pre-charges this call.
+    ///
+    /// # Errors
+    ///
+    /// Propagates every failure of the selected kernel, including
+    /// [`TreeAciError::InternalInvariant`] for an unknown edge or input and
+    /// [`TreeAciError::SizeOverflow`] on checked dimension arithmetic.
     pub(crate) fn candidate_frames_for_edge<V: TreeAciNode>(
         &self,
         inputs: &[TreeTN<IdxTensor, V>],
@@ -1423,6 +1459,7 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
         input: usize,
         directed_edge: DirectedEdgeId,
         candidates: &[ComponentSample],
+        reserved_bytes: usize,
     ) -> Result<PackedCandidateFrames<T>> {
         self.candidate_frames_for_edge_with_layout(
             inputs,
@@ -1431,9 +1468,17 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
             directed_edge,
             candidates,
             PackedCandidateFrameLayout::BondByCandidate,
+            reserved_bytes,
         )
     }
 
+    /// The candidate-major counterpart of
+    /// [`Self::candidate_frames_for_edge`], with the same `reserved_bytes`
+    /// contract.
+    ///
+    /// # Errors
+    ///
+    /// Propagates every failure of the selected kernel.
     pub(crate) fn candidate_frames_for_edge_rows<V: TreeAciNode>(
         &self,
         inputs: &[TreeTN<IdxTensor, V>],
@@ -1441,6 +1486,7 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
         input: usize,
         directed_edge: DirectedEdgeId,
         candidates: &[ComponentSample],
+        reserved_bytes: usize,
     ) -> Result<PackedCandidateFrames<T>> {
         self.candidate_frames_for_edge_with_layout(
             inputs,
@@ -1449,9 +1495,11 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
             directed_edge,
             candidates,
             PackedCandidateFrameLayout::CandidateByBond,
+            reserved_bytes,
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn candidate_frames_for_edge_with_layout<V: TreeAciNode>(
         &self,
         inputs: &[TreeTN<IdxTensor, V>],
@@ -1460,6 +1508,7 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
         directed_edge: DirectedEdgeId,
         candidates: &[ComponentSample],
         layout: PackedCandidateFrameLayout,
+        reserved_bytes: usize,
     ) -> Result<PackedCandidateFrames<T>> {
         let directed =
             problem
@@ -1486,6 +1535,7 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
                 directed_edge,
                 candidates,
                 layout,
+                reserved_bytes,
             );
         }
         if directed.incoming_to_from.is_empty() {
@@ -1749,9 +1799,9 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
     /// * the **batched** route, [`incoming_batch_matrix`], when the group's
     ///   complete Cartesian cross is no larger than the number of candidates
     ///   the caller actually asked for *and* every simultaneously live buffer
-    ///   of that cross fits `max_working_bytes`
-    ///   ([`multi_incoming_scratch_elements`] plus
-    ///   [`grouped_gemm_descriptor_bytes`]);
+    ///   of that cross fits what is left of `max_working_bytes` after the
+    ///   caller's own `reserved_bytes` ([`multi_incoming_scratch_elements`]
+    ///   plus [`grouped_gemm_descriptor_bytes`]);
     /// * the **scalar** route, the same
     ///   [`contract_prepared_core_slices`] contraction
     ///   [`Self::candidate_frame`] performs, otherwise.
@@ -1763,12 +1813,17 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
     /// complete cross, so production groups take the batched route whenever
     /// their intermediates are affordable. The budget condition selects a
     /// route instead of raising a limit error, so a tight budget degrades to
-    /// the previous per-candidate cost rather than failing.
+    /// the previous per-candidate cost rather than failing. It is evaluated
+    /// against the budget that remains after the caller's `reserved_bytes`,
+    /// so this degradation happens at exactly the boundary the caller's own
+    /// aggregate pre-flight charges: the two cannot disagree in the direction
+    /// that would overrun the budget (#726).
     ///
     /// Cache semantics are unchanged from the scalar route this replaces:
     /// three-or-more-incoming candidates are still never cached, because
     /// their exact identity would need an unbounded vector key
     /// ([`Self::candidate_cache_key`]).
+    #[allow(clippy::too_many_arguments)]
     fn candidate_frames_for_edge_multi_incoming<V: TreeAciNode>(
         &self,
         inputs: &[TreeTN<IdxTensor, V>],
@@ -1777,6 +1832,7 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
         directed_edge: DirectedEdgeId,
         candidates: &[ComponentSample],
         layout: PackedCandidateFrameLayout,
+        reserved_bytes: usize,
     ) -> Result<PackedCandidateFrames<T>> {
         let directed =
             problem
@@ -1876,7 +1932,12 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
             let scratch = multi_incoming_scratch_elements(outgoing_dim, &incoming_dims, &counts)?;
             let descriptor_bytes = grouped_gemm_descriptor_bytes(&incoming_dims)?;
             let batched = cross <= indices.len()
-                && frame_working_elements_fit::<T, V>(problem, scratch, descriptor_bytes);
+                && frame_working_elements_fit::<T, V>(
+                    problem,
+                    scratch,
+                    descriptor_bytes,
+                    reserved_bytes,
+                );
 
             if !batched {
                 #[cfg(test)]

--- a/crates/tensor4all-treeaci/src/frames/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/frames/tests/mod.rs
@@ -30,7 +30,8 @@ fn two_node_tree<T: TreeAciScalar + From<f64>>() -> TreeTN<IdxTensor, usize> {
 fn assert_two_node_frames<T: TreeAciScalar + From<f64> + PartialEq + std::fmt::Debug>() {
     let input = two_node_tree::<T>();
     let problem =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
     let (arena, _) = SampleArena::from_global_seeds(&problem, &[vec![0, 0], vec![1, 1]]).unwrap();
     let frames = InputFrameStore::<T>::from_samples(&[input], &problem, &arena).unwrap();
 
@@ -78,7 +79,8 @@ fn y_tree<T: TreeAciScalar + From<f64>>() -> TreeTN<IdxTensor, usize> {
 fn assert_y_frames<T: TreeAciScalar + From<f64>>() {
     let input = y_tree::<T>();
     let problem =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
     let seeds = [vec![0, 0, 0, 0], vec![0, 1, 1, 1]];
     let (arena, active) = SampleArena::from_global_seeds(&problem, &seeds).unwrap();
     let frames = InputFrameStore::<T>::from_samples(&[input], &problem, &arena).unwrap();
@@ -120,7 +122,8 @@ fn multiple_physical_axes_use_first_axis_fast_flattening() {
     let right = IdxTensor::from_dense(vec![bond, DynIndex::new_dyn(1)], vec![1.0, 1.0]).unwrap();
     let input = TreeTN::from_tensors(vec![left, right], vec![0, 1]).unwrap();
     let problem =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
     let (arena, _) = SampleArena::from_global_seeds(&problem, &[vec![4, 0]]).unwrap();
     let frames = InputFrameStore::<f64>::from_samples(&[input], &problem, &arena).unwrap();
 
@@ -131,7 +134,8 @@ fn multiple_physical_axes_use_first_axis_fast_flattening() {
 fn frames_remain_addressable_after_active_set_replacement() {
     let input = two_node_tree::<f64>();
     let problem =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
     let (arena, mut active) =
         SampleArena::from_global_seeds(&problem, &[vec![0, 0], vec![1, 1]]).unwrap();
     let old_id = active.ids[0][0];
@@ -150,7 +154,8 @@ fn frames_remain_addressable_after_active_set_replacement() {
 fn extend_matches_a_full_rebuild_on_the_grown_arena() {
     let input = y_tree::<f64>();
     let problem =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
     let seed0 = vec![0, 0, 0, 0];
     let seed1 = vec![0, 1, 1, 1];
     let (mut arena, mut candidates) =
@@ -195,7 +200,8 @@ fn extend_new_samples_matches_full_rebuild_on_chain_and_branch() {
 
     for (input, seed0, seed1) in cases {
         let problem =
-            prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+            prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+                .unwrap();
         let (mut arena, mut candidates) =
             SampleArena::from_global_seeds(&problem, std::slice::from_ref(&seed0)).unwrap();
         let initial =
@@ -247,7 +253,8 @@ fn extend_new_samples_matches_full_rebuild_on_chain_and_branch() {
 fn extend_new_samples_computes_only_new_ranges() {
     let input = chain5_tree_for_dedup_regression();
     let problem =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
     let (mut arena, _candidates) =
         SampleArena::from_global_seeds(&problem, &[vec![0, 0, 0, 0, 0]]).unwrap();
     let initial =
@@ -309,7 +316,8 @@ fn paired_release_measurement_for_cut_local_extension() {
 
     let input = chain5_tree_for_dedup_regression();
     let problem =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
     let (mut arena, _candidates) =
         SampleArena::from_global_seeds(&problem, &[vec![0, 0, 0, 0, 0]]).unwrap();
     let initial =
@@ -431,7 +439,8 @@ fn paired_release_measurement_for_cut_local_extension() {
 fn extend_recomputes_only_the_newly_interned_samples() {
     let input = y_tree::<f64>();
     let problem =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
     let seed0 = vec![0, 0, 0, 0];
     let seed1 = vec![0, 1, 1, 1];
     let (mut arena, mut candidates) =
@@ -474,7 +483,8 @@ fn extend_recomputes_only_the_newly_interned_samples() {
 fn extend_reuses_the_same_cores_allocation_instead_of_cloning_it() {
     let input = y_tree::<f64>();
     let problem =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
     let seed0 = vec![0, 0, 0, 0];
     let seed1 = vec![0, 1, 1, 1];
     let (mut arena, mut candidates) =
@@ -504,7 +514,8 @@ fn extend_reuses_the_same_cores_allocation_instead_of_cloning_it() {
 fn candidate_frame_hits_the_cache_on_a_repeated_lookup() {
     let input = two_node_tree::<f64>();
     let problem =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
     let (arena, _) = SampleArena::from_global_seeds(&problem, &[vec![0, 0]]).unwrap();
     let frames =
         InputFrameStore::<f64>::from_samples(std::slice::from_ref(&input), &problem, &arena)
@@ -546,7 +557,7 @@ fn candidate_frame_stays_correct_when_the_shared_budget_has_no_headroom_for_cach
     // Exactly the persistent frame cache's own cost (see
     // `the_frame_cache_is_bounded_in_aggregate`: 64 bytes for this fixture),
     // leaving zero headroom for the candidate cache.
-    let tight = prepare_problem(
+    let tight = prepare_problem::<f64, _>(
         std::slice::from_ref(&input),
         &TreeAciOptions {
             max_frame_bytes: 64,
@@ -589,7 +600,7 @@ fn extend_reclaims_candidate_cache_when_base_frames_consume_its_budget() {
         std::mem::size_of::<super::CandidateCacheKey>() + 2 * std::mem::size_of::<f64>();
     let initial_frame_bytes = 32;
     let frame_budget = initial_frame_bytes + candidate_entry_bytes;
-    let problem = prepare_problem(
+    let problem = prepare_problem::<f64, _>(
         std::slice::from_ref(&input),
         &TreeAciOptions {
             max_frame_bytes: frame_budget,
@@ -646,7 +657,8 @@ fn the_frame_cache_is_bounded_in_aggregate() {
     let seeds = [vec![0, 0], vec![1, 1]];
 
     let generous =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
     let (arena, _) = SampleArena::from_global_seeds(&generous, &seeds).unwrap();
     let frames =
         InputFrameStore::<f64>::from_samples(std::slice::from_ref(&input), &generous, &arena)
@@ -657,7 +669,7 @@ fn the_frame_cache_is_bounded_in_aggregate() {
     assert_eq!(frames.records(), 2);
     assert_eq!(frames.retained_bytes(), 64);
 
-    let tight = prepare_problem(
+    let tight = prepare_problem::<f64, _>(
         std::slice::from_ref(&input),
         &TreeAciOptions {
             max_frame_bytes: 63,
@@ -683,10 +695,10 @@ fn the_frame_cache_is_bounded_in_aggregate() {
     // The two bounds are independent: a per-frame ceiling sized exactly to one
     // frame still admits every frame, which is why it cannot stand in for the
     // aggregate.
-    let per_frame_only = prepare_problem(
+    let per_frame_only = prepare_problem::<f64, _>(
         std::slice::from_ref(&input),
         &TreeAciOptions {
-            max_frame_elements: 4,
+            max_frame_elements: Some(4),
             ..TreeAciOptions::default()
         },
     )
@@ -952,7 +964,7 @@ fn star_tree_for_fallback_dispatch() -> TreeTN<IdxTensor, usize> {
 fn two_incoming_core_matrix_batched_matches_scalar_contraction_on_every_pair() {
     let inputs = vec![star_tree_for_fallback_dispatch()];
     let options = TreeAciOptions::default();
-    let problem = prepare_problem(&inputs, &options).unwrap();
+    let problem = prepare_problem::<f64, _>(&inputs, &options).unwrap();
     let cores = super::prepare_cores::<f64, usize>(&inputs[0], &problem).unwrap();
 
     let edge = problem
@@ -1166,7 +1178,7 @@ fn packed_candidate_frame_batch_preserves_column_major_order() {
 fn candidate_batches_reuse_one_oriented_core_for_distinct_candidates() {
     let input = chain_tree_for_batched_compute();
     let inputs = vec![input];
-    let problem = prepare_problem(&inputs, &TreeAciOptions::default()).unwrap();
+    let problem = prepare_problem::<f64, _>(&inputs, &TreeAciOptions::default()).unwrap();
     let edge = problem
         .directed_edges
         .iter()
@@ -1207,7 +1219,7 @@ fn candidate_batches_reuse_one_oriented_core_for_distinct_candidates() {
 fn complex_branch_candidate_batch_preserves_order_and_matches_scalar_frames() {
     let input = y_tree::<Complex64>();
     let inputs = vec![input];
-    let problem = prepare_problem(&inputs, &TreeAciOptions::default()).unwrap();
+    let problem = prepare_problem::<f64, _>(&inputs, &TreeAciOptions::default()).unwrap();
     let edge = problem
         .directed_edges
         .iter()
@@ -1254,7 +1266,7 @@ fn complex_branch_candidate_batch_preserves_order_and_matches_scalar_frames() {
 fn candidate_frames_for_edge_falls_back_on_a_leaf_edge_with_zero_incoming_edges() {
     let inputs = vec![star_tree_for_fallback_dispatch()];
     let options = TreeAciOptions::default();
-    let problem = prepare_problem(&inputs, &options).unwrap();
+    let problem = prepare_problem::<f64, _>(&inputs, &options).unwrap();
 
     let edge = problem
         .directed_edges
@@ -1302,7 +1314,7 @@ fn candidate_frames_for_edge_falls_back_on_a_leaf_edge_with_zero_incoming_edges(
 fn candidate_frames_for_edge_batches_a_branch_edge_with_two_incoming_edges() {
     let inputs = vec![star_tree_for_fallback_dispatch()];
     let options = TreeAciOptions::default();
-    let problem = prepare_problem(&inputs, &options).unwrap();
+    let problem = prepare_problem::<f64, _>(&inputs, &options).unwrap();
 
     let edge = problem
         .directed_edges
@@ -1365,7 +1377,7 @@ fn candidate_frames_for_edge_records_frame_diagnostics_with_hub_coordination_num
 
     let inputs = vec![star_tree_for_fallback_dispatch()];
     let options = TreeAciOptions::default();
-    let problem = prepare_problem(&inputs, &options).unwrap();
+    let problem = prepare_problem::<f64, _>(&inputs, &options).unwrap();
 
     let edge = problem
         .directed_edges
@@ -1423,7 +1435,7 @@ fn frame_diagnostics_keys_are_namespaced_per_input_operand() {
     let tree = star_tree_for_fallback_dispatch();
     let inputs = vec![tree.clone(), tree];
     let options = TreeAciOptions::default();
-    let problem = prepare_problem(&inputs, &options).unwrap();
+    let problem = prepare_problem::<f64, _>(&inputs, &options).unwrap();
 
     let edge = problem
         .directed_edges
@@ -1472,7 +1484,7 @@ fn frame_diagnostics_keys_are_namespaced_per_input_operand() {
 #[test]
 fn two_incoming_candidate_batch_obeys_the_working_byte_limit() {
     let inputs = vec![star_tree_for_fallback_dispatch()];
-    let mut problem = prepare_problem(&inputs, &TreeAciOptions::default()).unwrap();
+    let mut problem = prepare_problem::<f64, _>(&inputs, &TreeAciOptions::default()).unwrap();
     let edge = problem
         .directed_edges
         .iter()
@@ -1555,7 +1567,7 @@ fn four_arm_star_tree_for_three_incoming_fallback() -> TreeTN<IdxTensor, usize> 
 fn candidate_frames_for_edge_batches_three_incoming_edges() {
     let inputs = vec![four_arm_star_tree_for_three_incoming_fallback()];
     let options = TreeAciOptions::default();
-    let problem = prepare_problem(&inputs, &options).unwrap();
+    let problem = prepare_problem::<f64, _>(&inputs, &options).unwrap();
 
     let edge = problem
         .directed_edges
@@ -1668,7 +1680,7 @@ fn chain_tree_for_batched_compute() -> TreeTN<IdxTensor, usize> {
 fn batched_duplicate_candidates_are_counted_once_in_the_cache_budget() {
     let input = chain_tree_for_batched_compute();
     let inputs = vec![input];
-    let problem = prepare_problem(&inputs, &TreeAciOptions::default()).unwrap();
+    let problem = prepare_problem::<f64, _>(&inputs, &TreeAciOptions::default()).unwrap();
     let edge = problem
         .directed_edges
         .iter()
@@ -1705,7 +1717,8 @@ fn batched_duplicate_candidates_are_counted_once_in_the_cache_budget() {
 fn compute_batch_matches_scalar_compute_on_a_chain_edge() {
     let input = chain_tree_for_batched_compute();
     let problem =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
 
     let edge = problem
         .directed_edges
@@ -1767,7 +1780,8 @@ fn compute_batch_matches_scalar_compute_on_a_chain_edge() {
 fn extend_matches_a_full_rebuild_on_a_chain_with_a_batched_edge() {
     let input = chain_tree_for_batched_compute();
     let problem =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
 
     let edge = problem
         .directed_edges
@@ -1890,7 +1904,8 @@ fn chain5_tree_for_dedup_regression() -> TreeTN<IdxTensor, usize> {
 fn from_samples_issues_exactly_one_compute_call_per_memo_slot_on_a_five_node_chain() {
     let input = chain5_tree_for_dedup_regression();
     let problem =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
 
     // Four distinct global seeds, varying node 0/1/2's physical values, so
     // every directed edge accumulates multiple distinct samples rather than
@@ -1930,7 +1945,8 @@ fn from_samples_issues_exactly_one_compute_call_per_memo_slot_on_a_five_node_cha
 fn priming_reuses_memoized_incoming_without_copying_again() {
     let input = chain_tree_for_batched_compute();
     let problem =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
     let (arena, _) = SampleArena::from_global_seeds(&problem, &[vec![0, 0, 0]]).unwrap();
     let edge = problem
         .directed_edges
@@ -1958,7 +1974,8 @@ fn priming_reuses_memoized_incoming_without_copying_again() {
 fn from_samples_uses_scalar_only_for_non_batch_edges_on_a_chain() {
     let input = chain5_tree_for_dedup_regression();
     let problem =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
     let seeds = vec![
         vec![0, 0, 0, 0, 0],
         vec![1, 0, 0, 0, 0],
@@ -1993,7 +2010,8 @@ fn from_samples_uses_scalar_only_for_non_batch_edges_on_a_chain() {
 fn dependency_order_places_incoming_frames_before_dependents_on_a_star() {
     let input = star_tree_for_fallback_dispatch();
     let problem =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
     let order = crate::problem::dependency_order(&problem.directed_edges).unwrap();
     assert_eq!(order.len(), problem.directed_edges.len());
 
@@ -2022,7 +2040,8 @@ fn dependency_order_places_incoming_frames_before_dependents_on_a_star() {
 fn compute_batch_falls_back_correctly_on_a_leaf_edge() {
     let input = star_tree_for_fallback_dispatch();
     let problem =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
 
     let edge = problem
         .directed_edges
@@ -2076,7 +2095,8 @@ fn compute_batch_falls_back_correctly_on_a_leaf_edge() {
 fn compute_batch_batches_a_branch_edge_with_two_incoming_edges() {
     let input = star_tree_for_fallback_dispatch();
     let problem =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
 
     let edge = problem
         .directed_edges
@@ -2120,7 +2140,8 @@ fn compute_batch_batches_a_branch_edge_with_two_incoming_edges() {
 fn compute_batch_keeps_the_scalar_route_on_three_incoming_edges() {
     let input = four_arm_star_tree_for_three_incoming_fallback();
     let problem =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
 
     let edge = problem
         .directed_edges
@@ -2175,7 +2196,8 @@ fn compute_batch_keeps_the_scalar_route_on_three_incoming_edges() {
 fn compute_pulls_already_known_samples_from_the_previous_store_without_recomputing() {
     let input = chain_tree_for_batched_compute();
     let problem =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
 
     let edge = problem
         .directed_edges
@@ -2299,7 +2321,8 @@ fn compute_pulls_already_known_samples_from_the_previous_store_without_recomputi
 fn extend_reuses_unchanged_edges_via_rc_instead_of_rebuilding_them() {
     let input = chain5_tree_for_dedup_regression();
     let problem =
-        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+        prepare_problem::<f64, _>(std::slice::from_ref(&input), &TreeAciOptions::default())
+            .unwrap();
     let edge_count = problem.directed_edges.len();
 
     let (mut arena, _candidates) =
@@ -2431,7 +2454,7 @@ fn branch_point_batched_speedup_vs_scalar_at_realistic_scale() {
 
     let inputs = vec![star];
     let options = TreeAciOptions::default();
-    let problem = prepare_problem(&inputs, &options).unwrap();
+    let problem = prepare_problem::<f64, _>(&inputs, &options).unwrap();
     let edge = problem
         .directed_edges
         .iter()
@@ -2946,7 +2969,7 @@ fn assert_multi_incoming_matches_scalar<T: FixtureScalar>(
     degree: usize,
 ) {
     let inputs = vec![input];
-    let problem = prepare_problem(&inputs, &TreeAciOptions::default()).unwrap();
+    let problem = prepare_problem::<f64, _>(&inputs, &TreeAciOptions::default()).unwrap();
     let edge = hub_edge(&problem, degree);
     let (arena, candidate_sets) = SampleArena::from_global_seeds(&problem, seeds).unwrap();
     let frames = InputFrameStore::<T>::from_samples(&inputs, &problem, &arena).unwrap();
@@ -3035,7 +3058,7 @@ fn four_incoming_candidate_batches_match_the_scalar_oracle() {
 #[test]
 fn multi_incoming_batch_preserves_order_for_duplicate_and_reordered_candidates() {
     let inputs = vec![three_incoming_star::<f64>()];
-    let problem = prepare_problem(&inputs, &TreeAciOptions::default()).unwrap();
+    let problem = prepare_problem::<f64, _>(&inputs, &TreeAciOptions::default()).unwrap();
     let edge = hub_edge(&problem, 3);
     let seeds = vec![
         vec![0, 0, 0, 0, 0],
@@ -3082,7 +3105,7 @@ fn multi_incoming_batch_preserves_order_for_duplicate_and_reordered_candidates()
 #[test]
 fn multi_incoming_batch_falls_back_to_scalar_for_a_sparse_candidate_set() {
     let inputs = vec![three_incoming_star::<f64>()];
-    let problem = prepare_problem(&inputs, &TreeAciOptions::default()).unwrap();
+    let problem = prepare_problem::<f64, _>(&inputs, &TreeAciOptions::default()).unwrap();
     let edge = hub_edge(&problem, 3);
     let seeds = vec![
         vec![0, 0, 0, 0, 0],
@@ -3139,7 +3162,7 @@ fn multi_incoming_batch_falls_back_to_scalar_for_a_sparse_candidate_set() {
 #[test]
 fn multi_incoming_batch_falls_back_to_scalar_when_the_working_budget_is_tight() {
     let inputs = vec![three_incoming_star::<f64>()];
-    let mut problem = prepare_problem(&inputs, &TreeAciOptions::default()).unwrap();
+    let mut problem = prepare_problem::<f64, _>(&inputs, &TreeAciOptions::default()).unwrap();
     let edge = hub_edge(&problem, 3);
     let seeds = vec![
         vec![0, 0, 0, 0, 0],
@@ -3189,7 +3212,7 @@ fn multi_incoming_batch_falls_back_to_scalar_when_the_working_budget_is_tight() 
 #[test]
 fn multi_incoming_batch_is_deterministic_and_never_caches_candidates() {
     let inputs = vec![three_incoming_star::<f64>()];
-    let problem = prepare_problem(&inputs, &TreeAciOptions::default()).unwrap();
+    let problem = prepare_problem::<f64, _>(&inputs, &TreeAciOptions::default()).unwrap();
     let edge = hub_edge(&problem, 3);
     let seeds = vec![
         vec![0, 0, 0, 0, 0],
@@ -3506,7 +3529,7 @@ fn measure_three_incoming_case(m: usize, d: usize) {
     let inputs =
         vec![TreeTN::from_tensors(vec![hub, arm1, arm2, arm3, arm4], vec![0, 1, 2, 3, 4]).unwrap()];
 
-    let problem = prepare_problem(&inputs, &TreeAciOptions::default()).unwrap();
+    let problem = prepare_problem::<f64, _>(&inputs, &TreeAciOptions::default()).unwrap();
     let edge = hub_edge(&problem, 3);
     let seeds: Vec<Vec<usize>> = (0..m)
         .map(|index| vec![0, 0, index, index, index])
@@ -3666,7 +3689,7 @@ fn measure_candidate_product_accounting(
     }
     let inputs = vec![TreeTN::from_tensors(tensors, (0..5).collect()).unwrap()];
 
-    let problem = prepare_problem(&inputs, &TreeAciOptions::default()).unwrap();
+    let problem = prepare_problem::<f64, _>(&inputs, &TreeAciOptions::default()).unwrap();
     let edge = hub_edge(&problem, 3);
     let seeds: Vec<Vec<usize>> = (0..m)
         .map(|index| vec![0, 0, index, index, index])

--- a/crates/tensor4all-treeaci/src/frames/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/frames/tests/mod.rs
@@ -1206,6 +1206,7 @@ fn candidate_batches_reuse_one_oriented_core_for_distinct_candidates() {
                     local_coordinate,
                     incoming: vec![(incoming_edge, incoming_sample)],
                 }],
+                0,
             )
             .unwrap();
     }
@@ -1245,7 +1246,7 @@ fn complex_branch_candidate_batch_preserves_order_and_matches_scalar_frames() {
         .collect::<Vec<_>>();
 
     let packed = frames
-        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates)
+        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates, 0)
         .unwrap();
     let scalar = candidates
         .iter()
@@ -1293,7 +1294,7 @@ fn candidate_frames_for_edge_falls_back_on_a_leaf_edge_with_zero_incoming_edges(
     ];
 
     let dispatched = frames
-        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates)
+        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates, 0)
         .unwrap();
     let scalar = candidates
         .iter()
@@ -1353,7 +1354,7 @@ fn candidate_frames_for_edge_batches_a_branch_edge_with_two_incoming_edges() {
     assert_eq!(candidates.len(), 8);
 
     let dispatched = frames
-        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates)
+        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates, 0)
         .unwrap();
     let scalar = candidates
         .iter()
@@ -1410,7 +1411,7 @@ fn candidate_frames_for_edge_records_frame_diagnostics_with_hub_coordination_num
 
     branch_diagnostics::reset();
     let _dispatched = frames
-        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates)
+        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates, 0)
         .unwrap();
 
     let snapshot = branch_diagnostics::snapshot();
@@ -1507,14 +1508,14 @@ fn two_incoming_candidate_batch_obeys_the_working_byte_limit() {
         }
     }
     let scratch_bytes = frames
-        .enumerated_candidate_frame_scratch_elements(&problem, 0, edge, &candidate_sets)
+        .enumerated_candidate_frame_scratch_elements(&problem, 0, edge, &candidate_sets, 0)
         .unwrap()
         * std::mem::size_of::<f64>();
     assert!(scratch_bytes > 0);
     problem.max_working_bytes = scratch_bytes - 1;
 
     let error = frames
-        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates)
+        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates, 0)
         .unwrap_err();
 
     assert!(matches!(
@@ -1600,7 +1601,7 @@ fn candidate_frames_for_edge_batches_three_incoming_edges() {
 
     super::multi_incoming_debug_stats::reset();
     let dispatched = frames
-        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates)
+        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates, 0)
         .unwrap();
     // The complete cross now takes the generalized batched route; the scalar
     // `candidate_frame` path below stays the differential oracle.
@@ -1697,7 +1698,14 @@ fn batched_duplicate_candidates_are_counted_once_in_the_cache_budget() {
     let retained_before = frames.retained_bytes();
 
     let result = frames
-        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &[candidate.clone(), candidate])
+        .candidate_frames_for_edge(
+            &inputs,
+            &problem,
+            0,
+            edge,
+            &[candidate.clone(), candidate],
+            0,
+        )
         .unwrap();
 
     assert_eq!(result[0], result[1]);
@@ -2487,7 +2495,7 @@ fn branch_point_batched_speedup_vs_scalar_at_realistic_scale() {
     let batched_frames = InputFrameStore::<f64>::from_samples(&inputs, &problem, &arena).unwrap();
     let batched_start = Instant::now();
     let batched = batched_frames
-        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates)
+        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates, 0)
         .unwrap();
     let batched_elapsed = batched_start.elapsed();
 
@@ -2981,7 +2989,7 @@ fn assert_multi_incoming_matches_scalar<T: FixtureScalar>(
 
     super::multi_incoming_debug_stats::reset();
     let packed = frames
-        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates)
+        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates, 0)
         .unwrap();
     let batched_groups = super::multi_incoming_debug_stats::batched_groups();
 
@@ -3079,7 +3087,7 @@ fn multi_incoming_batch_preserves_order_for_duplicate_and_reordered_candidates()
 
     super::multi_incoming_debug_stats::reset();
     let packed = frames
-        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates)
+        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates, 0)
         .unwrap();
     assert!(super::multi_incoming_debug_stats::batched_groups() > 0);
 
@@ -3142,7 +3150,7 @@ fn multi_incoming_batch_falls_back_to_scalar_for_a_sparse_candidate_set() {
 
     super::multi_incoming_debug_stats::reset();
     let packed = frames
-        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates)
+        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates, 0)
         .unwrap();
     assert_eq!(super::multi_incoming_debug_stats::batched_groups(), 0);
     assert_eq!(super::multi_incoming_debug_stats::scalar_groups(), 1);
@@ -3174,7 +3182,7 @@ fn multi_incoming_batch_falls_back_to_scalar_when_the_working_budget_is_tight() 
     let candidates = full_cross_candidates(&problem, &candidate_sets, edge);
 
     let batched_bytes = frames
-        .enumerated_candidate_frame_scratch_elements(&problem, 0, edge, &candidate_sets)
+        .enumerated_candidate_frame_scratch_elements(&problem, 0, edge, &candidate_sets, 0)
         .unwrap()
         * std::mem::size_of::<f64>();
     assert!(batched_bytes > 0);
@@ -3185,7 +3193,7 @@ fn multi_incoming_batch_falls_back_to_scalar_when_the_working_budget_is_tight() 
     // over budget or raising a limit error.
     super::multi_incoming_debug_stats::reset();
     let packed = frames
-        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates)
+        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates, 0)
         .unwrap();
     assert_eq!(super::multi_incoming_debug_stats::batched_groups(), 0);
     assert!(super::multi_incoming_debug_stats::scalar_groups() > 0);
@@ -3204,9 +3212,199 @@ fn multi_incoming_batch_falls_back_to_scalar_when_the_working_budget_is_tight() 
     // The over-budget estimate must also shrink back to the scalar charge, so
     // the local update's pre-flight and the kernel agree on the same route.
     let fallback_elements = frames
-        .enumerated_candidate_frame_scratch_elements(&problem, 0, edge, &candidate_sets)
+        .enumerated_candidate_frame_scratch_elements(&problem, 0, edge, &candidate_sets, 0)
         .unwrap();
     assert!(fallback_elements * std::mem::size_of::<f64>() <= problem.max_working_bytes);
+}
+
+/// Issue #726: the batched route is affordable only relative to what the
+/// caller is already holding, so the same edge, the same candidates, and the
+/// same budget route differently once a reservation is declared -- and the
+/// estimate moves with the kernel, not against it.
+#[test]
+fn multi_incoming_routing_follows_the_caller_reservation() {
+    let inputs = vec![three_incoming_star::<f64>()];
+    let problem = prepare_problem::<f64, _>(&inputs, &TreeAciOptions::default()).unwrap();
+    let edge = hub_edge(&problem, 3);
+    let seeds = vec![
+        vec![0, 0, 0, 0, 0],
+        vec![3, 1, 2, 1, 1],
+        vec![1, 0, 1, 0, 1],
+    ];
+    let (arena, candidate_sets) = SampleArena::from_global_seeds(&problem, &seeds).unwrap();
+    let frames = InputFrameStore::<f64>::from_samples(&inputs, &problem, &arena).unwrap();
+    let candidates = full_cross_candidates(&problem, &candidate_sets, edge);
+
+    let batched_elements = frames
+        .enumerated_candidate_frame_scratch_elements(&problem, 0, edge, &candidate_sets, 0)
+        .unwrap();
+    let batched_bytes = batched_elements * std::mem::size_of::<f64>();
+
+    // Nothing reserved: the whole budget is available and the cross is taken.
+    super::multi_incoming_debug_stats::reset();
+    let unreserved = frames
+        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates, 0)
+        .unwrap();
+    assert!(super::multi_incoming_debug_stats::batched_groups() > 0);
+    assert_eq!(super::multi_incoming_debug_stats::scalar_groups(), 0);
+
+    // Reserve everything but one byte less than the cross needs. The kernel
+    // degrades instead of overrunning the budget, and the estimate reports the
+    // route the kernel will take rather than the one it cannot afford.
+    let reservation = problem.max_working_bytes - batched_bytes + 1;
+    super::multi_incoming_debug_stats::reset();
+    let reserved = frames
+        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates, reservation)
+        .unwrap();
+    assert_eq!(super::multi_incoming_debug_stats::batched_groups(), 0);
+    assert!(super::multi_incoming_debug_stats::scalar_groups() > 0);
+
+    let scalar_elements = frames
+        .enumerated_candidate_frame_scratch_elements(
+            &problem,
+            0,
+            edge,
+            &candidate_sets,
+            reservation,
+        )
+        .unwrap();
+    assert!(
+        scalar_elements < batched_elements,
+        "the degraded charge must be the cheaper one: {scalar_elements} vs {batched_elements}"
+    );
+    assert!(
+        scalar_elements * std::mem::size_of::<f64>() + reservation <= problem.max_working_bytes,
+        "the reported charge must fit the budget that remains"
+    );
+    // Routing is a memory decision, never a numerical one: the two routes
+    // differ only in the order their identical contractions are reduced.
+    assert_eq!(unreserved.candidate_count(), reserved.candidate_count());
+    assert_eq!(unreserved.bond_dim(), reserved.bond_dim());
+    let scale = unreserved
+        .as_col_major_slice()
+        .iter()
+        .fold(0.0f64, |scale, value| scale.max(value.abs()));
+    let residual = unreserved
+        .as_col_major_slice()
+        .iter()
+        .zip(reserved.as_col_major_slice())
+        .fold(0.0f64, |residual, (left, right)| {
+            residual.max((left - right).abs())
+        });
+    assert!(
+        residual <= 1.0e-12 * scale,
+        "the degraded route changed the values: {residual:.3e} against scale {scale:.3e}"
+    );
+}
+
+/// The local update's aggregate pre-flight and the kernel it charges for now
+/// agree on the same route, so a budget that admits the batched cross alone
+/// but not together with the update's own live buffers runs on the scalar
+/// route instead of being refused (#726).
+#[test]
+fn local_update_degrades_instead_of_refusing_an_aggregate_overrun() {
+    let inputs = vec![three_incoming_star::<f64>()];
+    let mut problem = prepare_problem::<f64, _>(&inputs, &TreeAciOptions::default()).unwrap();
+    let edge = hub_edge(&problem, 3);
+    let seeds = vec![
+        vec![0, 0, 0, 0, 0],
+        vec![3, 1, 2, 1, 1],
+        vec![1, 0, 1, 0, 1],
+    ];
+    let (arena, candidate_sets) = SampleArena::from_global_seeds(&problem, &seeds).unwrap();
+    let frames = InputFrameStore::<f64>::from_samples(&inputs, &problem, &arena).unwrap();
+    let options = TreeAciOptions::default();
+    let mut square = |batch: crate::TreeElementwiseBatch<'_, f64>, output: &mut [f64]| {
+        for (point, value) in output.iter_mut().enumerate() {
+            let value_at_point = batch.get(0, point)?;
+            *value = value_at_point * value_at_point;
+        }
+        Ok(())
+    };
+
+    let generous = crate::local_update::materialize_and_factor_edge(
+        &inputs,
+        &problem,
+        &candidate_sets,
+        &frames,
+        edge,
+        &options,
+        true,
+        &mut square,
+    )
+    .expect("the default budget admits this edge");
+
+    // The exact window: the batched cross fits `max_working_bytes` on its own,
+    // and does not fit once the update's own buffers are counted. Before #726
+    // this configuration was refused with a typed limit error even though the
+    // scalar route was affordable.
+    let reserved_bytes = crate::local_update::reserved_working_bytes::<f64>(
+        inputs.len() * generous.row_count * generous.col_count,
+        generous.row_count * generous.col_count,
+        generous.row_count,
+        generous.col_count,
+        (0..inputs.len())
+            .map(|input| frames.bond_dim(input, edge).unwrap())
+            .max()
+            .unwrap(),
+    )
+    .unwrap();
+    let batched_bytes = (0..inputs.len())
+        .map(|input| {
+            frames
+                .enumerated_candidate_frame_scratch_elements(
+                    &problem,
+                    input,
+                    edge,
+                    &candidate_sets,
+                    0,
+                )
+                .unwrap()
+        })
+        .max()
+        .unwrap()
+        * std::mem::size_of::<f64>();
+    assert!(reserved_bytes > 0);
+    problem.max_working_bytes = reserved_bytes + batched_bytes - 1;
+    assert!(
+        batched_bytes <= problem.max_working_bytes,
+        "the batched cross must still fit the budget on its own"
+    );
+
+    super::multi_incoming_debug_stats::reset();
+    let degraded = crate::local_update::materialize_and_factor_edge(
+        &inputs,
+        &problem,
+        &candidate_sets,
+        &frames,
+        edge,
+        &options,
+        true,
+        &mut square,
+    )
+    .expect("an affordable scalar route must not be refused");
+    assert_eq!(super::multi_incoming_debug_stats::batched_groups(), 0);
+    assert!(super::multi_incoming_debug_stats::scalar_groups() > 0);
+    assert_eq!(degraded.row_count, generous.row_count);
+    assert_eq!(degraded.col_count, generous.col_count);
+    assert_eq!(degraded.pivot_errors.len(), generous.pivot_errors.len());
+    // The two routes contract the same numbers in a different order, so they
+    // agree to rounding rather than bit for bit.
+    let scale = generous
+        .local_values
+        .iter()
+        .fold(0.0f64, |scale, value| scale.max(value.abs()));
+    let residual = degraded
+        .local_values
+        .iter()
+        .zip(&generous.local_values)
+        .fold(0.0f64, |residual, (left, right)| {
+            residual.max((left - right).abs())
+        });
+    assert!(
+        residual <= 1.0e-12 * scale,
+        "the degraded route changed the local matrix: {residual:.3e} against scale {scale:.3e}"
+    );
 }
 
 #[test]
@@ -3227,7 +3425,7 @@ fn multi_incoming_batch_is_deterministic_and_never_caches_candidates() {
     for _ in 0..3 {
         super::candidate_debug_stats::reset();
         let packed = frames
-            .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates)
+            .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates, 0)
             .unwrap();
         // Three-or-more-incoming candidates are deliberately not cached: the
         // repeat runs must keep missing, exactly as the scalar route did.
@@ -3562,7 +3760,7 @@ fn measure_three_incoming_case(m: usize, d: usize) {
         super::multi_incoming_debug_stats::reset();
         let started = Instant::now();
         let batched = batched_frames
-            .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates)
+            .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates, 0)
             .unwrap();
         batched_times.push(started.elapsed());
         assert!(super::multi_incoming_debug_stats::batched_groups() > 0);
@@ -3717,7 +3915,7 @@ fn measure_candidate_product_accounting(
     super::debug_stats::reset();
     super::multi_incoming_debug_stats::reset();
     let batched = batched_frames
-        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates)
+        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates, 0)
         .unwrap();
     let batched_core_reads = super::debug_stats::core_element_reads();
     assert_eq!(

--- a/crates/tensor4all-treeaci/src/global_guard.rs
+++ b/crates/tensor4all-treeaci/src/global_guard.rs
@@ -110,7 +110,7 @@ where
             start,
             options.nsweeps_global_search,
             threshold,
-            |points: &[Vec<usize>]| -> Result<Vec<f64>> {
+            |scan_site: Option<usize>, points: &[Vec<usize>]| -> Result<Vec<f64>> {
                 evaluated_points = checked_add_points(evaluated_points, points.len())?;
                 let retained_bytes = site_dims_bytes
                     .checked_add(start_storage_bytes)
@@ -121,7 +121,10 @@ where
                 input_evaluators
                     .enforce_guard_batch_budget_with_retained::<T>(points.len(), retained_bytes)?;
                 let coordinates = input_evaluators.expand_points(points)?;
-                let hint = input_evaluators.evaluation_hint(points);
+                // The walk declares which site it is scanning, so the hint no
+                // longer has to be inferred from the batch -- which a batch of
+                // one point cannot support at all.
+                let hint = input_evaluators.hint_for_scan_site(scan_site);
                 let input_values =
                     input_evaluators.evaluate_expanded::<T>(points, &coordinates, hint.clone())?;
                 let batch =
@@ -612,31 +615,6 @@ pub(crate) mod input_evaluator_debug_stats {
     }
 }
 
-/// Returns the one logical site that varies across a floating-zone batch.
-///
-/// Single-point or multi-site batches do not provide enough scan structure and
-/// deliberately fall back to the evaluator's ordinary center selection.
-fn sole_varying_site(points: &[Vec<usize>]) -> Option<usize> {
-    let first = points.first()?;
-    let mut varying = None;
-    for point in points.iter().skip(1) {
-        if point.len() != first.len() {
-            return None;
-        }
-        for (site, (left, right)) in first.iter().zip(point).enumerate() {
-            if left == right {
-                continue;
-            }
-            match varying {
-                None => varying = Some(site),
-                Some(known) if known == site => {}
-                Some(_) => return None,
-            }
-        }
-    }
-    varying
-}
-
 impl<'a, V: TreeAciNode> InputEvaluators<'a, V> {
     #[cfg(test)]
     pub(crate) fn new(
@@ -700,10 +678,11 @@ impl<'a, V: TreeAciNode> InputEvaluators<'a, V> {
         })
     }
 
+    /// Evaluates an unstructured batch, with no scan site to hint.
     pub(crate) fn evaluate<T: TreeAciScalar>(&mut self, points: &[Vec<usize>]) -> Result<Vec<T>> {
         self.enforce_guard_batch_budget::<T>(points.len())?;
         let coordinates = self.expand_points(points)?;
-        let hint = self.evaluation_hint(points);
+        let hint = self.hint_for_scan_site(None);
         self.evaluate_expanded(points, &coordinates, hint)
     }
 
@@ -797,9 +776,12 @@ impl<'a, V: TreeAciNode> InputEvaluators<'a, V> {
         &self.plan
     }
 
-    fn evaluation_hint(&self, points: &[Vec<usize>]) -> EvaluationHint<V> {
-        sole_varying_site(points)
-            .and_then(|site| self.node_order.get(site).cloned())
+    /// The evaluation hint for a floating-zone scan of `site`.
+    ///
+    /// `None` is the seed evaluation, which has no scan structure to declare
+    /// and falls back to the evaluator's ordinary centre selection.
+    fn hint_for_scan_site(&self, site: Option<usize>) -> EvaluationHint<V> {
+        site.and_then(|site| self.node_order.get(site).cloned())
             .map(EvaluationHint::around)
             .unwrap_or_default()
     }
@@ -888,7 +870,7 @@ impl<'a, V: TreeAciNode> GuardOutputEvaluator<'a, V> {
     ) -> Result<Vec<T>> {
         input_evaluators.enforce_guard_batch_budget::<T>(points.len())?;
         let coordinates = input_evaluators.expand_points(points)?;
-        let hint = input_evaluators.evaluation_hint(points);
+        let hint = input_evaluators.hint_for_scan_site(None);
         self.evaluate_expanded(input_evaluators, points, &coordinates, hint)
     }
 

--- a/crates/tensor4all-treeaci/src/global_guard/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/global_guard/tests/mod.rs
@@ -4,7 +4,7 @@ use tensor4all_treetn::TreeTN;
 
 use super::{
     find_global_pivots, inject_global_pivots, per_evaluator_message_cache_budget,
-    sole_varying_site, GuardOutputEvaluator, InputEvaluators,
+    GuardOutputEvaluator, InputEvaluators,
 };
 use crate::{
     schedule::{run_directional_pass, PassDirection},
@@ -798,7 +798,7 @@ fn shared_guard_hint_preserves_input_and_output_values() {
     .unwrap();
     let points = vec![vec![0, 0], vec![1, 0]];
     let coordinates = input_evaluators.expand_points(&points).unwrap();
-    let hint = input_evaluators.evaluation_hint(&points);
+    let hint = input_evaluators.hint_for_scan_site(Some(0));
     let input_values = input_evaluators
         .evaluate_expanded::<f64>(&points, &coordinates, hint.clone())
         .unwrap();
@@ -830,15 +830,20 @@ fn guard_cached_evaluator_preserves_all_scalar_kinds() {
     assert_guard_typed_evaluation::<Complex64>();
 }
 
+/// The scan site the walk declares is what selects the centre, and the seed
+/// evaluation declares none.
 #[test]
-fn varying_site_detection_rejects_non_scan_batches() {
-    assert_eq!(
-        sole_varying_site(&[vec![0, 0, 0], vec![0, 1, 0], vec![0, 2, 0]]),
-        Some(1)
-    );
-    assert_eq!(sole_varying_site(&[vec![0, 0], vec![1, 1]]), None);
-    assert_eq!(sole_varying_site(&[vec![0, 0]]), None);
-    assert_eq!(sole_varying_site(&[vec![0, 0], vec![0]]), None);
+fn scan_site_selects_the_hinted_center() {
+    let (input, _, _) = delta_tree();
+    let inputs = vec![input];
+    let state =
+        TreeAciState::<f64, usize>::initialize(&inputs, &TreeAciOptions::default()).unwrap();
+    let evaluators = InputEvaluators::new(state.inputs, &state.problem).unwrap();
+
+    assert_eq!(evaluators.hint_for_scan_site(Some(1)).center, Some(1));
+    assert_eq!(evaluators.hint_for_scan_site(None).center, None);
+    // A site outside the tree cannot be hinted, and must not be invented.
+    assert_eq!(evaluators.hint_for_scan_site(Some(99)).center, None);
 }
 
 /// Padding rejects an over-budget request before allocating any padded core.
@@ -875,4 +880,240 @@ fn padding_refuses_an_over_budget_request() {
         ),
         "unexpected error: {error}"
     );
+}
+
+/// Opt-in cost attribution for the Guard's evaluation shape on the 32-site
+/// high-rank chain (issue #728).
+///
+/// The Guard walks `nsearch_global_pivots` independent floating-zone
+/// trajectories, and each walk step asks for one site's `local_dim` points.
+/// That is 2 points per evaluator call, which is what makes the reported 2,218
+/// calls for 8,844 scalars. The trajectories are independent, so the same
+/// points could be requested in one call per (sweep, site) across all starts
+/// instead -- "option 1" of the issue, which changes only how the search is
+/// executed and not what it searches.
+///
+/// This measures whether that is actually cheaper, using the same points in
+/// both shapes, before any search behaviour is changed. Run with
+/// `--ignored --nocapture`.
+#[test]
+#[ignore]
+fn diagnostic_guard_batch_shape_on_the_high_rank_chain() {
+    use std::time::Instant;
+
+    const N_SITES: usize = 32;
+    const NSEARCH: usize = 5;
+    const SWEEPS: usize = 3;
+
+    for chi in [64, 256] {
+        let guess = crate::state::tests::full_rank_chain_guess(N_SITES, chi);
+        let inputs = vec![guess.clone(), guess.clone()];
+        let options = TreeAciOptions {
+            tolerance: 1.0e-8,
+            max_bond_dim: Some(4096),
+            max_sweeps: 2,
+            min_sweeps: 2,
+            initial_guess: Some(guess),
+            enable_global_guard: false,
+            ..TreeAciOptions::default()
+        };
+        let state = TreeAciState::<f64, usize>::initialize(&inputs, &options).unwrap();
+        let budget =
+            per_evaluator_message_cache_budget(options.message_cache_max_bytes, inputs.len())
+                .unwrap();
+
+        // The trajectories the Guard would walk, materialized up front so both
+        // shapes evaluate exactly the same points in the same order.
+        let mut starts: Vec<Vec<usize>> = Vec::with_capacity(NSEARCH);
+        for start in 0..NSEARCH {
+            starts.push(
+                (0..N_SITES)
+                    .map(|site| (start * 7 + site * 3) % 2)
+                    .collect(),
+            );
+        }
+        let mut steps: Vec<Vec<Vec<usize>>> = Vec::new();
+        for _sweep in 0..SWEEPS {
+            for site in 0..N_SITES {
+                for start in &starts {
+                    let mut points = Vec::with_capacity(2);
+                    for value in 0..2 {
+                        let mut point = start.clone();
+                        point[site] = value;
+                        points.push(point);
+                    }
+                    steps.push(points);
+                }
+            }
+        }
+
+        // Shape A: one call per (start, sweep, site), which is what the walk
+        // does today.
+        let mut per_start =
+            InputEvaluators::new_with_message_cache_max_bytes(state.inputs, &state.problem, budget)
+                .unwrap();
+        per_start.evaluate::<f64>(&starts[..1]).unwrap();
+        let started = Instant::now();
+        let mut per_start_values = Vec::new();
+        for points in &steps {
+            per_start_values.extend(per_start.evaluate::<f64>(points).unwrap());
+        }
+        let per_start_elapsed = started.elapsed();
+
+        // Shape B: one call per (sweep, site) carrying every start's points.
+        // Identical points, identical order, `NSEARCH` times fewer calls.
+        let mut lockstep =
+            InputEvaluators::new_with_message_cache_max_bytes(state.inputs, &state.problem, budget)
+                .unwrap();
+        lockstep.evaluate::<f64>(&starts[..1]).unwrap();
+        let started = Instant::now();
+        let mut lockstep_values = Vec::new();
+        for chunk in steps.chunks(NSEARCH) {
+            let points = chunk.iter().flatten().cloned().collect::<Vec<_>>();
+            lockstep_values.extend(lockstep.evaluate::<f64>(&points).unwrap());
+        }
+        let lockstep_elapsed = started.elapsed();
+
+        assert_eq!(per_start_values.len(), lockstep_values.len());
+        let residual = per_start_values
+            .iter()
+            .zip(&lockstep_values)
+            .fold(0.0f64, |residual, (left, right)| {
+                residual.max((left - right).abs())
+            });
+        let scale = per_start_values
+            .iter()
+            .fold(0.0f64, |scale, value| scale.max(value.abs()));
+        assert!(
+            residual <= 1.0e-12 * scale.max(1.0),
+            "batching changed the values: {residual:.3e}"
+        );
+
+        eprintln!(
+            "guard batch shape chi={chi}: per_start={per_start_elapsed:?} over {} calls of 2 points ({:.1} us/call), lockstep={lockstep_elapsed:?} over {} calls of {} points ({:.1} us/call), speedup={:.2}x",
+            steps.len(),
+            per_start_elapsed.as_secs_f64() * 1.0e6 / steps.len() as f64,
+            steps.len() / NSEARCH,
+            2 * NSEARCH,
+            lockstep_elapsed.as_secs_f64() * 1.0e6 * NSEARCH as f64 / steps.len() as f64,
+            per_start_elapsed.as_secs_f64() / lockstep_elapsed.as_secs_f64(),
+        );
+    }
+}
+
+/// Opt-in comparison of the Guard's per-call evaluation cost on a chain and on
+/// a branched tree of the same walk shape (issues #727 and #728).
+///
+/// The #718 gate found an unequal incident-bond layout costing ~24x more per
+/// evaluated point than an equal one at the same hub bond product. The phase
+/// profile attributes that to the Guard running at all on the unequal layouts
+/// (the equal one is rank-limited and skips it), so what matters is what one
+/// Guard evaluation costs on a branched tree. Run with `--ignored --nocapture`.
+#[test]
+#[ignore]
+fn diagnostic_guard_call_cost_on_a_branched_tree() {
+    use std::time::Instant;
+
+    const NSEARCH: usize = 5;
+    const SWEEPS: usize = 3;
+    const ARM_LENGTH: usize = 3;
+    const ARM_CHI: usize = 4;
+
+    let cases: [(&str, Vec<usize>); 5] = [
+        ("chain_13_chi8", vec![]),
+        // A hub of 32 elements: smaller than any chain core in the case above,
+        // so a cost difference here cannot be the hub's arithmetic.
+        ("spider_tiny_2x2x2x2", vec![2, 2, 2, 2]),
+        ("spider_equal_4x4x4x4", vec![4, 4, 4, 4]),
+        ("spider_unequal_2x4x8x4", vec![2, 4, 8, 4]),
+        ("spider_unequal_8x4x2x4", vec![8, 4, 2, 4]),
+    ];
+    for (name, bonds) in cases {
+        let n_sites = if bonds.is_empty() {
+            13
+        } else {
+            bonds.len() * ARM_LENGTH + 1
+        };
+        let sites: Vec<DynIndex> = (0..n_sites).map(|_| DynIndex::new_dyn(2)).collect();
+        let inputs: Vec<_> = if bonds.is_empty() {
+            let chain = crate::state::tests::full_rank_chain_guess(n_sites, 8);
+            vec![chain.clone(), chain]
+        } else {
+            (0..2)
+                .map(|input| {
+                    crate::state::tests::spider_tree(&bonds, ARM_LENGTH, ARM_CHI, input, &sites)
+                })
+                .collect()
+        };
+        let options = TreeAciOptions {
+            tolerance: 1.0e-8,
+            max_sweeps: 2,
+            min_sweeps: 2,
+            enable_global_guard: false,
+            ..TreeAciOptions::default()
+        };
+        let state = TreeAciState::<f64, usize>::initialize(&inputs, &options).unwrap();
+        let budget =
+            per_evaluator_message_cache_budget(options.message_cache_max_bytes, inputs.len())
+                .unwrap();
+        let mut evaluators =
+            InputEvaluators::new_with_message_cache_max_bytes(state.inputs, &state.problem, budget)
+                .unwrap();
+
+        let starts: Vec<Vec<usize>> = (0..NSEARCH)
+            .map(|start| {
+                (0..n_sites)
+                    .map(|site| (start * 7 + site * 3) % 2)
+                    .collect()
+            })
+            .collect();
+        evaluators.evaluate::<f64>(&starts[..1]).unwrap();
+        let mut calls = 0usize;
+        let started = Instant::now();
+        for _sweep in 0..SWEEPS {
+            for site in 0..n_sites {
+                for start in &starts {
+                    let points: Vec<Vec<usize>> = (0..2)
+                        .map(|value| {
+                            let mut point = start.clone();
+                            point[site] = value;
+                            point
+                        })
+                        .collect();
+                    evaluators.evaluate::<f64>(&points).unwrap();
+                    calls += 1;
+                }
+            }
+        }
+        let elapsed = started.elapsed();
+
+        // The same walk with the coordinate the pivot already holds dropped
+        // from every batch: one point per call instead of two, with the
+        // varying site still declared explicitly so the batch keeps the
+        // centre hint a one-point batch cannot be asked to infer.
+        let mut single_calls = 0usize;
+        let single_started = Instant::now();
+        for _sweep in 0..SWEEPS {
+            for site in 0..n_sites {
+                for start in &starts {
+                    let mut point = start.clone();
+                    point[site] = 1 - point[site];
+                    let points = vec![point];
+                    let coordinates = evaluators.expand_points(&points).unwrap();
+                    let hint = tensor4all_treetn::EvaluationHint::around(site);
+                    evaluators
+                        .evaluate_expanded::<f64>(&points, &coordinates, hint)
+                        .unwrap();
+                    single_calls += 1;
+                }
+            }
+        }
+        let single_elapsed = single_started.elapsed();
+        eprintln!(
+            "guard call cost {name} ({n_sites} sites): two_point={elapsed:?} over {calls} calls = {:.1} us/call, one_point_hinted={single_elapsed:?} over {single_calls} calls = {:.1} us/call, per-call saving={:.0}%",
+            elapsed.as_secs_f64() * 1.0e6 / calls as f64,
+            single_elapsed.as_secs_f64() * 1.0e6 / single_calls as f64,
+            100.0 * (1.0 - single_elapsed.as_secs_f64() / elapsed.as_secs_f64()),
+        );
+    }
 }

--- a/crates/tensor4all-treeaci/src/global_guard/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/global_guard/tests/mod.rs
@@ -355,6 +355,12 @@ fn global_search_rejects_the_start_batch_before_calling_the_operator() {
     let options = TreeAciOptions {
         nsearch_global_pivots: 4,
         max_working_bytes: 64,
+        // Pin the element ceilings so the 64-byte budget exercises only the
+        // guard's start-batch charge. Left unset they would follow the budget
+        // down to two elements and preparation would refuse the tree first.
+        max_local_matrix_elements: Some(1 << 24),
+        max_core_elements: Some(1 << 24),
+        max_frame_elements: Some(1 << 24),
         ..TreeAciOptions::default()
     };
     let inputs = vec![input];

--- a/crates/tensor4all-treeaci/src/initialize.rs
+++ b/crates/tensor4all-treeaci/src/initialize.rs
@@ -82,7 +82,6 @@ pub(crate) fn validate_initial_guess<T: TreeAciScalar, V: TreeAciNode>(
     guess: &TreeTN<IdxTensor, V>,
     reference: &TreeTN<IdxTensor, V>,
     problem: &PreparedTreeProblem<V>,
-    options: &TreeAciOptions<V>,
 ) -> Result<()> {
     guess
         .validate_tree()
@@ -112,7 +111,7 @@ pub(crate) fn validate_initial_guess<T: TreeAciScalar, V: TreeAciNode>(
                 message: format!("missing tensor at node {node:?}"),
             })?;
         let elements = checked_product(tensor.indices().iter().map(IndexLike::dim), "guess core")?;
-        enforce_limit("core elements", elements, options.max_core_elements)?;
+        enforce_limit("core elements", elements, problem.max_core_elements)?;
         validate_initial_guess_scalar_kind::<T>(tensor)?;
     }
     guess
@@ -195,7 +194,7 @@ pub(crate) fn build_random_output<T: TreeAciScalar, V: TreeAciNode>(
             )?);
         }
         let elements = checked_product(indices.iter().map(IndexLike::dim), "output core")?;
-        enforce_limit("core elements", elements, options.max_core_elements)?;
+        enforce_limit("core elements", elements, problem.max_core_elements)?;
         let values = (0..elements)
             .map(|_| {
                 let value: f64 = StandardNormal.sample(&mut rng);

--- a/crates/tensor4all-treeaci/src/initialize/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/initialize/tests/mod.rs
@@ -62,8 +62,9 @@ fn bootstrap_samples_reaches_the_requested_rank_on_every_edge() {
         (vec![(0, 1), (0, 2), (0, 3)], 4),
     ] {
         let tree = make_tree(&edges, node_count);
-        let problem = prepare_problem(std::slice::from_ref(&tree), &TreeAciOptions::default())
-            .expect("prepared problem");
+        let problem =
+            prepare_problem::<f64, _>(std::slice::from_ref(&tree), &TreeAciOptions::default())
+                .expect("prepared problem");
         let algebraic = algebraic_edge_bounds(&problem).expect("algebraic bounds");
         // Ask for less than the algebraic maximum everywhere it is more than
         // 1, so the loop must actually enumerate multiple points per edge
@@ -110,8 +111,9 @@ fn long_chain_algebraic_bounds_saturate_without_rejecting_small_active_ranks() {
         .map(|node| (node, node + 1))
         .collect::<Vec<_>>();
     let tree = make_tree(&edges, node_count);
-    let problem = prepare_problem(std::slice::from_ref(&tree), &TreeAciOptions::default())
-        .expect("long rank-two chain must prepare");
+    let problem =
+        prepare_problem::<f64, _>(std::slice::from_ref(&tree), &TreeAciOptions::default())
+            .expect("long rank-two chain must prepare");
 
     let bounds = algebraic_edge_bounds(&problem)
         .expect("an unrepresentably large physical space is still a valid rank ceiling");
@@ -128,8 +130,9 @@ fn long_chain_algebraic_bounds_saturate_without_rejecting_small_active_ranks() {
 fn middle_cut_bootstrap_points() -> Vec<Vec<usize>> {
     let edges = [(0, 1), (1, 2), (2, 3)];
     let tree = make_tree_with_dims(&edges, &[2, 3, 2, 3]);
-    let problem = prepare_problem(std::slice::from_ref(&tree), &TreeAciOptions::default())
-        .expect("prepared problem");
+    let problem =
+        prepare_problem::<f64, _>(std::slice::from_ref(&tree), &TreeAciOptions::default())
+            .expect("prepared problem");
     let (arena, _, pivots) = bootstrap_samples(&problem, &[1, 4, 1]).expect("bootstrap samples");
 
     let mut points = Vec::new();

--- a/crates/tensor4all-treeaci/src/local_update.rs
+++ b/crates/tensor4all-treeaci/src/local_update.rs
@@ -84,7 +84,7 @@ where
     enforce_limit(
         "local matrix elements",
         point_count,
-        options.max_local_matrix_elements,
+        problem.max_local_matrix_elements,
     )?;
     let input_value_elements =
         inputs
@@ -151,8 +151,8 @@ where
             .ok_or(TreeAciError::SizeOverflow {
                 context: "right local factor elements",
             })?;
-    enforce_limit("core elements", left_elements, options.max_core_elements)?;
-    enforce_limit("core elements", right_elements, options.max_core_elements)?;
+    enforce_limit("core elements", left_elements, problem.max_core_elements)?;
+    enforce_limit("core elements", right_elements, problem.max_core_elements)?;
 
     let mut input_values = vec![T::default(); input_value_elements];
     #[cfg(test)]

--- a/crates/tensor4all-treeaci/src/local_update.rs
+++ b/crates/tensor4all-treeaci/src/local_update.rs
@@ -96,42 +96,42 @@ where
     let max_cut_rank = (0..inputs.len()).try_fold(0usize, |max_rank, input| {
         Ok::<usize, TreeAciError>(max_rank.max(frames.bond_dim(input, forward)?))
     })?;
-    let candidate_frame_elements = row_count
-        .checked_add(col_count)
-        .and_then(|count| count.checked_mul(max_cut_rank))
-        // Candidate vectors and their packed BLAS matrices coexist for one
-        // input at a time. Other inputs are streamed and dropped.
-        .and_then(|count| count.checked_mul(2))
-        .ok_or(TreeAciError::SizeOverflow {
-            context: "candidate frame working elements",
-        })?;
+    // Everything charged here stays live while candidate frames are built, so
+    // it is what the candidate-frame kernels may *not* spend.
+    let reserved_bytes = reserved_working_bytes::<T>(
+        input_value_elements,
+        point_count,
+        row_count,
+        col_count,
+        max_cut_rank,
+    )?;
     let candidate_frame_scratch =
         inputs
             .iter()
             .enumerate()
             .try_fold(0usize, |peak, (input, _)| {
                 let row_scratch = frames.enumerated_candidate_frame_scratch_elements(
-                    problem, input, forward, candidates,
+                    problem,
+                    input,
+                    forward,
+                    candidates,
+                    reserved_bytes,
                 )?;
                 let col_scratch = frames.enumerated_candidate_frame_scratch_elements(
-                    problem, input, reverse, candidates,
+                    problem,
+                    input,
+                    reverse,
+                    candidates,
+                    reserved_bytes,
                 )?;
                 Ok::<usize, TreeAciError>(peak.max(row_scratch).max(col_scratch))
             })?;
-    let working_elements = input_value_elements
-        // One point-sized output/product buffer coexists with input values.
-        .checked_add(point_count)
-        .and_then(|count| count.checked_add(candidate_frame_elements))
-        .and_then(|count| count.checked_add(candidate_frame_scratch))
+    let working_bytes = candidate_frame_scratch
+        .checked_mul(size_of::<T>())
+        .and_then(|bytes| bytes.checked_add(reserved_bytes))
         .ok_or(TreeAciError::SizeOverflow {
-            context: "local update working elements",
+            context: "local matrix working bytes",
         })?;
-    let working_bytes =
-        working_elements
-            .checked_mul(size_of::<T>())
-            .ok_or(TreeAciError::SizeOverflow {
-                context: "local matrix working bytes",
-            })?;
     enforce_limit("working bytes", working_bytes, options.max_working_bytes)?;
     let factor_rank_bound = options
         .max_bond_dim
@@ -179,6 +179,7 @@ where
                 input,
                 forward,
                 &row_candidates,
+                reserved_bytes,
             )?;
             #[cfg(test)]
             crate::state::profile_debug_stats::record(|stats| {
@@ -192,6 +193,7 @@ where
                 input,
                 reverse,
                 &col_candidates,
+                reserved_bytes,
             )?;
             #[cfg(test)]
             crate::state::profile_debug_stats::record(|stats| {
@@ -365,6 +367,52 @@ where
         #[cfg(test)]
         local_values: retained_local_values,
     })
+}
+
+/// Bytes of `max_working_bytes` that stay live for the whole candidate-frame
+/// phase of one edge update.
+///
+/// This is the reservation the candidate-frame kernels are told about, so that
+/// an arbitrary-degree edge whose batched cross fits the budget on its own,
+/// but not once these buffers are counted, degrades to the scalar route on
+/// both sides of the contract instead of being refused by the pre-flight and
+/// then batched anyway by the kernel (#726). It is also the constant part of
+/// the pre-flight charge, so both uses read the same rule from one place.
+///
+/// # Arguments
+///
+/// * `input_value_elements` - one per input per point, all live at once.
+/// * `point_count` - the one point-sized output/product buffer that coexists
+///   with the input values.
+/// * `row_count`, `col_count`, `max_cut_rank` - the packed candidate frames of
+///   both sides, counted twice because a side's candidate vectors and their
+///   packed BLAS matrix coexist for one input at a time. Other inputs are
+///   streamed and dropped.
+///
+/// # Errors
+///
+/// Returns [`TreeAciError::SizeOverflow`] when the charge does not fit `usize`.
+pub(crate) fn reserved_working_bytes<T: TreeAciScalar>(
+    input_value_elements: usize,
+    point_count: usize,
+    row_count: usize,
+    col_count: usize,
+    max_cut_rank: usize,
+) -> Result<usize> {
+    let candidate_frame_elements = row_count
+        .checked_add(col_count)
+        .and_then(|count| count.checked_mul(max_cut_rank))
+        .and_then(|count| count.checked_mul(2))
+        .ok_or(TreeAciError::SizeOverflow {
+            context: "candidate frame working elements",
+        })?;
+    input_value_elements
+        .checked_add(point_count)
+        .and_then(|count| count.checked_add(candidate_frame_elements))
+        .and_then(|count| count.checked_mul(size_of::<T>()))
+        .ok_or(TreeAciError::SizeOverflow {
+            context: "local update working elements",
+        })
 }
 
 fn select_pivot_samples(

--- a/crates/tensor4all-treeaci/src/local_update/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/local_update/tests/mod.rs
@@ -56,7 +56,7 @@ fn local_entries_equal_direct_values_and_callback_layout_is_column_major() {
         two_node_tree_with_indices(2.0, s0, s1, DynIndex::new_dyn(2)),
     ];
     let options = TreeAciOptions::default();
-    let problem = prepare_problem(&inputs, &options).unwrap();
+    let problem = prepare_problem::<f64, _>(&inputs, &options).unwrap();
     let (arena, active) = SampleArena::from_global_seeds(&problem, &[]).unwrap();
     let frames = InputFrameStore::from_samples(&inputs, &problem, &arena).unwrap();
     let calls = Cell::new(0);
@@ -98,7 +98,7 @@ fn luci_factors_reconstruct_rank_one_and_zero_targets() {
     for zero in [false, true] {
         let inputs = vec![two_node_tree(1.0)];
         let options = TreeAciOptions::default();
-        let problem = prepare_problem(&inputs, &options).unwrap();
+        let problem = prepare_problem::<f64, _>(&inputs, &options).unwrap();
         let (arena, active) = SampleArena::from_global_seeds(&problem, &[]).unwrap();
         let frames = InputFrameStore::from_samples(&inputs, &problem, &arena).unwrap();
         let mut operator = |batch: crate::TreeElementwiseBatch<'_, f64>, output: &mut [f64]| {
@@ -137,7 +137,7 @@ fn luci_factors_reconstruct_rank_one_and_zero_targets() {
 fn callback_error_and_matrix_budget_stop_before_factorization() {
     let inputs = vec![two_node_tree(1.0)];
     let options = TreeAciOptions::default();
-    let problem = prepare_problem(&inputs, &options).unwrap();
+    let problem = prepare_problem::<f64, _>(&inputs, &options).unwrap();
     let (arena, active) = SampleArena::from_global_seeds(&problem, &[]).unwrap();
     let frames = InputFrameStore::from_samples(&inputs, &problem, &arena).unwrap();
     let mut failing = |_batch: crate::TreeElementwiseBatch<'_, f64>, _output: &mut [f64]| {
@@ -152,15 +152,24 @@ fn callback_error_and_matrix_budget_stop_before_factorization() {
         Err(TreeAciError::Callback { message }) if message == "sentinel"
     ));
 
+    // Ceilings are resolved once, at preparation, so the ceiling this update
+    // enforces lives on the prepared problem. A whole-run configuration cannot
+    // reach this update with a ceiling below four elements -- preparation
+    // refuses the same two-by-two minimum first, which is the point of that
+    // earlier check -- so the boundary is pinned on the prepared problem the
+    // way the working-byte boundaries below and in `frames` are.
     let limited = TreeAciOptions {
-        max_local_matrix_elements: 3,
+        max_local_matrix_elements: Some(4),
         ..TreeAciOptions::default()
     };
+    let mut limited_problem = prepare_problem::<f64, _>(&inputs, &limited).unwrap();
+    assert_eq!(limited_problem.max_local_matrix_elements, 4);
+    limited_problem.max_local_matrix_elements = 3;
     let mut unused = |_batch: crate::TreeElementwiseBatch<'_, f64>, _output: &mut [f64]| Ok(());
     assert!(matches!(
         materialize_and_factor_edge(
             &inputs,
-            &problem,
+            &limited_problem,
             &active,
             &frames,
             0,
@@ -182,12 +191,13 @@ fn callback_error_and_matrix_budget_stop_before_factorization() {
         max_working_bytes: 191,
         ..TreeAciOptions::default()
     };
+    let working_limited_problem = prepare_problem::<f64, _>(&inputs, &working_limited).unwrap();
     let mut working_unused =
         |_batch: crate::TreeElementwiseBatch<'_, f64>, _output: &mut [f64]| Ok(());
     assert!(matches!(
         materialize_and_factor_edge(
             &inputs,
-            &problem,
+            &working_limited_problem,
             &active,
             &frames,
             0,
@@ -312,7 +322,7 @@ fn run_local_update_measurement(
 ) {
     let inputs = vec![input.clone()];
     let options = crate::TreeAciOptions::default();
-    let problem = crate::problem::prepare_problem(&inputs, &options).unwrap();
+    let problem = crate::problem::prepare_problem::<f64, _>(&inputs, &options).unwrap();
     let (arena, active) = SampleArena::from_global_seeds(&problem, samples).unwrap();
     let frames = InputFrameStore::from_samples(&inputs, &problem, &arena).unwrap();
     let forward = problem
@@ -429,7 +439,7 @@ fn packed_local_update_release_measurement_for_chain_and_branch() {
 fn candidate_frames_batched_path_matches_scalar_path_on_a_chain() {
     let inputs = vec![three_node_chain_for_batched_dispatch()];
     let options = TreeAciOptions::default();
-    let problem = prepare_problem(&inputs, &options).unwrap();
+    let problem = prepare_problem::<f64, _>(&inputs, &options).unwrap();
 
     // Seed both physical values of node 0 so directed edge 0 -> 1's
     // candidate set has two distinct incoming samples; combined with node

--- a/crates/tensor4all-treeaci/src/local_update/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/local_update/tests/mod.rs
@@ -474,7 +474,7 @@ fn candidate_frames_batched_path_matches_scalar_path_on_a_chain() {
     let frames_batched =
         InputFrameStore::<f64>::from_samples(&inputs, &problem, &arena_for_batched).unwrap();
     let batched = frames_batched
-        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &row_candidates)
+        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &row_candidates, 0)
         .unwrap();
 
     // The scalar oracle: a second, independently built store, walked one

--- a/crates/tensor4all-treeaci/src/options.rs
+++ b/crates/tensor4all-treeaci/src/options.rs
@@ -1,9 +1,21 @@
 //! Configuration for tree ACI preparation and execution.
 
+use std::mem::size_of;
+
 use tensor4all_core::IdxTensor;
 use tensor4all_treetn::TreeTN;
 
-use crate::{TreeAciNode, TreeAciTraversalStrategy};
+use crate::{TreeAciNode, TreeAciScalar, TreeAciTraversalStrategy};
+
+/// Share of [`TreeAciOptions::max_working_bytes`] one derived object may claim.
+///
+/// A local candidate matrix, a node core, and a cached directed frame each
+/// coexist with the other transient buffers of a single local update, so no
+/// one of them may claim the whole budget. A quarter is the ratio the crate's
+/// original hard-coded ceilings had against the original budget (`2^24` f64
+/// elements is 128 MiB, against 512 MiB), so deriving at this share leaves the
+/// `f64` defaults exactly where they were while making them follow the budget.
+const WORKING_BUDGET_OBJECT_SHARE: usize = 4;
 
 /// Controls tree ACI sweeps, global validation, and allocation limits.
 ///
@@ -62,19 +74,44 @@ pub struct TreeAciOptions<V: TreeAciNode> {
     /// Multiplier applied to the global-search acceptance threshold. Default: `10`.
     pub global_tolerance_margin: f64,
     /// Maximum rows in a materialized local candidate matrix. Default: `2^20`.
+    ///
+    /// This and [`Self::max_candidate_cols`] are shape guards rather than
+    /// memory guards: they bound how far candidate enumeration may run away on
+    /// one side of an edge, counted in candidates and not in bytes, and they
+    /// therefore do not follow [`Self::max_working_bytes`]. What the resulting
+    /// matrix may occupy is [`Self::max_local_matrix_elements`], which does.
     pub max_candidate_rows: usize,
     /// Maximum columns in a materialized local candidate matrix. Default: `2^20`.
+    ///
+    /// The column-side counterpart of [`Self::max_candidate_rows`], with the
+    /// same units and the same independence from the working budget.
     pub max_candidate_cols: usize,
-    /// Maximum elements in a local candidate matrix. Default: `2^24`.
-    pub max_local_matrix_elements: usize,
-    /// Maximum elements in any prepared or output node core. Default: `2^24`.
-    pub max_core_elements: usize,
-    /// Maximum elements in one cached directed frame. Default: `2^24`.
+    /// Maximum elements in a local candidate matrix, or `None` (the default)
+    /// to derive the ceiling from [`Self::max_working_bytes`].
+    ///
+    /// A derived ceiling is a quarter of the working budget expressed in
+    /// elements of the run's scalar type, so raising the budget raises this
+    /// ceiling with it; at the default 512 MiB budget it is `2^24` `f64`
+    /// elements, the value this field was fixed at before it followed the
+    /// budget. Set `Some(n)` only to pin a ceiling that must *not* follow the
+    /// budget. [`Self::resolved_max_local_matrix_elements`] returns the value
+    /// a run actually enforces.
+    pub max_local_matrix_elements: Option<usize>,
+    /// Maximum elements in any prepared or output node core, or `None` (the
+    /// default) to derive the ceiling from [`Self::max_working_bytes`] exactly
+    /// as [`Self::max_local_matrix_elements`] does.
+    ///
+    /// [`Self::resolved_max_core_elements`] returns the enforced value.
+    pub max_core_elements: Option<usize>,
+    /// Maximum elements in one cached directed frame, or `None` (the default)
+    /// to derive the ceiling from [`Self::max_working_bytes`] exactly as
+    /// [`Self::max_local_matrix_elements`] does.
     ///
     /// This bounds a single frame. The frame cache retains one frame per input
     /// per directed edge, so [`Self::max_frame_bytes`] is what bounds the
-    /// cache as a whole.
-    pub max_frame_elements: usize,
+    /// cache as a whole. [`Self::resolved_max_frame_elements`] returns the
+    /// enforced value.
+    pub max_frame_elements: Option<usize>,
     /// Maximum logical bytes retained by the directed-frame cache, across every
     /// input and every directed edge, plus the pivot-search candidate-frame
     /// cache that shares this budget. Default: 256 MiB.
@@ -89,6 +126,19 @@ pub struct TreeAciOptions<V: TreeAciNode> {
     /// Maximum logical bytes retained by immutable component samples. Default: 256 MiB.
     pub max_sample_arena_bytes: usize,
     /// Maximum estimated temporary working storage. Default: 512 MiB.
+    ///
+    /// This is the governing budget for one local update's live buffers, and
+    /// every element ceiling left unset follows it: raising this field raises
+    /// [`Self::max_local_matrix_elements`], [`Self::max_core_elements`], and
+    /// [`Self::max_frame_elements`] in step, each to a quarter of the budget
+    /// in elements of the run's scalar type. A ceiling set explicitly keeps
+    /// overriding the budget in either direction.
+    ///
+    /// The retention budgets are separate and do not follow this one, because
+    /// they bound what is kept *between* updates rather than what one update
+    /// may allocate: [`Self::max_frame_bytes`],
+    /// [`Self::message_cache_max_bytes`], and
+    /// [`Self::max_sample_arena_bytes`].
     pub max_working_bytes: usize,
     /// Edge traversal strategy. Default: continuous minimum-retracing walk.
     pub traversal_strategy: TreeAciTraversalStrategy,
@@ -113,9 +163,9 @@ impl<V: TreeAciNode> Default for TreeAciOptions<V> {
             global_tolerance_margin: 10.0,
             max_candidate_rows: 1 << 20,
             max_candidate_cols: 1 << 20,
-            max_local_matrix_elements: 1 << 24,
-            max_core_elements: 1 << 24,
-            max_frame_elements: 1 << 24,
+            max_local_matrix_elements: None,
+            max_core_elements: None,
+            max_frame_elements: None,
             max_frame_bytes: 256 << 20,
             max_sample_arena_bytes: 256 << 20,
             max_working_bytes: 512 << 20,
@@ -124,8 +174,115 @@ impl<V: TreeAciNode> Default for TreeAciOptions<V> {
     }
 }
 
+impl<V: TreeAciNode> TreeAciOptions<V> {
+    /// Element ceiling a run with scalar `T` enforces for a local candidate
+    /// matrix.
+    ///
+    /// Returns [`Self::max_local_matrix_elements`] when it is set, and the
+    /// budget-derived ceiling otherwise.
+    ///
+    /// # Returns
+    ///
+    /// The ceiling in elements of `T`, which is what
+    /// [`TreeAciError::ResourceLimit`](crate::TreeAciError::ResourceLimit)
+    /// reports as `limit` for the `local matrix elements` resource.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_treeaci::TreeAciOptions;
+    ///
+    /// let mut options = TreeAciOptions::<usize>::default();
+    /// assert_eq!(options.resolved_max_local_matrix_elements::<f64>(), 1 << 24);
+    ///
+    /// // The ceiling follows the budget instead of silently overriding it.
+    /// options.max_working_bytes *= 4;
+    /// assert_eq!(options.resolved_max_local_matrix_elements::<f64>(), 1 << 26);
+    ///
+    /// // An explicit ceiling still wins, in either direction.
+    /// options.max_local_matrix_elements = Some(1024);
+    /// assert_eq!(options.resolved_max_local_matrix_elements::<f64>(), 1024);
+    /// ```
+    pub fn resolved_max_local_matrix_elements<T: TreeAciScalar>(&self) -> usize {
+        self.max_local_matrix_elements
+            .unwrap_or_else(|| self.derived_element_ceiling::<T>())
+    }
+
+    /// Element ceiling a run with scalar `T` enforces for one node core.
+    ///
+    /// Returns [`Self::max_core_elements`] when it is set, and the
+    /// budget-derived ceiling otherwise.
+    ///
+    /// # Returns
+    ///
+    /// The ceiling in elements of `T`, reported as `limit` for the
+    /// `core elements` resource.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_treeaci::TreeAciOptions;
+    ///
+    /// let mut options = TreeAciOptions::<usize>::default();
+    /// assert_eq!(options.resolved_max_core_elements::<f64>(), 1 << 24);
+    ///
+    /// // Complex runs get the same number of *bytes*, not of elements.
+    /// assert_eq!(
+    ///     options.resolved_max_core_elements::<num_complex::Complex64>(),
+    ///     1 << 23
+    /// );
+    ///
+    /// options.max_core_elements = Some(64);
+    /// assert_eq!(options.resolved_max_core_elements::<f64>(), 64);
+    /// ```
+    pub fn resolved_max_core_elements<T: TreeAciScalar>(&self) -> usize {
+        self.max_core_elements
+            .unwrap_or_else(|| self.derived_element_ceiling::<T>())
+    }
+
+    /// Element ceiling a run with scalar `T` enforces for one cached directed
+    /// frame.
+    ///
+    /// Returns [`Self::max_frame_elements`] when it is set, and the
+    /// budget-derived ceiling otherwise.
+    ///
+    /// # Returns
+    ///
+    /// The ceiling in elements of `T`, reported as `limit` for the
+    /// `frame elements` resource. It bounds one frame; the cache as a whole is
+    /// bounded by [`Self::max_frame_bytes`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_treeaci::TreeAciOptions;
+    ///
+    /// let mut options = TreeAciOptions::<usize>::default();
+    /// assert_eq!(options.resolved_max_frame_elements::<f64>(), 1 << 24);
+    ///
+    /// options.max_working_bytes /= 2;
+    /// assert_eq!(options.resolved_max_frame_elements::<f64>(), 1 << 23);
+    /// ```
+    pub fn resolved_max_frame_elements<T: TreeAciScalar>(&self) -> usize {
+        self.max_frame_elements
+            .unwrap_or_else(|| self.derived_element_ceiling::<T>())
+    }
+
+    /// Elements of `T` one object may claim from the working budget.
+    ///
+    /// The floor of one element keeps a budget smaller than a single scalar
+    /// from deriving a zero ceiling, which would refuse every allocation
+    /// including the ones the prepared minimum needs;
+    /// [`crate::TreeAciError::InvalidOption`] already refuses an explicit zero.
+    fn derived_element_ceiling<T: TreeAciScalar>(&self) -> usize {
+        (self.max_working_bytes / (WORKING_BUDGET_OBJECT_SHARE * size_of::<T>())).max(1)
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use num_complex::Complex64;
+
     use super::TreeAciOptions;
 
     #[test]
@@ -133,5 +290,84 @@ mod tests {
         let options = TreeAciOptions::<usize>::default();
 
         assert_eq!(options.message_cache_max_bytes, 256 << 20);
+    }
+
+    /// The derived ceilings must reproduce the constants they replaced, so a
+    /// caller who never touches `max_working_bytes` sees no change.
+    #[test]
+    fn default_element_ceilings_match_the_historical_constants() {
+        let options = TreeAciOptions::<usize>::default();
+
+        assert_eq!(options.max_local_matrix_elements, None);
+        assert_eq!(options.max_core_elements, None);
+        assert_eq!(options.max_frame_elements, None);
+        assert_eq!(options.resolved_max_local_matrix_elements::<f64>(), 1 << 24);
+        assert_eq!(options.resolved_max_core_elements::<f64>(), 1 << 24);
+        assert_eq!(options.resolved_max_frame_elements::<f64>(), 1 << 24);
+    }
+
+    /// Issue #729: a caller who raises the byte budget must actually get it.
+    #[test]
+    fn derived_ceilings_follow_the_working_budget() {
+        let options = TreeAciOptions::<usize> {
+            max_working_bytes: 10 << 30,
+            ..TreeAciOptions::default()
+        };
+
+        let expected = (10usize << 30) / 4 / size_of::<f64>();
+        assert_eq!(
+            options.resolved_max_local_matrix_elements::<f64>(),
+            expected
+        );
+        assert_eq!(options.resolved_max_core_elements::<f64>(), expected);
+        assert_eq!(options.resolved_max_frame_elements::<f64>(), expected);
+        // The 17,958,192-element local matrix of the reported failure fits a
+        // 10 GiB budget, which is what the caller asked for.
+        assert!(expected > 17_958_192);
+    }
+
+    /// The ceilings measure bytes, so a complex run gets half the elements and
+    /// the same memory.
+    #[test]
+    fn derived_ceilings_charge_the_run_scalar() {
+        let options = TreeAciOptions::<usize>::default();
+
+        assert_eq!(
+            options.resolved_max_core_elements::<f64>() * size_of::<f64>(),
+            options.resolved_max_core_elements::<Complex64>() * size_of::<Complex64>()
+        );
+    }
+
+    /// An explicit ceiling is a pin: it overrides the budget in both
+    /// directions and does not move when the budget does.
+    #[test]
+    fn explicit_ceilings_override_the_derived_value() {
+        let mut options = TreeAciOptions::<usize> {
+            max_local_matrix_elements: Some(7),
+            max_core_elements: Some(1 << 30),
+            ..TreeAciOptions::default()
+        };
+
+        assert_eq!(options.resolved_max_local_matrix_elements::<f64>(), 7);
+        assert_eq!(options.resolved_max_core_elements::<f64>(), 1 << 30);
+        options.max_working_bytes = 1 << 40;
+        assert_eq!(options.resolved_max_local_matrix_elements::<f64>(), 7);
+        assert_eq!(options.resolved_max_core_elements::<f64>(), 1 << 30);
+        assert_eq!(
+            options.resolved_max_frame_elements::<f64>(),
+            (1usize << 40) / 4 / size_of::<f64>()
+        );
+    }
+
+    /// A budget below one scalar still derives a usable ceiling; the working
+    /// budget itself is what refuses the allocation.
+    #[test]
+    fn derived_ceiling_never_reaches_zero() {
+        let options = TreeAciOptions::<usize> {
+            max_working_bytes: 1,
+            ..TreeAciOptions::default()
+        };
+
+        assert_eq!(options.resolved_max_local_matrix_elements::<f64>(), 1);
     }
 }

--- a/crates/tensor4all-treeaci/src/problem.rs
+++ b/crates/tensor4all-treeaci/src/problem.rs
@@ -5,7 +5,9 @@ use std::collections::{HashMap, VecDeque};
 use tensor4all_core::{DynIndex, IdxTensor, IndexLike};
 use tensor4all_treetn::TreeTN;
 
-use crate::{path_cover::SweepPlan, Result, TreeAciError, TreeAciNode, TreeAciOptions};
+use crate::{
+    path_cover::SweepPlan, Result, TreeAciError, TreeAciNode, TreeAciOptions, TreeAciScalar,
+};
 
 pub(crate) type DirectedEdgeId = usize;
 
@@ -38,17 +40,31 @@ pub(crate) struct PreparedTreeProblem<V> {
     pub(crate) root: V,
     pub(crate) schedule: SweepPlan,
     pub(crate) max_sample_arena_bytes: usize,
+    /// Resource ceilings resolved once, for the scalar type the run uses.
+    ///
+    /// Every ceiling below is the value
+    /// [`TreeAciOptions::resolved_max_core_elements`] and its siblings return
+    /// for that scalar, so a ceiling left unset by the caller has already been
+    /// derived from `max_working_bytes` here and no later site re-derives it.
     pub(crate) max_frame_elements: usize,
     pub(crate) max_frame_bytes: usize,
     pub(crate) max_core_elements: usize,
+    pub(crate) max_local_matrix_elements: usize,
     pub(crate) max_working_bytes: usize,
 }
 
-pub(crate) fn prepare_problem<V: TreeAciNode>(
+/// Validates the inputs and options of one run and resolves its ceilings.
+///
+/// Scalar `T` is the type the run's cores and local matrices are materialized
+/// in, and is what the byte-derived element ceilings are charged against; see
+/// [`TreeAciOptions::max_working_bytes`].
+pub(crate) fn prepare_problem<T: TreeAciScalar, V: TreeAciNode>(
     inputs: &[TreeTN<IdxTensor, V>],
     options: &TreeAciOptions<V>,
 ) -> Result<PreparedTreeProblem<V>> {
     validate_options(options)?;
+    let max_core_elements = options.resolved_max_core_elements::<T>();
+    let max_local_matrix_elements = options.resolved_max_local_matrix_elements::<T>();
     let reference = inputs.first().ok_or(TreeAciError::NoInputs)?;
     if reference.node_count() == 0 {
         return Err(TreeAciError::EmptyTree { input: 0 });
@@ -149,23 +165,6 @@ pub(crate) fn prepare_problem<V: TreeAciNode>(
         });
     }
 
-    for tree in inputs {
-        for node in &node_order {
-            let node_index = tree
-                .node_index(node)
-                .ok_or(TreeAciError::InternalInvariant {
-                    message: "topology-compatible input is missing a node",
-                })?;
-            let tensor = tree
-                .tensor(node_index)
-                .ok_or(TreeAciError::InternalInvariant {
-                    message: "topology-compatible input is missing a tensor",
-                })?;
-            let elements = checked_product(tensor.indices().iter().map(IndexLike::dim), "core")?;
-            enforce_limit("core elements", elements, options.max_core_elements)?;
-        }
-    }
-
     let mut edges = Vec::with_capacity(reference.edge_count());
     for (from_position, from) in node_order.iter().enumerate() {
         let from_index = reference
@@ -193,6 +192,12 @@ pub(crate) fn prepare_problem<V: TreeAciNode>(
     }
     edges.sort_unstable();
 
+    // The byte budget is checked before any element ceiling derived from it,
+    // so a run that the budget alone cannot admit is reported against the
+    // budget the caller set rather than against a ceiling the caller never
+    // saw. A derived ceiling then only ever narrows a run the budget would
+    // have admitted. The minimum local matrix is charged at the widest
+    // supported scalar, because it is a topology-only lower bound.
     for &(left, right) in &edges {
         let elements = physical[left]
             .local_dim
@@ -200,17 +205,30 @@ pub(crate) fn prepare_problem<V: TreeAciNode>(
             .ok_or(TreeAciError::SizeOverflow {
                 context: "minimum local matrix",
             })?;
-        enforce_limit(
-            "local matrix elements",
-            elements,
-            options.max_local_matrix_elements,
-        )?;
         let bytes = elements
             .checked_mul(std::mem::size_of::<num_complex::Complex64>())
             .ok_or(TreeAciError::SizeOverflow {
                 context: "minimum local matrix bytes",
             })?;
         enforce_limit("working bytes", bytes, options.max_working_bytes)?;
+        enforce_limit("local matrix elements", elements, max_local_matrix_elements)?;
+    }
+
+    for tree in inputs {
+        for node in &node_order {
+            let node_index = tree
+                .node_index(node)
+                .ok_or(TreeAciError::InternalInvariant {
+                    message: "topology-compatible input is missing a node",
+                })?;
+            let tensor = tree
+                .tensor(node_index)
+                .ok_or(TreeAciError::InternalInvariant {
+                    message: "topology-compatible input is missing a tensor",
+                })?;
+            let elements = checked_product(tensor.indices().iter().map(IndexLike::dim), "core")?;
+            enforce_limit("core elements", elements, max_core_elements)?;
+        }
     }
 
     let requested_start = requested_root
@@ -237,9 +255,10 @@ pub(crate) fn prepare_problem<V: TreeAciNode>(
         root,
         schedule,
         max_sample_arena_bytes: options.max_sample_arena_bytes,
-        max_frame_elements: options.max_frame_elements,
+        max_frame_elements: options.resolved_max_frame_elements::<T>(),
         max_frame_bytes: options.max_frame_bytes,
-        max_core_elements: options.max_core_elements,
+        max_core_elements,
+        max_local_matrix_elements,
         max_working_bytes: options.max_working_bytes,
     })
 }
@@ -331,19 +350,24 @@ fn validate_options<V: TreeAciNode>(options: &TreeAciOptions<V>) -> Result<()> {
         });
     }
     for (name, limit) in [
-        ("max_candidate_rows", options.max_candidate_rows),
-        ("max_candidate_cols", options.max_candidate_cols),
+        ("max_candidate_rows", Some(options.max_candidate_rows)),
+        ("max_candidate_cols", Some(options.max_candidate_cols)),
         (
             "max_local_matrix_elements",
             options.max_local_matrix_elements,
         ),
         ("max_core_elements", options.max_core_elements),
         ("max_frame_elements", options.max_frame_elements),
-        ("max_frame_bytes", options.max_frame_bytes),
-        ("max_sample_arena_bytes", options.max_sample_arena_bytes),
-        ("max_working_bytes", options.max_working_bytes),
+        ("max_frame_bytes", Some(options.max_frame_bytes)),
+        (
+            "max_sample_arena_bytes",
+            Some(options.max_sample_arena_bytes),
+        ),
+        ("max_working_bytes", Some(options.max_working_bytes)),
     ] {
-        if limit == 0 {
+        // An unset element ceiling is derived from `max_working_bytes`, which
+        // is checked in this same loop, so only an explicit zero is rejected.
+        if limit == Some(0) {
             return Err(TreeAciError::InvalidOption {
                 option: name,
                 message: "resource limits must be positive",
@@ -468,7 +492,7 @@ mod tests {
         ] {
             let node_count = edges.len() + 1;
             let tree = make_tree(&edges, &one_site_indices(node_count), 2);
-            let prepared = prepare_problem(&[tree], &TreeAciOptions::default()).unwrap();
+            let prepared = prepare_problem::<f64, _>(&[tree], &TreeAciOptions::default()).unwrap();
             assert_eq!(prepared.node_order.len(), node_count);
             assert_eq!(prepared.directed_edges.len(), 2 * edges.len());
         }
@@ -477,7 +501,7 @@ mod tests {
     #[test]
     fn directed_edges_record_reverse_and_incoming_branches() {
         let tree = make_tree(&[(0, 1), (0, 2), (0, 3)], &one_site_indices(4), 2);
-        let prepared = prepare_problem(&[tree], &TreeAciOptions::default()).unwrap();
+        let prepared = prepare_problem::<f64, _>(&[tree], &TreeAciOptions::default()).unwrap();
 
         for arc in &prepared.directed_edges {
             let reverse = &prepared.directed_edges[arc.reverse];
@@ -506,14 +530,14 @@ mod tests {
     #[test]
     fn physical_layout_follows_reference_tensor_order_and_allows_zero_legs() {
         let scalar_tree = make_tree(&[], &[vec![]], 1);
-        let scalar = prepare_problem(&[scalar_tree], &TreeAciOptions::default()).unwrap();
+        let scalar = prepare_problem::<f64, _>(&[scalar_tree], &TreeAciOptions::default()).unwrap();
         assert_eq!(scalar.physical[0].local_dim, 1);
         assert!(scalar.physical[0].strides.is_empty());
 
         let first = DynIndex::new_dyn(2);
         let second = DynIndex::new_dyn(3);
         let tree = make_tree(&[], &[vec![second.clone(), first.clone()]], 1);
-        let prepared = prepare_problem(&[tree], &TreeAciOptions::default()).unwrap();
+        let prepared = prepare_problem::<f64, _>(&[tree], &TreeAciOptions::default()).unwrap();
         assert_eq!(prepared.physical[0].indices, vec![second, first]);
         assert_eq!(prepared.physical[0].dims, vec![3, 2]);
         assert_eq!(prepared.physical[0].strides, vec![1, 3]);
@@ -527,7 +551,7 @@ mod tests {
         let primed = make_tree(&[], &[vec![site.prime()]], 1);
 
         assert!(matches!(
-            prepare_problem(&[reference, primed], &TreeAciOptions::default()),
+            prepare_problem::<f64, _>(&[reference, primed], &TreeAciOptions::default()),
             Err(TreeAciError::PhysicalIndexMismatch { input: 1, .. })
         ));
     }
@@ -537,17 +561,19 @@ mod tests {
         let physical = one_site_indices(2);
         let rank_two = make_tree(&[(0, 1)], &physical, 2);
         let rank_five = make_tree(&[(0, 1)], &physical, 5);
-        assert!(prepare_problem(&[rank_two, rank_five], &TreeAciOptions::default()).is_ok());
+        assert!(
+            prepare_problem::<f64, _>(&[rank_two, rank_five], &TreeAciOptions::default()).is_ok()
+        );
     }
 
     #[test]
     fn rejects_missing_empty_mismatched_and_oversized_inputs() {
         assert!(matches!(
-            prepare_problem::<usize>(&[], &TreeAciOptions::default()),
+            prepare_problem::<f64, usize>(&[], &TreeAciOptions::default()),
             Err(TreeAciError::NoInputs)
         ));
         assert!(matches!(
-            prepare_problem::<usize>(&[TreeTN::new()], &TreeAciOptions::default()),
+            prepare_problem::<f64, usize>(&[TreeTN::new()], &TreeAciOptions::default()),
             Err(TreeAciError::EmptyTree { input: 0 })
         ));
 
@@ -555,17 +581,17 @@ mod tests {
         let path = make_tree(&[(0, 1), (1, 2)], &sites, 2);
         let star = make_tree(&[(0, 1), (0, 2)], &sites, 2);
         assert!(matches!(
-            prepare_problem(&[path, star], &TreeAciOptions::default()),
+            prepare_problem::<f64, _>(&[path, star], &TreeAciOptions::default()),
             Err(TreeAciError::TopologyMismatch { input: 1 })
         ));
 
         let tree = make_tree(&[], &[vec![DynIndex::new_dyn(8)]], 1);
         let options = TreeAciOptions {
-            max_core_elements: 7,
+            max_core_elements: Some(7),
             ..TreeAciOptions::default()
         };
         assert!(matches!(
-            prepare_problem(&[tree], &options),
+            prepare_problem::<f64, _>(&[tree], &options),
             Err(TreeAciError::ResourceLimit {
                 resource: "core elements",
                 requested: 8,
@@ -594,7 +620,7 @@ mod tests {
         cycle.connect(nodes[1], &b12, nodes[2], &b12).unwrap();
         cycle.connect(nodes[2], &b20, nodes[0], &b20).unwrap();
         assert!(matches!(
-            prepare_problem(&[cycle], &TreeAciOptions::default()),
+            prepare_problem::<f64, _>(&[cycle], &TreeAciOptions::default()),
             Err(TreeAciError::TreeTN(_))
         ));
 
@@ -607,7 +633,7 @@ mod tests {
             ..TreeAciOptions::default()
         };
         assert!(matches!(
-            prepare_problem(&[tree], &options),
+            prepare_problem::<f64, _>(&[tree], &options),
             Err(TreeAciError::InvalidOption { option: "root", .. })
         ));
     }

--- a/crates/tensor4all-treeaci/src/samples/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/samples/tests/mod.rs
@@ -31,7 +31,7 @@ fn prepare(
     edges: &[(usize, usize)],
     node_count: usize,
 ) -> crate::problem::PreparedTreeProblem<usize> {
-    prepare_problem(&[make_tree(edges, node_count)], &TreeAciOptions::default()).unwrap()
+    prepare_problem::<f64, _>(&[make_tree(edges, node_count)], &TreeAciOptions::default()).unwrap()
 }
 
 #[test]
@@ -331,7 +331,7 @@ fn invalid_points_and_arena_budget_fail_before_active_commit() {
         max_sample_arena_bytes: 1,
         ..TreeAciOptions::default()
     };
-    let limited_problem = prepare_problem(&[make_tree(&[(0, 1)], 2)], &options).unwrap();
+    let limited_problem = prepare_problem::<f64, _>(&[make_tree(&[(0, 1)], 2)], &options).unwrap();
     assert!(matches!(
         SampleArena::from_global_seeds(&limited_problem, &[vec![0, 0]]),
         Err(TreeAciError::ResourceLimit {

--- a/crates/tensor4all-treeaci/src/single_site.rs
+++ b/crates/tensor4all-treeaci/src/single_site.rs
@@ -19,14 +19,14 @@ where
     V: TreeAciNode,
     F: for<'batch> FnMut(TreeElementwiseBatch<'batch, T>, &mut [T]) -> Result<()>,
 {
-    let problem = prepare_problem(inputs, options)?;
+    let problem = prepare_problem::<T, V>(inputs, options)?;
     if problem.node_order.len() != 1 {
         return Err(TreeAciError::InternalInvariant {
             message: "single-site evaluation received a multi-node tree",
         });
     }
     if let Some(guess) = &options.initial_guess {
-        validate_initial_guess::<T, V>(guess, &inputs[0], &problem, options)?;
+        validate_initial_guess::<T, V>(guess, &inputs[0], &problem)?;
     }
     let node = &problem.node_order[0];
     let indices = problem.physical[0].indices.clone();

--- a/crates/tensor4all-treeaci/src/single_site/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/single_site/tests/mod.rs
@@ -158,15 +158,21 @@ fn the_exact_path_respects_the_working_budget() {
     };
 
     // The four-point input and output buffers coexist: 2 * 4 * 8 = 64 bytes.
+    // The element ceilings are pinned so that this budget charges only those
+    // buffers; derived ceilings would follow the budget down and refuse the
+    // four-element core during preparation instead.
     let generous = TreeAciOptions::<usize> {
         max_working_bytes: 64,
+        max_local_matrix_elements: Some(1 << 24),
+        max_core_elements: Some(1 << 24),
+        max_frame_elements: Some(1 << 24),
         ..TreeAciOptions::default()
     };
     assert!(evaluate_single_site(std::slice::from_ref(&tree), &generous, &mut square).is_ok());
 
     let tight = TreeAciOptions::<usize> {
         max_working_bytes: 63,
-        ..TreeAciOptions::default()
+        ..generous.clone()
     };
     let error = evaluate_single_site(std::slice::from_ref(&tree), &tight, &mut square)
         .expect_err("a 63-byte ceiling must reject two 32-byte buffers");

--- a/crates/tensor4all-treeaci/src/skeleton/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/skeleton/tests/mod.rs
@@ -42,7 +42,7 @@ fn all_points(node_count: usize) -> Vec<Vec<usize>> {
 }
 
 fn prepare(edges: &[(usize, usize)], node_count: usize) -> PreparedTreeProblem<usize> {
-    prepare_problem(&[make_tree(edges, node_count)], &TreeAciOptions::default())
+    prepare_problem::<f64, _>(&[make_tree(edges, node_count)], &TreeAciOptions::default())
         .expect("fixture problem")
 }
 

--- a/crates/tensor4all-treeaci/src/state.rs
+++ b/crates/tensor4all-treeaci/src/state.rs
@@ -156,7 +156,7 @@ impl<'a, T: TreeAciScalar, V: TreeAciNode> TreeAciState<'a, T, V> {
     ) -> Result<Self> {
         #[cfg(test)]
         let stage_started = std::time::Instant::now();
-        let problem = prepare_problem(inputs, options)?;
+        let problem = prepare_problem::<T, V>(inputs, options)?;
         let algebraic_edge_bounds = algebraic_edge_bounds(&problem)?;
         let initial_edge_ranks =
             initial_edge_ranks(inputs, &problem, options, &algebraic_edge_bounds)?;
@@ -165,7 +165,7 @@ impl<'a, T: TreeAciScalar, V: TreeAciNode> TreeAciState<'a, T, V> {
         #[cfg(test)]
         let stage_started = std::time::Instant::now();
         let mut output = if let Some(guess) = &options.initial_guess {
-            validate_initial_guess::<T, V>(guess, &inputs[0], &problem, options)?;
+            validate_initial_guess::<T, V>(guess, &inputs[0], &problem)?;
             guess.clone()
         } else {
             build_random_output::<T, V>(&inputs[0], &problem, &initial_edge_ranks, options)?

--- a/crates/tensor4all-treeaci/src/state.rs
+++ b/crates/tensor4all-treeaci/src/state.rs
@@ -230,4 +230,4 @@ impl<'a, T: TreeAciScalar, V: TreeAciNode> TreeAciState<'a, T, V> {
 }
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;

--- a/crates/tensor4all-treeaci/src/state/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/state/tests/mod.rs
@@ -403,7 +403,7 @@ fn unseeded_initialization_defers_numeric_canonicalization() {
         rng_seed: 7,
         ..TreeAciOptions::default()
     };
-    let problem = prepare_problem(&inputs, &options).unwrap();
+    let problem = prepare_problem::<f64, _>(&inputs, &options).unwrap();
     let algebraic_bounds = algebraic_edge_bounds(&problem).unwrap();
     let edge_ranks = initial_edge_ranks(&inputs, &problem, &options, &algebraic_bounds).unwrap();
     let raw =
@@ -439,7 +439,7 @@ fn explicit_guess_rank_and_resource_limits_are_rejected() {
             &inputs,
             &TreeAciOptions {
                 initial_guess: Some(guess),
-                max_core_elements: 3,
+                max_core_elements: Some(3),
                 ..TreeAciOptions::default()
             }
         ),

--- a/crates/tensor4all-treeaci/src/state/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/state/tests/mod.rs
@@ -40,7 +40,9 @@ fn rank_deficient_two_node_tree(sites: [DynIndex; 2]) -> TreeTN<IdxTensor, usize
     TreeTN::from_tensors(vec![left, right], vec![0, 1]).unwrap()
 }
 
-fn full_rank_chain_guess(n_sites: usize, chi: usize) -> TreeTN<IdxTensor, usize> {
+/// Shared with `global_guard::tests`, which measures the Guard's evaluation
+/// shape on the same 32-site high-rank chain this module profiles.
+pub(crate) fn full_rank_chain_guess(n_sites: usize, chi: usize) -> TreeTN<IdxTensor, usize> {
     let sites = (0..n_sites)
         .map(|_| DynIndex::new_dyn(2))
         .collect::<Vec<_>>();
@@ -391,6 +393,245 @@ fn profile_high_rank_chain_phases_and_candidate_cache() {
         } else {
             assert_eq!(history.max_ranks.len(), 2);
         }
+    }
+}
+
+/// Deterministic analytic core value, matching the `aci_scaling` benchmark's
+/// fixture so this profile attributes the same workload the #718 gate timed.
+fn spider_core_value(input: usize, node: usize, flat: usize, dims: &[usize]) -> f64 {
+    let mut phase = 0.173 * (input as f64 + 1.0) * (node as f64 + 1.3) + 0.31 * 0.5;
+    let mut coordinates = Vec::with_capacity(dims.len());
+    let mut rest = flat;
+    for &dim in dims {
+        coordinates.push((rest % dim) as f64);
+        rest /= dim;
+    }
+    for (axis, &coordinate) in coordinates.iter().enumerate() {
+        phase += (0.191 + 0.037 * axis as f64) * coordinate * (axis as f64 + 1.7);
+    }
+    let mut cross = 0.0;
+    for (axis, &left) in coordinates.iter().enumerate() {
+        for (other, &right) in coordinates.iter().enumerate().skip(axis + 1) {
+            cross += 0.071 * left * right * (axis + other + 2) as f64;
+        }
+    }
+    (phase.sin() + 0.5 * (phase + cross).cos()) / (1.0 + 0.05 * flat as f64)
+}
+
+fn spider_dense_tensor(indices: Vec<DynIndex>, input: usize, node: usize) -> IdxTensor {
+    let dims: Vec<usize> = indices.iter().map(IndexLike::dim).collect();
+    let size: usize = dims.iter().product();
+    IdxTensor::from_dense(
+        indices,
+        (0..size)
+            .map(|flat| spider_core_value(input, node, flat, &dims))
+            .collect::<Vec<f64>>(),
+    )
+    .unwrap()
+}
+
+/// One hub with `arm_bonds.len()` arms of `arm_length` sites each, the same
+/// shape the `aci_scaling` unequal-incident-bond case builds.
+/// Shared with `global_guard::tests`, which measures the Guard's evaluation
+/// cost on this branched fixture against the chain's.
+pub(crate) fn spider_tree(
+    arm_bonds: &[usize],
+    arm_length: usize,
+    chi: usize,
+    input: usize,
+    sites: &[DynIndex],
+) -> TreeTN<IdxTensor, usize> {
+    let arms = arm_bonds.len();
+    let n_sites = 1 + arms * arm_length;
+    assert_eq!(sites.len(), n_sites);
+    let exact_cut_rank = |outer_sites: usize| {
+        let inner = n_sites - outer_sites;
+        2usize.saturating_pow(outer_sites.min(inner) as u32).max(1)
+    };
+    let hub_bonds: Vec<DynIndex> = arm_bonds
+        .iter()
+        .map(|&dim| DynIndex::new_dyn(dim.min(exact_cut_rank(arm_length)).max(1)))
+        .collect();
+    let arm_bond_indices: Vec<Vec<DynIndex>> = (0..arms)
+        .map(|_| {
+            (1..arm_length)
+                .map(|position| DynIndex::new_dyn(chi.min(exact_cut_rank(arm_length - position))))
+                .collect()
+        })
+        .collect();
+
+    let mut hub_indices = vec![sites[0].clone()];
+    hub_indices.extend(hub_bonds.iter().cloned());
+    let mut tensors = vec![spider_dense_tensor(hub_indices, input, 0)];
+    for arm in 0..arms {
+        for position in 0..arm_length {
+            let node = 1 + arm * arm_length + position;
+            let mut indices = vec![sites[node].clone()];
+            if position == 0 {
+                indices.push(hub_bonds[arm].clone());
+            } else {
+                indices.push(arm_bond_indices[arm][position - 1].clone());
+            }
+            if position + 1 < arm_length {
+                indices.push(arm_bond_indices[arm][position].clone());
+            }
+            tensors.push(spider_dense_tensor(indices, input, node));
+        }
+    }
+    // Rescale the hub so the dense maximum modulus is one, exactly as the
+    // benchmark fixture does: the two runs must see the same magnitudes for
+    // the scaled tolerance to mean the same thing.
+    let tree = TreeTN::from_tensors(tensors, (0..n_sites).collect()).unwrap();
+    let scale = tree.to_dense().unwrap().maxabs().unwrap();
+    assert!(scale.is_finite() && scale > 0.0);
+    let rescaled = (0..n_sites)
+        .map(|name| {
+            let tensor = tree.tensor(tree.node_index(&name).unwrap()).unwrap();
+            if name == 0 {
+                IdxTensor::from_dense(
+                    tensor.indices().to_vec(),
+                    tensor
+                        .to_vec::<f64>()
+                        .unwrap()
+                        .into_iter()
+                        .map(|value| value / scale)
+                        .collect::<Vec<f64>>(),
+                )
+                .unwrap()
+            } else {
+                tensor.clone()
+            }
+        })
+        .collect::<Vec<_>>();
+    TreeTN::from_tensors(rescaled, (0..n_sites).collect()).unwrap()
+}
+
+/// Opt-in phase attribution for the unequal incident-bond asymmetry the #718
+/// scaling gate found (issue #727): at coordination 4 and a fixed hub bond
+/// product, an unequal layout costs far more per evaluated point than an equal
+/// one. Run with `--ignored --nocapture`.
+///
+/// The layouts share the site count, the arm length, the arm bond dimension,
+/// and the hub bond *product*, so `outgoing_dim * product(incoming bonds)` on
+/// every outward hub arc is identical and any difference in cost is not
+/// topology-required work.
+#[test]
+#[ignore]
+fn profile_unequal_incident_bonds_at_coordination_four() {
+    const ARM_LENGTH: usize = 3;
+    const ARM_CHI: usize = 4;
+    const LAYOUTS: [(&str, [usize; 4]); 3] = [
+        ("equal_4x4x4x4", [4, 4, 4, 4]),
+        ("unequal_2x4x8x4", [2, 4, 8, 4]),
+        ("unequal_8x4x2x4", [8, 4, 2, 4]),
+    ];
+
+    for (name, bonds) in LAYOUTS {
+        assert_eq!(bonds.iter().product::<usize>(), 256);
+        let sites: Vec<DynIndex> = (0..bonds.len() * ARM_LENGTH + 1)
+            .map(|_| DynIndex::new_dyn(2))
+            .collect();
+        let inputs: Vec<_> = (0..2)
+            .map(|input| spider_tree(&bonds, ARM_LENGTH, ARM_CHI, input, &sites))
+            .collect();
+        // The benchmark this profile attributes runs the default options, so
+        // the Guard is on unless the operator turns it off.
+        let enable_global_guard =
+            std::env::var("T4A_TREEACI_DISABLE_PROFILE_GUARD").as_deref() != Ok("1");
+        let options = TreeAciOptions {
+            tolerance: 1.0e-8,
+            max_sweeps: 12,
+            min_sweeps: 2,
+            enable_global_guard,
+            ..TreeAciOptions::default()
+        };
+
+        crate::frames::candidate_debug_stats::reset();
+        crate::frames::debug_stats::reset();
+        crate::frames::multi_incoming_debug_stats::reset();
+        super::profile_debug_stats::reset();
+        let initialize_started = std::time::Instant::now();
+        let mut state = TreeAciState::<f64, usize>::initialize(&inputs, &options).unwrap();
+        let initialize_elapsed = initialize_started.elapsed();
+        let sweep_started = std::time::Instant::now();
+        let history = run_local_sweeps(&mut state, &options, &mut |batch, output| {
+            for (point, value) in output.iter_mut().enumerate() {
+                *value = batch.get(0, point)? * batch.get(1, point)?;
+            }
+            Ok(())
+        })
+        .unwrap();
+        let sweep_elapsed = sweep_started.elapsed();
+        let profile = super::profile_debug_stats::snapshot();
+        let (base_frame_bytes, candidate_cache_entries, candidate_cache_bytes) =
+            state.input_frames.cache_debug_totals();
+
+        eprintln!(
+            "spider {name}: initialize={initialize_elapsed:?} [prepare={:?}, output={:?}, bootstrap={:?}, frames={:?}], sweeps={sweep_elapsed:?} [proposals={:?}: prepare={:?}, input_frames={:?} {{row={:?}, col={:?}, pack={:?}, matmul={:?}, scatter={:?}}}, operator={:?}, luci={:?}; output_staging={:?}, sample_staging={:?}, frame_extension={:?}, commits={}], sweeps_completed={}",
+            profile.preparation,
+            profile.output,
+            profile.bootstrap,
+            profile.frames,
+            profile.proposals,
+            profile.local_preparation,
+            profile.local_input_frames,
+            profile.local_row_frames,
+            profile.local_col_frames,
+            profile.local_frame_pack,
+            profile.local_frame_matmul,
+            profile.local_frame_scatter,
+            profile.operator,
+            profile.luci,
+            profile.output_staging,
+            profile.sample_staging,
+            profile.frame_extension,
+            profile.commits,
+            history.max_ranks.len(),
+        );
+        eprintln!(
+            "spider {name} work counters: evaluated_points={}, max_rank={:?}, packed_frame_values={}, candidate hits/misses={}/{}, multi_incoming groups batched/scalar={}/{}, frame compute calls={} (scalar={}, batched={}), core_element_reads={}",
+            history.evaluated_points,
+            history.max_ranks.last(),
+            profile.local_packed_frame_values,
+            crate::frames::candidate_debug_stats::hits(),
+            crate::frames::candidate_debug_stats::misses(),
+            crate::frames::multi_incoming_debug_stats::batched_groups(),
+            crate::frames::multi_incoming_debug_stats::scalar_groups(),
+            crate::frames::debug_stats::compute_calls(),
+            crate::frames::debug_stats::scalar_compute_calls(),
+            crate::frames::debug_stats::batched_compute_calls(),
+            crate::frames::debug_stats::core_element_reads(),
+        );
+        eprintln!(
+            "spider {name} global guard enabled={enable_global_guard}: search={:?}, injection={:?} {{candidate_clone={:?}, projection={:?}, output_padding={:?}, frame_extension={:?}}}, input_eval={:?}/{} calls/{} scalar results, output_eval={:?}/{} calls/{} scalar results",
+            profile.global_guard,
+            profile.global_injection,
+            profile.guard_candidate_clone,
+            profile.guard_projection,
+            profile.guard_output_padding,
+            profile.guard_frame_extension,
+            profile.guard_input_evaluation,
+            profile.guard_input_calls,
+            profile.guard_input_points,
+            profile.guard_output_evaluation,
+            profile.guard_output_calls,
+            profile.guard_output_points,
+        );
+        eprintln!(
+            "spider {name} frame extension: {:?} over {} calls {{setup={:?}, scan={:?} across {} edge-input visits (reused={}, grown={}), compute={:?}, rebuild={:?}, finalize={:?}, old_values_copied={}, new_values_copied={}}}, retained base={base_frame_bytes} bytes, candidate_cache={candidate_cache_entries} entries/{candidate_cache_bytes} bytes",
+            profile.frame_extension,
+            profile.frame_extension_calls,
+            profile.frame_extension_setup,
+            profile.frame_extension_scan,
+            profile.frame_extension_scanned_edges,
+            profile.frame_extension_reused_edges,
+            profile.frame_extension_grown_edges,
+            profile.frame_extension_compute,
+            profile.frame_extension_rebuild,
+            profile.frame_extension_finalize,
+            profile.frame_extension_old_values_copied,
+            profile.frame_extension_new_values_copied,
+        );
     }
 }
 

--- a/crates/tensor4all-treeaci/tests/public_api.rs
+++ b/crates/tensor4all-treeaci/tests/public_api.rs
@@ -29,9 +29,23 @@ fn options_defaults_are_bounded_and_consistent() {
     assert!(options.root.is_none());
     assert!(options.max_candidate_rows > 0);
     assert!(options.max_candidate_cols > 0);
-    assert!(options.max_local_matrix_elements > 0);
-    assert!(options.max_core_elements > 0);
-    assert!(options.max_frame_elements > 0);
+    // The element ceilings are unset by default and derived from the working
+    // budget, which is what a caller raising that budget actually gets.
+    assert_eq!(options.max_local_matrix_elements, None);
+    assert_eq!(options.max_core_elements, None);
+    assert_eq!(options.max_frame_elements, None);
+    assert_eq!(
+        options.resolved_max_local_matrix_elements::<f64>(),
+        options.max_working_bytes / 4 / std::mem::size_of::<f64>()
+    );
+    assert_eq!(
+        options.resolved_max_core_elements::<f64>(),
+        options.resolved_max_local_matrix_elements::<f64>()
+    );
+    assert_eq!(
+        options.resolved_max_frame_elements::<f64>(),
+        options.resolved_max_local_matrix_elements::<f64>()
+    );
     assert!(options.max_sample_arena_bytes > 0);
     assert!(options.max_working_bytes > 0);
     assert_eq!(

--- a/crates/tensor4all-treeaci/tests/resource_limits.rs
+++ b/crates/tensor4all-treeaci/tests/resource_limits.rs
@@ -1,0 +1,180 @@
+//! `max_working_bytes` is the governing memory budget of a TreeACI run.
+//!
+//! Issue #729: the element ceilings used to be constants that stayed where
+//! they were when a caller raised the byte budget, so a run could be refused
+//! by a limit two orders of magnitude below the budget it had been granted.
+//! These tests pin the coupling from the public surface: an unset ceiling
+//! moves with the budget in both directions, and an explicitly set one does
+//! not move at all.
+
+use tensor4all_core::{DynIndex, IdxTensor};
+use tensor4all_treeaci::{tree_elementwise_batched, Result, TreeAciError, TreeAciOptions};
+use tensor4all_treetn::TreeTN;
+
+/// Two shared sites of physical dimension two joined by a bond of dimension one.
+///
+/// Each core holds two elements and the only edge's smallest possible local
+/// matrix holds `2 * 2 = 4`, so a ceiling of three refuses the edge while the
+/// cores still fit -- which is what makes the reported `requested` value below
+/// unambiguous.
+fn two_site_tree(
+    sites: &[DynIndex; 2],
+    first: [f64; 2],
+    second: [f64; 2],
+) -> TreeTN<IdxTensor, usize> {
+    let bond = DynIndex::new_dyn(1);
+    let tensors = vec![
+        IdxTensor::from_dense(vec![sites[0].clone(), bond.clone()], first.to_vec())
+            .expect("first fixture core"),
+        IdxTensor::from_dense(vec![sites[1].clone(), bond], second.to_vec())
+            .expect("second fixture core"),
+    ];
+    TreeTN::from_tensors(tensors, vec![0usize, 1usize]).expect("two-site fixture tree")
+}
+
+fn multiply(
+    batch: tensor4all_treeaci::TreeElementwiseBatch<'_, f64>,
+    out: &mut [f64],
+) -> Result<()> {
+    for (point, value) in out.iter_mut().enumerate() {
+        *value = batch.get(0, point)? * batch.get(1, point)?;
+    }
+    Ok(())
+}
+
+/// The budget a run is granted is the budget its element ceilings enforce.
+#[test]
+fn unset_element_ceilings_follow_the_working_budget() {
+    let sites = [DynIndex::new_dyn(2), DynIndex::new_dyn(2)];
+    let inputs = vec![
+        two_site_tree(&sites, [1.0, 2.0], [3.0, 4.0]),
+        two_site_tree(&sites, [5.0, 6.0], [7.0, 8.0]),
+    ];
+
+    // Ninety-six bytes is twelve f64, so one object may claim three of them.
+    // Before #729 this same configuration ran with a ceiling of 2^24.
+    let starved = TreeAciOptions::<usize> {
+        max_working_bytes: 96,
+        ..TreeAciOptions::default()
+    };
+    let error = tree_elementwise_batched::<f64, _, _>(multiply, &inputs, &starved)
+        .expect_err("a twelve-element budget cannot hold a four-element local matrix");
+    assert!(
+        matches!(
+            error,
+            TreeAciError::ResourceLimit {
+                resource: "local matrix elements",
+                requested: 4,
+                limit: 3,
+            }
+        ),
+        "unexpected error: {error}"
+    );
+
+    // The same run at the default budget succeeds and is exact: the product of
+    // two rank-one trees is the rank-one tree of the products.
+    let generous = TreeAciOptions::<usize>::default();
+    let result = tree_elementwise_batched::<f64, _, _>(multiply, &inputs, &generous)
+        .expect("the default budget admits this run");
+    let expected = two_site_tree(&sites, [5.0, 12.0], [21.0, 32.0])
+        .to_dense()
+        .expect("dense reference");
+    assert!(result
+        .tree
+        .to_dense()
+        .expect("dense interpolation")
+        .isapprox(&expected, 1.0e-12, 1.0e-14)
+        .expect("comparable dense results"));
+}
+
+/// An explicitly set ceiling is a pin: the budget no longer moves it, so the
+/// starved run is refused by the budget itself rather than by a ceiling.
+#[test]
+fn explicit_element_ceilings_do_not_follow_the_working_budget() {
+    let sites = [DynIndex::new_dyn(2), DynIndex::new_dyn(2)];
+    let inputs = vec![
+        two_site_tree(&sites, [1.0, 2.0], [3.0, 4.0]),
+        two_site_tree(&sites, [5.0, 6.0], [7.0, 8.0]),
+    ];
+    let pinned = TreeAciOptions::<usize> {
+        max_working_bytes: 96,
+        max_local_matrix_elements: Some(1 << 24),
+        max_core_elements: Some(1 << 24),
+        max_frame_elements: Some(1 << 24),
+        ..TreeAciOptions::default()
+    };
+
+    let error = tree_elementwise_batched::<f64, _, _>(multiply, &inputs, &pinned)
+        .expect_err("ninety-six bytes cannot hold this run's live buffers");
+    assert!(
+        matches!(
+            error,
+            TreeAciError::ResourceLimit {
+                resource: "working bytes",
+                ..
+            }
+        ),
+        "unexpected error: {error}"
+    );
+}
+
+/// A ceiling set to zero is refused as an invalid option, while leaving it
+/// unset is not: an unset ceiling is derived from a budget that is itself
+/// validated.
+#[test]
+fn zero_is_rejected_only_when_a_ceiling_is_set_explicitly() {
+    let sites = [DynIndex::new_dyn(2), DynIndex::new_dyn(2)];
+    let inputs = vec![
+        two_site_tree(&sites, [1.0, 2.0], [3.0, 4.0]),
+        two_site_tree(&sites, [5.0, 6.0], [7.0, 8.0]),
+    ];
+    let zeroed = TreeAciOptions::<usize> {
+        max_core_elements: Some(0),
+        ..TreeAciOptions::default()
+    };
+
+    let error = tree_elementwise_batched::<f64, _, _>(multiply, &inputs, &zeroed)
+        .expect_err("an explicit zero ceiling admits nothing");
+    assert!(
+        matches!(
+            error,
+            TreeAciError::InvalidOption {
+                option: "max_core_elements",
+                ..
+            }
+        ),
+        "unexpected error: {error}"
+    );
+}
+
+/// A budget too small for the topology itself is reported against the budget,
+/// not against a ceiling derived from it.
+///
+/// Downstream callers (the `sgw` stage harness among them) assert exactly this
+/// message for a deliberately impossible budget, and the derived ceilings must
+/// not take that report away from them.
+#[test]
+fn an_impossible_budget_is_reported_as_working_bytes() {
+    let sites = [DynIndex::new_dyn(2), DynIndex::new_dyn(2)];
+    let inputs = vec![
+        two_site_tree(&sites, [1.0, 2.0], [3.0, 4.0]),
+        two_site_tree(&sites, [5.0, 6.0], [7.0, 8.0]),
+    ];
+    let impossible = TreeAciOptions::<usize> {
+        max_working_bytes: 1,
+        ..TreeAciOptions::default()
+    };
+
+    let error = tree_elementwise_batched::<f64, _, _>(multiply, &inputs, &impossible)
+        .expect_err("a one-byte budget admits nothing");
+    assert!(
+        matches!(
+            error,
+            TreeAciError::ResourceLimit {
+                resource: "working bytes",
+                ..
+            }
+        ),
+        "unexpected error: {error}"
+    );
+}

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -325,6 +325,19 @@ struct ChainContractionSpec {
 /// point per group (see `grouped_branch_message_contraction`).
 const BRANCH_BLAS_WORK_THRESHOLD: usize = 4096;
 
+/// Largest prepared slice the arbitrary-degree branch kernel will materialize
+/// for one physical group, in scalars.
+///
+/// That slice is `parent_dim * prod(child_dims)`, which grows as `chi^z` in
+/// the node's coordination number `z` -- the same exponent a tree contraction
+/// carries in general (Tindall, Stoudenmire and Levy, arXiv:2410.03572v3,
+/// Sec. 2, the paragraph after Eq. (1): a TTN contraction "can be done in
+/// `O(nL chi^z)` time, where `z` is the maximum co-ordination number"). The
+/// arithmetic is therefore unavoidable for such a node, but *buffering* it is
+/// not, so beyond this size the flat kernel runs instead and allocates
+/// nothing. At 4 Mi scalars this is 32 MiB of `f64` or 64 MiB of `Complex64`.
+const MULTI_BRANCH_MAX_PREPARED_ELEMENTS: usize = 1 << 22;
+
 // [AI Supplied] Test-only A/B seam for independently checking whether the
 // existing generic `contract_with_options` path can replace the specialized
 // raw message kernels without relying on historical worklog claims.
@@ -2375,12 +2388,14 @@ where
         if !neighbors.contains_key(center) {
             return Ok(false);
         }
-        // Every non-center node then has at most two children, which is covered
-        // by the raw branch-message kernel. The center itself is handled by the
-        // degree-1/2/3 raw center kernel.
-        if neighbors.values().any(|neighbors| neighbors.len() > 3) {
-            return Ok(false);
-        }
+        // Coordination is no longer a condition: a non-center node with three
+        // or more children is covered by
+        // `try_compute_multi_branch_message_raw` and the center of any degree
+        // by the raw center kernel. Refusing a single high-coordination node
+        // used to push *every* message of the whole tree onto the generic
+        // `IdxTensor` path, which measured ~20x per hinted evaluation on a
+        // 13-site spider against a chain of the same size, independently of
+        // bond dimension (tensor4all-rs #727).
         if self
             .layout()
             .entries_by_node
@@ -3954,6 +3969,167 @@ where
         Ok(Some(result))
     }
 
+    /// Computes a rooted message for a node with three or more children,
+    /// staying on the raw `Vec<T>` representation.
+    ///
+    /// The zero-, one-, and two-child cases keep their own kernels above;
+    /// this is their arbitrary-degree generalization, and it is what lets
+    /// [`Self::can_use_raw_messages`] admit a tree containing a node of
+    /// coordination four or more at all. Before it existed, one such node
+    /// forced *every* message of the whole tree onto the generic
+    /// `IdxTensor` path.
+    ///
+    /// # Arguments
+    ///
+    /// * `kind` - the scalar kind `T` decodes; a node stored in another kind
+    ///   returns `Ok(None)` so the caller falls back.
+    /// * `decode` - reads one cached scalar as `T`, returning `None` for a
+    ///   cached message of a different kind.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(None)` whenever this node is not eligible (wrong child count,
+    /// several physical indices, a foreign scalar kind, or a child message
+    /// that cannot be read as `T`), which is not an error: the caller then
+    /// uses the generic contraction.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the tree is inconsistent with the plan, an
+    /// offset overflows `usize`, or the backend rejects the contraction.
+    #[allow(clippy::too_many_arguments)]
+    fn try_compute_multi_branch_message_raw<T>(
+        &self,
+        node: &V,
+        values: ColMajorArrayRef<'_, usize>,
+        points: &[usize],
+        plan: &RootedMessagePlan<V>,
+        assignment_batches: &HashMap<V, AssignmentBatch>,
+        messages: &HashMap<V, StackedMessage>,
+        kind: ScalarKind,
+        decode: impl Fn(&CachedScalar) -> Option<T> + Copy,
+    ) -> Result<Option<Vec<T>>>
+    where
+        T: TensorElement
+            + BlasMul
+            + Copy
+            + Default
+            + std::ops::AddAssign
+            + std::ops::Mul<Output = T>,
+    {
+        #[cfg(test)]
+        if raw_message_kernels_disabled_for_test() {
+            return Ok(None);
+        }
+        let entries = self
+            .layout()
+            .entries_by_node
+            .get(node)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        let [entry] = entries else {
+            return Ok(None);
+        };
+        let children = plan.children.get(node).map(Vec::as_slice).unwrap_or(&[]);
+        if children.len() < 3 {
+            return Ok(None);
+        }
+        if plan.parent.get(node).and_then(Clone::clone).is_none() {
+            return Ok(None);
+        }
+
+        let tensor = tensor_for_node(self.tree, node)?;
+        if tensor_scalar_kind(tensor)? != kind {
+            return Ok(None);
+        }
+        let tensor_indices = tensor.indices();
+        if tensor_indices.len() != children.len() + 2 {
+            return Ok(None);
+        }
+        let Some(physical_axis) = tensor_indices.iter().position(|idx| idx == &entry.index) else {
+            return Ok(None);
+        };
+        let mut child_axes = Vec::with_capacity(children.len());
+        for child in children {
+            let Some(edge) = self.tree.edge_between(node, child) else {
+                return Ok(None);
+            };
+            let Some(bond) = self.tree.bond_index(edge) else {
+                return Ok(None);
+            };
+            let Some(axis) = tensor_indices.iter().position(|idx| idx == bond) else {
+                return Ok(None);
+            };
+            child_axes.push(axis);
+        }
+        let Some(parent_axis) = (0..tensor_indices.len())
+            .find(|axis| *axis != physical_axis && !child_axes.contains(axis))
+        else {
+            return Ok(None);
+        };
+
+        let dims = tensor.dims();
+        let mut strides = Vec::with_capacity(dims.len());
+        let mut stride = 1usize;
+        for &dim in &dims {
+            strides.push(stride);
+            stride = stride
+                .checked_mul(dim)
+                .ok_or_else(|| anyhow::anyhow!("multi-branch tensor strides overflow usize"))?;
+        }
+        let spec = MultiBranchContractionSpec {
+            strides,
+            physical_axis,
+            parent_axis,
+            child_dims: child_axes.iter().map(|&axis| dims[axis]).collect(),
+            child_axes,
+            parent_dim: dims[parent_axis],
+        };
+
+        let mut child_columns = Vec::with_capacity(children.len());
+        for (position, child) in children.iter().enumerate() {
+            let message = messages.get(child).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "TreeTNCachedEvaluator::try_compute_multi_branch_message_raw: missing message for child {:?}",
+                    child
+                )
+            })?;
+            let assignment_batch = assignment_batches.get(child).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "TreeTNCachedEvaluator::try_compute_multi_branch_message_raw: missing assignment batch for child {:?}",
+                    child
+                )
+            })?;
+            let Some(columns) = gather_message_columns(
+                message,
+                spec.child_dims[position],
+                points,
+                assignment_batch,
+                decode,
+                "TreeTNCachedEvaluator::try_compute_multi_branch_message_raw child",
+            )?
+            else {
+                return Ok(None);
+            };
+            child_columns.push(columns);
+        }
+
+        let mut physical_values = Vec::with_capacity(points.len());
+        for &point in points {
+            physical_values.push(value_at(
+                values,
+                entry.input_position,
+                point,
+                "TreeTNCachedEvaluator::try_compute_multi_branch_message_raw",
+            )?);
+        }
+
+        let result = tensor.with_dense_slice::<T, _>(|raw| {
+            multi_branch_message_contraction(&spec, raw, &physical_values, &child_columns)
+        })??;
+        Ok(Some(result))
+    }
+
     fn compute_generic_cached_message_values(
         &self,
         node: &V,
@@ -4199,7 +4375,7 @@ where
                         messages,
                     )?
                 };
-                let raw_missing_values = if chain.is_some() {
+                let branch = if chain.is_some() {
                     chain
                 } else {
                     self.try_compute_branch_message_complex_raw(
@@ -4209,6 +4385,23 @@ where
                         plan,
                         assignment_batches,
                         messages,
+                    )?
+                };
+                let raw_missing_values = if branch.is_some() {
+                    branch
+                } else {
+                    self.try_compute_multi_branch_message_raw::<Complex64>(
+                        node,
+                        values,
+                        &missing_points,
+                        plan,
+                        assignment_batches,
+                        messages,
+                        ScalarKind::C64,
+                        |value| match value {
+                            CachedScalar::C64(value) => Some(*value),
+                            _ => None,
+                        },
                     )?
                 };
                 match raw_missing_values {
@@ -4237,7 +4430,7 @@ where
                         messages,
                     )?
                 };
-                let raw_missing_values = if chain.is_some() {
+                let branch = if chain.is_some() {
                     chain
                 } else {
                     self.try_compute_branch_message_raw(
@@ -4247,6 +4440,23 @@ where
                         plan,
                         assignment_batches,
                         messages,
+                    )?
+                };
+                let raw_missing_values = if branch.is_some() {
+                    branch
+                } else {
+                    self.try_compute_multi_branch_message_raw::<f64>(
+                        node,
+                        values,
+                        &missing_points,
+                        plan,
+                        assignment_batches,
+                        messages,
+                        ScalarKind::F64,
+                        |value| match value {
+                            CachedScalar::F64(value) => Some(*value),
+                            _ => None,
+                        },
                     )?
                 };
                 match raw_missing_values {
@@ -4761,7 +4971,7 @@ where
     ) -> Result<Option<Vec<CachedScalar>>> {
         #[cfg(test)]
         let prelude_started = std::time::Instant::now();
-        if !(2..=3).contains(&component_batches.len()) {
+        if component_batches.len() < 2 {
             return Ok(None);
         }
         let entries = self
@@ -5393,6 +5603,32 @@ fn tensor_from_cached_values(
 #[cfg(test)]
 thread_local! {
     static RAW_CENTER_CORE_VISITS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    /// `(grouped, flat)` calls of the arbitrary-degree branch kernel, so a
+    /// test can pin which route a configuration actually takes. Thread-local
+    /// rather than atomic because the test harness runs tests in parallel
+    /// threads of one process.
+    static MULTI_BRANCH_ROUTES: std::cell::Cell<(usize, usize)> =
+        const { std::cell::Cell::new((0, 0)) };
+}
+
+#[cfg(test)]
+fn record_multi_branch_route(grouped: bool) {
+    let (grouped_calls, flat_calls) = MULTI_BRANCH_ROUTES.get();
+    if grouped {
+        MULTI_BRANCH_ROUTES.set((grouped_calls + 1, flat_calls));
+    } else {
+        MULTI_BRANCH_ROUTES.set((grouped_calls, flat_calls + 1));
+    }
+}
+
+#[cfg(test)]
+fn reset_multi_branch_routes_for_test() {
+    MULTI_BRANCH_ROUTES.set((0, 0));
+}
+
+#[cfg(test)]
+fn multi_branch_routes_for_test() -> (usize, usize) {
+    MULTI_BRANCH_ROUTES.get()
 }
 
 #[cfg(test)]
@@ -5416,8 +5652,8 @@ where
     T: Copy + Default + std::ops::AddAssign + std::ops::Mul<Output = T>,
 {
     ensure!(
-        (2..=3).contains(&components.len()),
-        "raw internal center needs two or three components"
+        components.len() >= 2,
+        "raw internal center needs at least two components"
     );
     ensure!(
         physical_axis < dims.len(),
@@ -5470,10 +5706,6 @@ where
         );
     }
 
-    let component_value = |component: &RawCenterComponent<T>, point: usize, bond: usize| {
-        let assignment = component.point_to_assignment[point];
-        component.values[assignment * component.dim + bond]
-    };
     #[cfg(test)]
     let mut core_visits = 0usize;
     let mut output = Vec::with_capacity(physical_values.len());
@@ -5483,57 +5715,508 @@ where
             "raw center physical value is out of bounds"
         );
         let physical_offset = physical * strides[physical_axis];
-        let mut sum = T::default();
-        match components {
-            [first, second] => {
-                for first_bond in 0..first.dim {
-                    let first_value = component_value(first, point, first_bond);
-                    let mut inner = T::default();
-                    for second_bond in 0..second.dim {
-                        #[cfg(test)]
-                        {
-                            core_visits += 1;
-                        }
-                        let second_value = component_value(second, point, second_bond);
-                        let offset = physical_offset
-                            + first_bond * strides[first.axis]
-                            + second_bond * strides[second.axis];
-                        inner += core[offset] * second_value;
-                    }
-                    sum += inner * first_value;
-                }
-            }
-            [first, second, third] => {
-                for first_bond in 0..first.dim {
-                    let first_value = component_value(first, point, first_bond);
-                    let mut middle = T::default();
-                    for second_bond in 0..second.dim {
-                        let second_value = component_value(second, point, second_bond);
-                        let mut inner = T::default();
-                        for third_bond in 0..third.dim {
-                            #[cfg(test)]
-                            {
-                                core_visits += 1;
-                            }
-                            let third_value = component_value(third, point, third_bond);
-                            let offset = physical_offset
-                                + first_bond * strides[first.axis]
-                                + second_bond * strides[second.axis]
-                                + third_bond * strides[third.axis];
-                            inner += core[offset] * third_value;
-                        }
-                        middle += inner * second_value;
-                    }
-                    sum += middle * first_value;
-                }
-            }
-            _ => bail!("raw internal center needs two or three components"),
-        }
+        let sum = fold_raw_center_components(
+            core,
+            &strides,
+            components,
+            point,
+            0,
+            physical_offset,
+            #[cfg(test)]
+            &mut core_visits,
+        );
         output.push(sum);
     }
     #[cfg(test)]
     RAW_CENTER_CORE_VISITS.set(core_visits);
     Ok(output)
+}
+
+/// Sums one point's center contraction over the components from `level` on.
+///
+/// The descent keeps the nesting the two- and three-component cases used
+/// before it replaced them: each level multiplies its own component value
+/// onto the sum accumulated by the levels inside it, so the arithmetic and
+/// its order are unchanged where those cases still apply, and the same
+/// nesting simply continues for a center of higher coordination. Components
+/// arrive sorted by descending axis, so the innermost loop is the
+/// smallest-stride one.
+fn fold_raw_center_components<T>(
+    core: &[T],
+    strides: &[usize],
+    components: &[RawCenterComponent<T>],
+    point: usize,
+    level: usize,
+    offset: usize,
+    #[cfg(test)] core_visits: &mut usize,
+) -> T
+where
+    T: Copy + Default + std::ops::AddAssign + std::ops::Mul<Output = T>,
+{
+    let component = &components[level];
+    let assignment = component.point_to_assignment[point];
+    let innermost = level + 1 == components.len();
+    let mut sum = T::default();
+    for bond in 0..component.dim {
+        let value = component.values[assignment * component.dim + bond];
+        let offset = offset + bond * strides[component.axis];
+        let inner = if innermost {
+            #[cfg(test)]
+            {
+                *core_visits += 1;
+            }
+            core[offset]
+        } else {
+            fold_raw_center_components(
+                core,
+                strides,
+                components,
+                point,
+                level + 1,
+                offset,
+                #[cfg(test)]
+                core_visits,
+            )
+        };
+        sum += inner * value;
+    }
+    sum
+}
+
+/// One arbitrary-degree branch node's contraction geometry.
+///
+/// The counterpart of [`BranchContractionSpec`] for a node with any number of
+/// rooted children. `child_axes` and `child_dims` are in rooted-child order,
+/// so `child_axes[0]` is the child whose bond the grouped kernel folds with
+/// its shared GEMM and the rest are folded per point afterwards.
+#[derive(Clone, Debug)]
+struct MultiBranchContractionSpec {
+    strides: Vec<usize>,
+    physical_axis: usize,
+    parent_axis: usize,
+    child_axes: Vec<usize>,
+    parent_dim: usize,
+    child_dims: Vec<usize>,
+}
+
+impl MultiBranchContractionSpec {
+    /// Elements of the prepared left operand of one physical group.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the product overflows `usize`.
+    fn prepared_elements(&self) -> Result<usize> {
+        self.child_dims
+            .iter()
+            .try_fold(self.parent_dim, |product, &dim| {
+                product
+                    .checked_mul(dim)
+                    .ok_or_else(|| anyhow::anyhow!("multi-branch slice size overflows usize"))
+            })
+    }
+
+    /// Destination weights of the prepared left operand, in child order.
+    ///
+    /// The prepared operand is column-major with `parent` fastest, then the
+    /// children from last to second, and `child_axes[0]` as the trailing
+    /// (column) axis. Folding the children in order therefore always reduces
+    /// the slowest remaining axis, so every step reads a contiguous block and
+    /// no intermediate transpose is needed -- the obstacle that kept the
+    /// two-child kernel from being generalized when it was written (see
+    /// `docs/worklogs/2026-08-22-treetn-branch-message-raw-path.md`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a weight overflows `usize`.
+    fn destination_weights(&self) -> Result<Vec<usize>> {
+        let mut weights = vec![0usize; self.child_dims.len()];
+        let mut weight = self.parent_dim;
+        for (position, &dim) in self.child_dims.iter().enumerate().skip(1).rev() {
+            weights[position] = weight;
+            weight = weight
+                .checked_mul(dim)
+                .ok_or_else(|| anyhow::anyhow!("multi-branch slice weight overflows usize"))?;
+        }
+        // `child_axes[0]` is the GEMM's column axis, so its weight is the row
+        // count of the prepared operand.
+        if let Some(first) = weights.first_mut() {
+            *first = weight;
+        }
+        Ok(weights)
+    }
+}
+
+/// Prepares one physical slice of an arbitrary-degree branch node as the
+/// column-major left operand of the grouped GEMM.
+///
+/// The result has `parent_dim * prod(child_dims[1..])` rows and
+/// `child_dims[0]` columns; see
+/// [`MultiBranchContractionSpec::destination_weights`] for the layout and why
+/// it is the one that makes every later fold contiguous.
+///
+/// # Errors
+///
+/// Returns an error when an offset overflows `usize` or falls outside `raw`.
+fn prepare_multi_branch_slice<T>(
+    spec: &MultiBranchContractionSpec,
+    raw: &[T],
+    physical_value: usize,
+) -> Result<Vec<T>>
+where
+    T: Copy + Default,
+{
+    let length = spec.prepared_elements()?;
+    let weights = spec.destination_weights()?;
+    let mut left = vec![T::default(); length];
+    let physical_base = physical_value
+        .checked_mul(spec.strides[spec.physical_axis])
+        .ok_or_else(|| anyhow::anyhow!("multi-branch tensor offset overflows usize"))?;
+    let parent_stride = spec.strides[spec.parent_axis];
+    let parent_dim = spec.parent_dim;
+    let degree = spec.child_dims.len();
+    let mut coordinates = vec![0usize; degree];
+    loop {
+        let mut source = physical_base;
+        let mut destination = 0usize;
+        for (position, &coordinate) in coordinates.iter().enumerate() {
+            source = coordinate
+                .checked_mul(spec.strides[spec.child_axes[position]])
+                .and_then(|offset| source.checked_add(offset))
+                .ok_or_else(|| anyhow::anyhow!("multi-branch tensor offset overflows usize"))?;
+            destination = coordinate
+                .checked_mul(weights[position])
+                .and_then(|offset| destination.checked_add(offset))
+                .ok_or_else(|| anyhow::anyhow!("multi-branch slice offset overflows usize"))?;
+        }
+        if parent_stride == 1 {
+            let end = source
+                .checked_add(parent_dim)
+                .ok_or_else(|| anyhow::anyhow!("multi-branch tensor offset overflows usize"))?;
+            let block = raw.get(source..end).ok_or_else(|| {
+                anyhow::anyhow!("multi-branch tensor offset {source}..{end} is out of bounds")
+            })?;
+            left[destination..destination + parent_dim].copy_from_slice(block);
+        } else {
+            let mut flat = source;
+            for parent in 0..parent_dim {
+                left[destination + parent] = *raw.get(flat).ok_or_else(|| {
+                    anyhow::anyhow!("multi-branch tensor offset {flat} is out of bounds")
+                })?;
+                flat = flat
+                    .checked_add(parent_stride)
+                    .ok_or_else(|| anyhow::anyhow!("multi-branch tensor offset overflows usize"))?;
+            }
+        }
+
+        // Odometer over the child bonds, least significant last so the walk
+        // covers every combination exactly once.
+        let mut position = degree;
+        loop {
+            if position == 0 {
+                return Ok(left);
+            }
+            position -= 1;
+            coordinates[position] += 1;
+            if coordinates[position] < spec.child_dims[position] {
+                break;
+            }
+            coordinates[position] = 0;
+        }
+    }
+}
+
+/// Folds one point's remaining children into its parent-message column.
+///
+/// `column` enters as the prepared operand's rows for one point, laid out
+/// `[parent, child_{q-1}, ..., child_1]` with `child_1` slowest, and each fold
+/// reduces the slowest remaining axis in place of a transpose.
+///
+/// # Errors
+///
+/// Returns an error when a child's column is missing or the buffer length is
+/// not divisible by the child dimension it is about to fold.
+fn fold_multi_branch_children<T>(
+    spec: &MultiBranchContractionSpec,
+    mut column: Vec<T>,
+    child_columns: &[Vec<T>],
+    point: usize,
+) -> Result<Vec<T>>
+where
+    T: Copy + Default + std::ops::AddAssign + std::ops::Mul<Output = T>,
+{
+    for (position, &dim) in spec.child_dims.iter().enumerate().skip(1) {
+        anyhow::ensure!(
+            dim > 0 && column.len().is_multiple_of(dim),
+            "multi-branch fold buffer of length {} is incompatible with child dimension {dim}",
+            column.len()
+        );
+        let block = column.len() / dim;
+        let values = child_columns.get(position).ok_or_else(|| {
+            anyhow::anyhow!("multi-branch fold is missing child {position}'s columns")
+        })?;
+        let base = point
+            .checked_mul(dim)
+            .ok_or_else(|| anyhow::anyhow!("multi-branch child offset overflows usize"))?;
+        let mut folded = vec![T::default(); block];
+        for coordinate in 0..dim {
+            let value = *values
+                .get(base + coordinate)
+                .ok_or_else(|| anyhow::anyhow!("multi-branch child column is out of bounds"))?;
+            let start = coordinate * block;
+            for (target, source) in folded.iter_mut().zip(&column[start..start + block]) {
+                *target += *source * value;
+            }
+        }
+        column = folded;
+    }
+    Ok(column)
+}
+
+/// Contracts an arbitrary-degree branch node against every child's message
+/// columns without materializing a prepared slice.
+///
+/// This is the memory-flat route: it walks the node's own tensor with a
+/// strided odometer and accumulates directly into each point's parent column,
+/// so its only allocation is the output itself. The grouped route below is
+/// faster per flop but needs a `parent_dim * prod(child_dims)` scratch buffer,
+/// which is why this one stays reachable at every size.
+///
+/// # Errors
+///
+/// Returns an error when a child column list has the wrong length or an
+/// offset leaves `raw`.
+fn scalar_multi_branch_message_contraction<T>(
+    spec: &MultiBranchContractionSpec,
+    raw: &[T],
+    physical_values: &[usize],
+    child_columns: &[Vec<T>],
+) -> Result<Vec<T>>
+where
+    T: Copy + Default + std::ops::AddAssign + std::ops::Mul<Output = T>,
+{
+    let point_count = physical_values.len();
+    let output_len = point_count
+        .checked_mul(spec.parent_dim)
+        .ok_or_else(|| anyhow::anyhow!("multi-branch output length overflows usize"))?;
+    let mut output = vec![T::default(); output_len];
+    let parent_stride = spec.strides[spec.parent_axis];
+    for (point, &physical_value) in physical_values.iter().enumerate() {
+        let physical_base = physical_value
+            .checked_mul(spec.strides[spec.physical_axis])
+            .ok_or_else(|| anyhow::anyhow!("multi-branch tensor offset overflows usize"))?;
+        let destination = point * spec.parent_dim;
+        accumulate_multi_branch_point(
+            spec,
+            raw,
+            child_columns,
+            point,
+            0,
+            physical_base,
+            None,
+            parent_stride,
+            &mut output[destination..destination + spec.parent_dim],
+        )?;
+    }
+    Ok(output)
+}
+
+/// Recursive Horner descent over one point's child bonds.
+///
+/// `weight` is the product of the child values chosen so far, or `None` at the
+/// root so that a childless node copies its slice rather than multiplying by a
+/// synthetic one.
+///
+/// # Errors
+///
+/// Returns an error when an offset overflows `usize` or leaves `raw`.
+#[allow(clippy::too_many_arguments)]
+fn accumulate_multi_branch_point<T>(
+    spec: &MultiBranchContractionSpec,
+    raw: &[T],
+    child_columns: &[Vec<T>],
+    point: usize,
+    level: usize,
+    offset: usize,
+    weight: Option<T>,
+    parent_stride: usize,
+    output: &mut [T],
+) -> Result<()>
+where
+    T: Copy + Default + std::ops::AddAssign + std::ops::Mul<Output = T>,
+{
+    if level == spec.child_dims.len() {
+        let mut flat = offset;
+        for target in output.iter_mut() {
+            let value = *raw.get(flat).ok_or_else(|| {
+                anyhow::anyhow!("multi-branch tensor offset {flat} is out of bounds")
+            })?;
+            match weight {
+                Some(weight) => *target += value * weight,
+                None => *target += value,
+            }
+            flat = flat
+                .checked_add(parent_stride)
+                .ok_or_else(|| anyhow::anyhow!("multi-branch tensor offset overflows usize"))?;
+        }
+        return Ok(());
+    }
+    let dim = spec.child_dims[level];
+    let stride = spec.strides[spec.child_axes[level]];
+    let values = child_columns
+        .get(level)
+        .ok_or_else(|| anyhow::anyhow!("multi-branch contraction is missing child {level}"))?;
+    let base = point
+        .checked_mul(dim)
+        .ok_or_else(|| anyhow::anyhow!("multi-branch child offset overflows usize"))?;
+    for coordinate in 0..dim {
+        let value = *values
+            .get(base + coordinate)
+            .ok_or_else(|| anyhow::anyhow!("multi-branch child column is out of bounds"))?;
+        let next_weight = Some(match weight {
+            Some(weight) => weight * value,
+            None => value,
+        });
+        let next_offset = coordinate
+            .checked_mul(stride)
+            .and_then(|shift| offset.checked_add(shift))
+            .ok_or_else(|| anyhow::anyhow!("multi-branch tensor offset overflows usize"))?;
+        accumulate_multi_branch_point(
+            spec,
+            raw,
+            child_columns,
+            point,
+            level + 1,
+            next_offset,
+            next_weight,
+            parent_stride,
+            output,
+        )?;
+    }
+    Ok(())
+}
+
+/// Contracts an arbitrary-degree branch node one physical group at a time,
+/// folding the first child with a shared GEMM.
+///
+/// Every point in a physical group multiplies the *same* slice of the node's
+/// tensor, so that slice is prepared once and all of the group's first-child
+/// columns are folded into it in a single matrix multiplication. The
+/// remaining children differ per point already after that step, so they are
+/// folded per point by [`fold_multi_branch_children`] -- the same two-stage
+/// shape the two-child kernel uses, generalized by choosing a layout in which
+/// every later fold reduces the slowest remaining axis.
+///
+/// # Errors
+///
+/// Returns an error when a child column list has the wrong length, an offset
+/// leaves `raw`, or the backend rejects the multiplication.
+fn grouped_multi_branch_message_contraction<T>(
+    spec: &MultiBranchContractionSpec,
+    raw: &[T],
+    physical_values: &[usize],
+    child_columns: &[Vec<T>],
+) -> Result<Vec<T>>
+where
+    T: BlasMul + Copy + Default + std::ops::AddAssign + std::ops::Mul<Output = T>,
+{
+    let point_count = physical_values.len();
+    let output_len = point_count
+        .checked_mul(spec.parent_dim)
+        .ok_or_else(|| anyhow::anyhow!("multi-branch output length overflows usize"))?;
+    let first_dim = *spec
+        .child_dims
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("multi-branch grouped kernel needs at least one child"))?;
+    let rows = spec
+        .prepared_elements()?
+        .checked_div(first_dim)
+        .ok_or_else(|| anyhow::anyhow!("multi-branch child dimension must be positive"))?;
+    let mut groups = HashMap::<usize, Vec<usize>>::new();
+    for (point, &physical_value) in physical_values.iter().enumerate() {
+        groups.entry(physical_value).or_default().push(point);
+    }
+    let mut output = vec![T::default(); output_len];
+    let first_columns = child_columns
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("multi-branch grouped kernel needs at least one child"))?;
+    for (physical_value, points) in groups {
+        let left = prepare_multi_branch_slice(spec, raw, physical_value)?;
+        let mut right = Vec::with_capacity(first_dim * points.len());
+        for &point in &points {
+            let start = point
+                .checked_mul(first_dim)
+                .ok_or_else(|| anyhow::anyhow!("multi-branch child offset overflows usize"))?;
+            let end = start
+                .checked_add(first_dim)
+                .ok_or_else(|| anyhow::anyhow!("multi-branch child offset overflows usize"))?;
+            right.extend_from_slice(
+                first_columns
+                    .get(start..end)
+                    .ok_or_else(|| anyhow::anyhow!("multi-branch child column is out of bounds"))?,
+            );
+        }
+        let intermediate = mat_mul_owned(
+            Matrix::from_col_major_vec(rows, first_dim, left),
+            Matrix::from_col_major_vec(first_dim, points.len(), right),
+        )
+        .map_err(anyhow::Error::from)?;
+        let intermediate = intermediate.as_col_major_slice();
+        for (column, &point) in points.iter().enumerate() {
+            let start = column * rows;
+            let folded = fold_multi_branch_children(
+                spec,
+                intermediate[start..start + rows].to_vec(),
+                child_columns,
+                point,
+            )?;
+            anyhow::ensure!(
+                folded.len() == spec.parent_dim,
+                "multi-branch fold produced {} values, expected {}",
+                folded.len(),
+                spec.parent_dim
+            );
+            let destination = point * spec.parent_dim;
+            output[destination..destination + spec.parent_dim].copy_from_slice(&folded);
+        }
+    }
+    Ok(output)
+}
+
+/// Routes one arbitrary-degree branch contraction to the grouped or the flat
+/// kernel.
+///
+/// The grouped kernel is used when the group's arithmetic is large enough to
+/// pay for a backend call *and* its prepared slice fits
+/// [`MULTI_BRANCH_MAX_PREPARED_ELEMENTS`]; a node whose
+/// `parent_dim * prod(child_dims)` cross would need more scratch than that
+/// stays on the flat kernel, which allocates nothing beyond its output. Both
+/// routes compute the same contraction and differ only in the order the sums
+/// are accumulated.
+///
+/// # Errors
+///
+/// Propagates the selected kernel's failures.
+fn multi_branch_message_contraction<T>(
+    spec: &MultiBranchContractionSpec,
+    raw: &[T],
+    physical_values: &[usize],
+    child_columns: &[Vec<T>],
+) -> Result<Vec<T>>
+where
+    T: BlasMul + Copy + Default + std::ops::AddAssign + std::ops::Mul<Output = T>,
+{
+    let prepared = spec.prepared_elements()?;
+    let scalar_work = prepared
+        .checked_mul(physical_values.len())
+        .ok_or_else(|| anyhow::anyhow!("multi-branch work estimate overflows usize"))?;
+    if scalar_work < BRANCH_BLAS_WORK_THRESHOLD || prepared > MULTI_BRANCH_MAX_PREPARED_ELEMENTS {
+        #[cfg(test)]
+        record_multi_branch_route(false);
+        return scalar_multi_branch_message_contraction(spec, raw, physical_values, child_columns);
+    }
+    #[cfg(test)]
+    record_multi_branch_route(true);
+    grouped_multi_branch_message_contraction(spec, raw, physical_values, child_columns)
 }
 
 fn scalar_chain_message_contraction<T>(
@@ -8086,8 +8769,10 @@ mod tests {
             .1
             .remove(&0)
             .unwrap();
-        assert!(hub.tensor.is_some());
-        assert!(hub.raw_values.is_none());
+        // The values above already match the tree's own evaluation; the hub's
+        // three rooted children now reach that answer on the raw path.
+        assert!(hub.raw_values.is_some());
+        assert!(hub.tensor.is_none());
     }
 
     // [AI Supplied] Small exact fixture plumbing around the #671 relation.
@@ -9892,8 +10577,12 @@ mod tests {
         }
     }
 
+    /// A degree-4 hub used to disqualify the whole tree from the raw path,
+    /// because its leaf-rooted form has three children and no kernel covered
+    /// that. `try_compute_multi_branch_message_raw` does, so the tree keeps
+    /// its raw messages (tensor4all-rs #727).
     #[test]
-    fn degree_four_hub_does_not_keep_raw_messages_when_center_is_a_leaf() {
+    fn degree_four_hub_keeps_raw_messages_when_center_is_a_leaf() {
         let (tree, indices) = four_arm_star_tree();
         let mut evaluator = TreeTNCachedEvaluator::new(
             &tree,
@@ -9914,10 +10603,10 @@ mod tests {
             .expect("leaf-centered star must expose the hub environment");
 
         assert!(
-            hub_message.raw_values.is_none(),
-            "a degree-4 hub needs the generic multi-child message path"
+            hub_message.raw_values.is_some(),
+            "a degree-4 hub is covered by the arbitrary-degree message kernel"
         );
-        assert!(hub_message.tensor.is_some());
+        assert!(hub_message.tensor.is_none());
     }
 
     fn complex_star_tree() -> (TreeTN<IdxTensor, usize>, Vec<DynIndex>) {
@@ -10360,6 +11049,367 @@ mod tests {
             values[4 * point + 3] = (point / 5 + offset) % 4;
         }
         values
+    }
+
+    /// A hub of `arms` unequal bonds whose physical index sits *between* two
+    /// of them, with unequal leaf dimensions.
+    ///
+    /// Rooted at leaf 1 the hub has `arms - 1` children, so `arms >= 4`
+    /// reaches the arbitrary-degree message kernel. Nothing about the fixture
+    /// is canonical: axis order, bond dimensions, and site dimensions all
+    /// differ, so a kernel that assumes any of them cannot pass by accident.
+    fn unequal_star_tree<T: CachedEvaluatorTestScalar>(
+        arms: usize,
+    ) -> (TreeTN<IdxTensor, usize>, Vec<DynIndex>) {
+        assert!(arms >= 2, "a star needs at least two arms");
+        let value = |offset: usize| {
+            T::from_parts(
+                (offset % 7) as f64 * 0.25 - 0.75,
+                ((offset % 5) as f64) * 0.125 - 0.25,
+            )
+        };
+        let hub_site = DynIndex::new_dyn(2);
+        let sites = (0..arms)
+            .map(|arm| DynIndex::new_dyn(2 + arm % 2))
+            .collect::<Vec<_>>();
+        // Bonds are large enough that a handful of points already crosses
+        // the grouped kernel's work threshold, so both routes are reachable
+        // through the evaluator rather than only through the primitives.
+        let bonds = (0..arms)
+            .map(|arm| DynIndex::new_dyn(4 + arm % 3))
+            .collect::<Vec<_>>();
+
+        let mut hub_indices = vec![bonds[0].clone(), hub_site.clone()];
+        hub_indices.extend(bonds[1..].iter().cloned());
+        let hub_len = hub_indices
+            .iter()
+            .map(|index| index.dim())
+            .product::<usize>();
+        let hub = IdxTensor::from_dense(hub_indices, (0..hub_len).map(value).collect::<Vec<T>>())
+            .unwrap();
+
+        let mut tensors = vec![hub];
+        for arm in 0..arms {
+            let leaf_len = bonds[arm].dim() * sites[arm].dim();
+            tensors.push(
+                IdxTensor::from_dense(
+                    vec![bonds[arm].clone(), sites[arm].clone()],
+                    (0..leaf_len)
+                        .map(|offset| value(offset + arm + 3))
+                        .collect::<Vec<T>>(),
+                )
+                .unwrap(),
+            );
+        }
+        let tree = TreeTN::<_, usize>::from_tensors(tensors, (0..=arms).collect()).unwrap();
+        let mut indices = vec![hub_site];
+        indices.extend(sites);
+        (tree, indices)
+    }
+
+    /// Distinct points, enumerated as an odometer over the site dimensions so
+    /// that `point_count` distinct assignments really do reach the kernel
+    /// (a cycling pattern repeats after `lcm(dims)` points and would silently
+    /// keep every batch under the grouped kernel's work threshold).
+    fn star_points(indices: &[DynIndex], point_count: usize) -> Vec<usize> {
+        let capacity: usize = indices.iter().map(|index| index.dim()).product();
+        assert!(
+            point_count <= capacity,
+            "the fixture has only {capacity} distinct points"
+        );
+        let mut values = Vec::with_capacity(indices.len() * point_count);
+        for point in 0..point_count {
+            let mut remaining = point;
+            for index in indices {
+                values.push(remaining % index.dim());
+                remaining /= index.dim();
+            }
+        }
+        values
+    }
+
+    /// Returns the `(grouped, flat)` route counts of the kernel call under
+    /// test, so the caller can pin which route this configuration takes
+    /// without counting the warm-up evaluation's own calls.
+    fn assert_multi_branch_matches_generic<T>(arms: usize, point_count: usize) -> (usize, usize)
+    where
+        T: CachedEvaluatorTestScalar
+            + BlasMul
+            + Copy
+            + Default
+            + std::ops::AddAssign
+            + std::ops::Mul<Output = T>,
+    {
+        let (tree, indices) = unequal_star_tree::<T>(arms);
+        let mut evaluator = TreeTNCachedEvaluator::new(
+            &tree,
+            &indices,
+            CachedEvaluatorOptions {
+                center: Some(1),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let values = star_points(&indices, point_count);
+        let shape = [indices.len(), point_count];
+        let points = ColMajorArrayRef::new(&values, &shape).unwrap();
+        evaluator.evaluate_batched(points).unwrap();
+
+        let plan = RootedMessagePlan::new(&tree, &1).unwrap();
+        let assignment_batches = evaluator
+            .build_message_assignment_batches(&plan, points)
+            .unwrap();
+
+        // Every leaf except the centre is a child of the hub; compute those
+        // through the generic oracle so only the hub's own step differs.
+        let mut messages = HashMap::new();
+        for leaf in 2..=arms {
+            let leaf_points = assignment_batches.get(&leaf).unwrap().first_points.clone();
+            let leaf_message = evaluator
+                .compute_stacked_message(
+                    &leaf,
+                    points,
+                    &leaf_points,
+                    &plan,
+                    &assignment_batches,
+                    &HashMap::new(),
+                )
+                .unwrap();
+            messages.insert(leaf, leaf_message);
+        }
+        assert_eq!(
+            plan.children.get(&0).map(Vec::len),
+            Some(arms - 1),
+            "the hub must have every non-centre arm as a rooted child"
+        );
+
+        let hub_points = assignment_batches.get(&0).unwrap().first_points.clone();
+        let expected_message = evaluator
+            .compute_stacked_message(
+                &0,
+                points,
+                &hub_points,
+                &plan,
+                &assignment_batches,
+                &messages,
+            )
+            .unwrap();
+        let expected = tensor_values_any(expected_message.tensor.as_ref().unwrap()).unwrap();
+
+        reset_multi_branch_routes_for_test();
+        let actual = evaluator
+            .try_compute_multi_branch_message_raw::<T>(
+                &0,
+                points,
+                &hub_points,
+                &plan,
+                &assignment_batches,
+                &messages,
+                if T::IS_COMPLEX {
+                    ScalarKind::C64
+                } else {
+                    ScalarKind::F64
+                },
+                |value| match (value, T::IS_COMPLEX) {
+                    (CachedScalar::F64(value), false) => Some(T::from_parts(*value, 0.0)),
+                    (CachedScalar::C64(value), true) => Some(T::from_parts(value.re, value.im)),
+                    _ => None,
+                },
+            )
+            .unwrap()
+            .unwrap_or_else(|| panic!("a hub with {} rooted children must be eligible", arms - 1));
+
+        assert_eq!(actual.len(), expected.len());
+        let mut residual = 0.0f64;
+        for (raw, generic) in actual.iter().zip(expected.iter()) {
+            let raw = raw.into_any_scalar();
+            residual = residual
+                .max((raw.real() - generic.real()).abs())
+                .max((raw.imag() - generic.imag()).abs());
+        }
+        assert!(
+            residual <= 1.0e-10,
+            "arbitrary-degree message differs from the generic contraction by {residual:.3e} \
+             (arms={arms}, points={point_count})"
+        );
+        multi_branch_routes_for_test()
+    }
+
+    /// The arbitrary-degree message kernel must reproduce the generic
+    /// contraction at every degree it claims, for both scalar kinds, and on
+    /// both of its routes.
+    ///
+    /// The route a case takes follows from its own arithmetic -- the grouped
+    /// kernel is chosen when `parent_dim * prod(child_dims) * points` clears
+    /// the backend threshold -- so rather than restate that rule per case,
+    /// the matrix asserts that each call took exactly one route and that the
+    /// matrix as a whole exercised both.
+    #[test]
+    fn multi_branch_raw_message_matches_generic_contraction() {
+        let mut grouped_total = 0usize;
+        let mut flat_total = 0usize;
+        for arms in [4usize, 5, 6] {
+            for point_count in [1usize, 32] {
+                for complex in [false, true] {
+                    let (grouped, flat) = if complex {
+                        assert_multi_branch_matches_generic::<Complex64>(arms, point_count)
+                    } else {
+                        assert_multi_branch_matches_generic::<f64>(arms, point_count)
+                    };
+                    assert_eq!(
+                        grouped + flat,
+                        1,
+                        "arms={arms} points={point_count} complex={complex} took {grouped} grouped \
+                         and {flat} flat routes"
+                    );
+                    grouped_total += grouped;
+                    flat_total += flat;
+                }
+            }
+        }
+        assert!(
+            grouped_total > 0 && flat_total > 0,
+            "the matrix must exercise both routes, saw {grouped_total} grouped and {flat_total} flat"
+        );
+    }
+
+    /// The two routes of the arbitrary-degree kernel are the same
+    /// contraction, so they must agree with each other as well as with the
+    /// generic path -- the fallback-parity half of the routing contract.
+    #[test]
+    fn multi_branch_grouped_and_flat_routes_agree() {
+        // A hub of shape [parent=3, physical=2, c0=2, c1=3, c2=2] with the
+        // physical axis in the middle and a non-contiguous parent axis.
+        let spec = MultiBranchContractionSpec {
+            strides: vec![1, 3, 6, 12, 36],
+            physical_axis: 1,
+            parent_axis: 0,
+            child_axes: vec![2, 3, 4],
+            parent_dim: 3,
+            child_dims: vec![2, 3, 2],
+        };
+        let raw = (0..72)
+            .map(|value| (value % 11) as f64 * 0.25 - 1.0)
+            .collect::<Vec<f64>>();
+        let physical_values = vec![0usize, 1, 1, 0];
+        let child_columns = vec![
+            (0..8)
+                .map(|v| (v % 5) as f64 * 0.5 - 0.75)
+                .collect::<Vec<f64>>(),
+            (0..12)
+                .map(|v| (v % 7) as f64 * 0.25 - 0.5)
+                .collect::<Vec<f64>>(),
+            (0..8)
+                .map(|v| (v % 3) as f64 * 0.75 - 0.25)
+                .collect::<Vec<f64>>(),
+        ];
+
+        let flat =
+            scalar_multi_branch_message_contraction(&spec, &raw, &physical_values, &child_columns)
+                .unwrap();
+        let grouped =
+            grouped_multi_branch_message_contraction(&spec, &raw, &physical_values, &child_columns)
+                .unwrap();
+
+        assert_eq!(flat.len(), physical_values.len() * spec.parent_dim);
+        assert_eq!(flat.len(), grouped.len());
+        let residual = flat
+            .iter()
+            .zip(&grouped)
+            .fold(0.0f64, |residual, (left, right)| {
+                residual.max((left - right).abs())
+            });
+        assert!(
+            residual <= 1.0e-12,
+            "the grouped and flat routes disagree by {residual:.3e}"
+        );
+
+        // A hand-computed reference for one output element pins the two
+        // routes to the intended contraction rather than to each other:
+        // point 0 has physical 0 and reads child columns 0..d of each child.
+        let mut reference = 0.0f64;
+        for c0 in 0..spec.child_dims[0] {
+            for c1 in 0..spec.child_dims[1] {
+                for c2 in 0..spec.child_dims[2] {
+                    // Point 0 has physical value 0, so its physical
+                    // offset contributes nothing to this reference.
+                    let offset = c0 * spec.strides[spec.child_axes[0]]
+                        + c1 * spec.strides[spec.child_axes[1]]
+                        + c2 * spec.strides[spec.child_axes[2]]
+                        + 2 * spec.strides[spec.parent_axis];
+                    reference += raw[offset]
+                        * child_columns[0][c0]
+                        * child_columns[1][c1]
+                        * child_columns[2][c2];
+                }
+            }
+        }
+        assert!(
+            (flat[2] - reference).abs() <= 1.0e-12,
+            "flat route gives {} against the hand-computed {reference}",
+            flat[2]
+        );
+    }
+
+    /// The whole public evaluation must match the tree's own contraction on a
+    /// high-coordination star, with the centre both at a leaf (which
+    /// exercises the arbitrary-degree *message* kernel) and at the hub (which
+    /// exercises the arbitrary-degree *centre* contraction).
+    #[test]
+    fn cached_evaluator_matches_tree_evaluate_on_high_coordination_stars() {
+        for arms in [4usize, 5, 6] {
+            let (tree, indices) = unequal_star_tree::<f64>(arms);
+            let values = star_points(&indices, 5);
+            let shape = [indices.len(), 5];
+            let points = ColMajorArrayRef::new(&values, &shape).unwrap();
+            let expected = tree.evaluate(&indices, points).unwrap();
+
+            for center in [1usize, 0] {
+                let mut evaluator = TreeTNCachedEvaluator::new(
+                    &tree,
+                    &indices,
+                    CachedEvaluatorOptions {
+                        center: Some(center),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+                let cold = evaluator.evaluate_batched(points).unwrap();
+                let warm = evaluator.evaluate_batched(points).unwrap();
+                assert_scalars_close(&cold, &expected);
+                assert_scalars_close(&warm, &expected);
+            }
+        }
+    }
+
+    /// A centre of coordination four or more is contracted by the same raw
+    /// centre kernel that used to stop at three components.
+    #[test]
+    fn raw_center_contraction_covers_high_coordination_centers() {
+        for arms in [4usize, 5] {
+            let (tree, indices) = unequal_star_tree::<f64>(arms);
+            let values = star_points(&indices, 3);
+            let shape = [indices.len(), 3];
+            let points = ColMajorArrayRef::new(&values, &shape).unwrap();
+            let expected = tree.evaluate(&indices, points).unwrap();
+            let mut evaluator = TreeTNCachedEvaluator::new(
+                &tree,
+                &indices,
+                CachedEvaluatorOptions {
+                    center: Some(0),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+            reset_raw_center_core_visits_for_test();
+            let actual = evaluator.evaluate_batched(points).unwrap();
+            assert_scalars_close(&actual, &expected);
+            assert!(
+                raw_center_core_visits_for_test() > 0,
+                "a degree-{arms} centre must reach the raw centre kernel"
+            );
+        }
     }
 
     fn four_arm_star_tree() -> (TreeTN<IdxTensor, usize>, Vec<DynIndex>) {

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -10955,7 +10955,7 @@ mod tests {
                 start,
                 MAX_SWEEPS,
                 f64::INFINITY,
-                |points: &[Vec<usize>]| -> Result<Vec<f64>> {
+                |_scan_site: Option<usize>, points: &[Vec<usize>]| -> Result<Vec<f64>> {
                     let mut values = vec![0usize; N_SITES * points.len()];
                     for (p, point) in points.iter().enumerate() {
                         for (site, &v) in point.iter().enumerate() {
@@ -11002,7 +11002,7 @@ mod tests {
                 start,
                 MAX_SWEEPS,
                 f64::INFINITY,
-                |points: &[Vec<usize>]| -> Result<Vec<f64>> {
+                |_scan_site: Option<usize>, points: &[Vec<usize>]| -> Result<Vec<f64>> {
                     let mut values = vec![0usize; N_SITES * points.len()];
                     for (p, point) in points.iter().enumerate() {
                         for (site, &v) in point.iter().enumerate() {
@@ -11098,7 +11098,7 @@ mod tests {
                 start,
                 MAX_SWEEPS,
                 f64::INFINITY,
-                |points: &[Vec<usize>]| -> Result<Vec<f64>> {
+                |_scan_site: Option<usize>, points: &[Vec<usize>]| -> Result<Vec<f64>> {
                     let mut values = vec![0usize; N_SITES * points.len()];
                     for (p, point) in points.iter().enumerate() {
                         for (site, &v) in point.iter().enumerate() {
@@ -11463,7 +11463,7 @@ mod tests {
                     start,
                     MAX_SWEEPS,
                     f64::INFINITY,
-                    |points: &[Vec<usize>]| -> Result<Vec<f64>> {
+                    |_scan_site: Option<usize>, points: &[Vec<usize>]| -> Result<Vec<f64>> {
                         let mut values = vec![0usize; n_sites * points.len()];
                         for (p, point) in points.iter().enumerate() {
                             for (site, &v) in point.iter().enumerate() {
@@ -11525,5 +11525,173 @@ mod tests {
         );
         assert!(chain_elapsed.as_nanos() > 0);
         assert!(comb_elapsed.as_nanos() > 0);
+    }
+
+    /// Where a hinted two-point Guard evaluation spends its time on a chain
+    /// and on a branched tree of the same site count (tensor4all-rs #727).
+    ///
+    /// The Guard walks one site at a time and hints the varying site as the
+    /// centre, so every call is two points that differ in one coordinate. On a
+    /// 13-site chain that call costs about 20 us; on a 13-site spider it costs
+    /// about 390 us, and the spider's cost does not move when its bonds shrink
+    /// from `8,8,8,8` to `2,2,2,2` -- so the gap is not arithmetic. This
+    /// attributes it. Run with `--ignored --nocapture`.
+    #[test]
+    #[ignore]
+    fn diagnostic_hinted_walk_cost_on_a_chain_versus_a_branched_tree() {
+        use std::sync::atomic::Ordering;
+        use std::time::Instant;
+
+        const N_SITES: usize = 13;
+        const LOCAL_DIM: usize = 2;
+        const SWEEPS: usize = 5;
+        const ARM_LENGTH: usize = 3;
+
+        fn chain(bond_dim: usize) -> (TreeTN<IdxTensor, usize>, Vec<DynIndex>) {
+            let physical = (0..N_SITES)
+                .map(|_| DynIndex::new_dyn(LOCAL_DIM))
+                .collect::<Vec<_>>();
+            let bonds = (0..N_SITES - 1)
+                .map(|_| DynIndex::new_dyn(bond_dim))
+                .collect::<Vec<_>>();
+            let mut tensors = Vec::with_capacity(N_SITES);
+            for site in 0..N_SITES {
+                let mut indices = vec![physical[site].clone()];
+                if site > 0 {
+                    indices.push(bonds[site - 1].clone());
+                }
+                if site + 1 < N_SITES {
+                    indices.push(bonds[site].clone());
+                }
+                let len: usize = indices.iter().map(IndexLike::dim).product();
+                tensors.push(
+                    IdxTensor::from_dense(
+                        indices,
+                        (0..len)
+                            .map(|flat| 1.0 + (flat % 7) as f64)
+                            .collect::<Vec<f64>>(),
+                    )
+                    .unwrap(),
+                );
+            }
+            (
+                TreeTN::from_tensors(tensors, (0..N_SITES).collect()).unwrap(),
+                physical,
+            )
+        }
+
+        fn spider(bond_dim: usize) -> (TreeTN<IdxTensor, usize>, Vec<DynIndex>) {
+            let arms = 4;
+            assert_eq!(arms * ARM_LENGTH + 1, N_SITES);
+            let physical = (0..N_SITES)
+                .map(|_| DynIndex::new_dyn(LOCAL_DIM))
+                .collect::<Vec<_>>();
+            let hub_bonds = (0..arms)
+                .map(|_| DynIndex::new_dyn(bond_dim))
+                .collect::<Vec<_>>();
+            let arm_bonds = (0..arms)
+                .map(|_| {
+                    (1..ARM_LENGTH)
+                        .map(|_| DynIndex::new_dyn(bond_dim))
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>();
+            let dense = |indices: Vec<DynIndex>| {
+                let len: usize = indices.iter().map(IndexLike::dim).product();
+                IdxTensor::from_dense(
+                    indices,
+                    (0..len)
+                        .map(|flat| 1.0 + (flat % 7) as f64)
+                        .collect::<Vec<f64>>(),
+                )
+                .unwrap()
+            };
+            let mut hub_indices = vec![physical[0].clone()];
+            hub_indices.extend(hub_bonds.iter().cloned());
+            let mut tensors = vec![dense(hub_indices)];
+            for arm in 0..arms {
+                for position in 0..ARM_LENGTH {
+                    let node = 1 + arm * ARM_LENGTH + position;
+                    let mut indices = vec![physical[node].clone()];
+                    if position == 0 {
+                        indices.push(hub_bonds[arm].clone());
+                    } else {
+                        indices.push(arm_bonds[arm][position - 1].clone());
+                    }
+                    if position + 1 < ARM_LENGTH {
+                        indices.push(arm_bonds[arm][position].clone());
+                    }
+                    tensors.push(dense(indices));
+                }
+            }
+            (
+                TreeTN::from_tensors(tensors, (0..N_SITES).collect()).unwrap(),
+                physical,
+            )
+        }
+
+        for (name, (tree, physical)) in [
+            ("chain_bond8", chain(8)),
+            ("spider_bond2", spider(2)),
+            ("spider_bond8", spider(8)),
+        ] {
+            let mut evaluator =
+                TreeTNCachedEvaluator::new(&tree, &physical, CachedEvaluatorOptions::default())
+                    .unwrap();
+            let warm = vec![0usize; N_SITES];
+            evaluator
+                .evaluate_batched_typed::<f64>(
+                    ColMajorArrayRef::new(&warm, &[N_SITES, 1]).unwrap(),
+                    EvaluationHint::default(),
+                )
+                .unwrap();
+
+            phase_timing::reset_all();
+            let mut calls = 0usize;
+            let started = Instant::now();
+            for sweep in 0..SWEEPS {
+                for site in 0..N_SITES {
+                    let mut values = vec![0usize; N_SITES * LOCAL_DIM];
+                    for point in 0..LOCAL_DIM {
+                        for other in 0..N_SITES {
+                            values[other + N_SITES * point] = if other == site {
+                                point
+                            } else {
+                                (other + sweep) % LOCAL_DIM
+                            };
+                        }
+                    }
+                    let batch = ColMajorArrayRef::new(&values, &[N_SITES, LOCAL_DIM]).unwrap();
+                    std::hint::black_box(
+                        evaluator
+                            .evaluate_batched_typed::<f64>(batch, EvaluationHint::around(site))
+                            .unwrap(),
+                    );
+                    calls += 1;
+                }
+            }
+            let total_ns = started.elapsed().as_nanos() as u64;
+            let per_call = |counter: u64| counter as f64 / calls as f64 / 1.0e3;
+            let stats = evaluator.stats_for_test();
+            eprintln!(
+                "hinted walk {name}: total={:.1}us/call over {calls} calls | environment={:.1}us {{capability={:.1}, assignments={:.1}, message_loop={:.1}, component_assembly={:.1}}}, centre={:.1}us, key_lookup={:.1}us, reconstruct={:.1}us, contract={:.1}us, insert={:.1}us, plan_build={:.1}us, layout_build={:.1}us, plans={}, cache hits/misses={}/{}",
+                per_call(total_ns),
+                per_call(phase_timing::BUILD_ENV_NS.load(Ordering::Relaxed)),
+                per_call(phase_timing::RAW_CAPABILITY_NS.load(Ordering::Relaxed)),
+                per_call(phase_timing::ASSIGNMENT_BATCH_NS.load(Ordering::Relaxed)),
+                per_call(phase_timing::MESSAGE_LOOP_NS.load(Ordering::Relaxed)),
+                per_call(phase_timing::COMPONENT_ASSEMBLY_NS.load(Ordering::Relaxed)),
+                per_call(phase_timing::CENTER_NS.load(Ordering::Relaxed)),
+                per_call(phase_timing::KEY_AND_LOOKUP_NS.load(Ordering::Relaxed)),
+                per_call(phase_timing::RECONSTRUCT_NS.load(Ordering::Relaxed)),
+                per_call(phase_timing::CONTRACT_NS.load(Ordering::Relaxed)),
+                per_call(phase_timing::INSERT_NS.load(Ordering::Relaxed)),
+                per_call(phase_timing::PLAN_BUILD_NS.load(Ordering::Relaxed)),
+                per_call(phase_timing::LAYOUT_BUILD_NS.load(Ordering::Relaxed)),
+                phase_timing::PLAN_COUNT.load(Ordering::Relaxed),
+                stats.message_cache_hits,
+                stats.message_cache_misses,
+            );
+        }
     }
 }

--- a/docs/design/tree-aci.md
+++ b/docs/design/tree-aci.md
@@ -91,7 +91,7 @@ the run boundary releases all of them.
 | lifetime | one run | one run, incrementally extended after sample growth | input evaluators: one run; output evaluator: one guard scan |
 | contents | immutable component-sample records and deduplication keys | exact directed component contractions plus optional candidate contractions | directed subtree messages reused across floating-zone batches |
 | aggregate bound | `max_sample_arena_bytes`, 256 MiB | `max_frame_bytes`, 256 MiB | `message_cache_max_bytes`, 256 MiB shared across all evaluators |
-| per-entry bound | -- | `max_frame_elements`, `2^24` | -- |
+| per-entry bound | -- | `max_frame_elements`, unset by default and then a quarter of `max_working_bytes` (`2^24` f64 elements at the 512 MiB default) | -- |
 | accounting | `sample_arena_records`, `sample_arena_retained_bytes` | `frame_records`, `frame_retained_bytes` | bounded but not currently exposed in diagnostics |
 
 Mandatory arena and directed-frame bounds are checked before allocation, so an
@@ -105,6 +105,20 @@ accounting, not allocator or process measurements.
 The per-entry and aggregate frame bounds are independent and neither implies the
 other: the cache keeps one frame per input per directed edge, so a per-frame
 ceiling sized to admit one frame still admits all of them.
+
+The element ceilings (`max_local_matrix_elements`, `max_core_elements`,
+`max_frame_elements`) and the working-byte budget measure the same physical
+resource, so the ceilings are not independent constants: each is `None` by
+default and then derived as a quarter of `max_working_bytes`, expressed in
+elements of the run's scalar type and resolved once, in `prepare_problem`, for
+every later enforcement site. Raising the budget raises them with it. Setting
+one explicitly pins it, and a pinned ceiling no longer follows the budget in
+either direction. The retention budgets (`max_frame_bytes`,
+`max_sample_arena_bytes`, `message_cache_max_bytes`) are separate and do not
+follow the working budget, because they bound what survives between local
+updates rather than what one update may allocate. Within one preparation the
+byte budget is checked before any ceiling derived from it, so an impossible
+budget is reported as `working bytes` rather than as a derived ceiling.
 
 The two state-owned cache families report through `TreeAciDiagnostics`, in the
 same logical-byte units. Evaluator messages obey their aggregate option bound

--- a/docs/worklogs/2026-09-01-treeaci-provenance-performance-audit.md
+++ b/docs/worklogs/2026-09-01-treeaci-provenance-performance-audit.md
@@ -3369,18 +3369,177 @@ scalars (1652 -> 742 input, 816 -> 361 output) with wall time flat within noise
 were already cached. The branched per-call penalty above is what dominates
 there, and it is the open item.
 
+## 2026-09-06 #727 follow-up: the branched evaluator penalty, removed
+
+The section above attributed the unequal incident-bond asymmetry to the Guard
+being invoked at all, and the Guard's cost on a branched tree to
+`TreeTNCachedEvaluator::can_use_raw_messages` refusing the raw kernels for the
+whole tree as soon as one node had more than three neighbours. That refusal is
+now gone, together with the two gaps that forced it.
+
+### Source lookup
+
+Primary sources cloned in full into ignored `target/literature/` and read
+page by page before any of the derivation below:
+
+| source | local clone | SHA-256 (PDF) | pages read |
+|---|---|---|---|
+| Ritter, *Fast elementwise operations on tensor trains with alternating cross interpolation*, [arXiv:2604.00037v2](https://arxiv.org/abs/2604.00037) | `target/literature/aci-2604.00037v2/` (`paper.pdf`, `source.tar.gz`, unpacked TeX) | `1eb0ab6047034d5a4e3155a385d3201df2e36a27412670f0c07f8d8856ff7369` | 1-17 of 17 |
+| Tindall, Stoudenmire and Levy, *Compressing multivariate functions with tree tensor networks*, [arXiv:2410.03572v3](https://arxiv.org/abs/2410.03572) | `target/literature/ttn-2410.03572/` | `18b27a93029842481285290ec58960320a068a6362e5b6a906dc334444a96456` | 1-24 of 24 |
+| Núñez Fernández et al., *Learning tensor networks with tensor cross interpolation*, [arXiv:2407.02454v3](https://arxiv.org/abs/2407.02454) / SciPost Phys. 18, 104 | `target/literature/tci-2407.02454v3/` | `f8d6c5e1dc19350d896f6a4f2bc9c29213d9752b1f45943819d130d2b7379bdf` | reference only, not cited below |
+
+Accessed 2026-09-06. The ACI PDF's hash reproduces the one the #718 session
+recorded, so both sessions read the same v2. What the sources do and do not
+support:
+
+- `Paper` (Tindall et al., v3 p3, Sec. 2, the paragraph immediately after
+  Eq. (1), text anchor "Such a contraction can be done in `O(nL chi^z)` time,
+  where `z` is the maximum co-ordination number of any of the tensors in the
+  network"): contracting a tree tensor network costs `chi^z` in the
+  coordination number `z`. This is the complexity the generalized kernel has
+  to *meet*, and it is why the arithmetic of a high-coordination node cannot
+  be avoided -- only its overhead can. The same scaling is restated for the
+  paper's Fredholm solver on p13 (`O(NnLr(chi_g^z chi_K^z + chi_K^{2z}))`).
+- `Paper` (Ritter v2, p8, Sec. 4, first paragraph of "Conclusions and
+  Outlook", text anchor "it is straightforward to generalize it to
+  tree-shaped tensor networks in the same manner as TCI"): the ACI algorithm
+  this crate implements is stated to generalize to trees, with the tree case
+  referred to Tindall et al. The chain frame recursion the tree message
+  recursion generalizes is Ritter v2 Eqs. (7)-(8) (p4) and Alg. 5 (p13,
+  `LeftFrame`/`RightFrame`).
+- **Not** supported by either paper: any statement about how a branch
+  message should be *implemented* -- axis layout, grouping by physical value,
+  BLAS routing, or a work threshold. Those are
+  `Tree generalization -- re-derived` plus `[AI Supplied]`, and the
+  differential tests against this crate's own generic contraction are their
+  authority.
+
+### What was in the way
+
+Two kernels stopped at coordination three:
+
+1. a rooted message for a node with three or more children had no raw kernel
+   (`try_compute_leaf_message_raw` covers zero, `..._chain_...` one, and
+   `..._branch_...` two), and
+2. `contract_raw_center` hard-coded its nesting for exactly two or three
+   components.
+
+The 2026-08-22 worklog that added the two-child kernel recorded the obstacle
+for the general case: "a general N-child version would need an inter-step
+buffer transpose this 2-child case avoids."
+
+### The derivation that removes the transpose
+
+Prepare the physical slice as `[parent, child_q, ..., child_2, child_1]` in
+column-major order -- parent fastest, the *first* child slowest. Then:
+
+- folding `child_1` is the GEMM over the slice's trailing axis, exactly as in
+  the two-child kernel;
+- what remains per point is `[parent, child_q, ..., child_2]`, whose slowest
+  axis is `child_2`, so folding it reads one contiguous block per coordinate;
+- and so on down to `[parent]`.
+
+Every fold therefore reduces the slowest remaining axis, which is contiguous
+by construction, so no intermediate transpose is needed at any degree. At
+`q = 2` the layout and the fold order are the ones the two-child kernel
+already used, which is why that kernel is left untouched as its own
+specialization. Cost is `parent * prod(child_dims)` per point, i.e. `chi^z` --
+the bound Tindall et al. state for a tree contraction, so the generalization
+is at the paper's complexity and not above it.
+
+`contract_raw_center` is generalized the same way, by replacing its two- and
+three-component `match` with a recursive Horner descent that reproduces the
+same nesting, in the same order, for those two cases.
+
+Two routes are kept for the message kernel: a grouped one that prepares the
+slice and folds the first child with one shared GEMM, and a flat one that
+walks the node's tensor with a strided odometer and allocates nothing beyond
+its output. The flat route runs when the arithmetic is too small to pay for a
+backend call *or* when the prepared slice would exceed
+`MULTI_BRANCH_MAX_PREPARED_ELEMENTS` (4 Mi scalars) -- because the slice is
+`chi^z`, the buffer, unlike the arithmetic, is worth refusing.
+
+### Result
+
+`cached_evaluator::tests::diagnostic_hinted_walk_cost_on_a_chain_versus_a_branched_tree`,
+one hinted two-point Guard-shaped call, 13 sites:
+
+| fixture | before | after | change |
+|---|---|---|---|
+| chain, `chi=8` | 13.8 us/call | 14.1 us/call | unchanged |
+| spider, hub bonds `2,2,2,2` | 292.1 us/call | **12.0 us/call** | 24x |
+| spider, hub bonds `8,8,8,8` | 288.4 us/call | **27.1 us/call** | 10.6x |
+
+The branched cost now *moves with bond dimension* (12.0 vs 27.1 us) instead of
+sitting at a flat ~290 us: what is left is arithmetic, which is the point.
+
+`global_guard::tests::diagnostic_guard_call_cost_on_a_branched_tree`, the same
+walk shape through TreeACI's own Guard evaluators:
+
+| fixture | before | after |
+|---|---|---|
+| 13-site chain, `chi=8` | 19.5 us/call | 20.3 us/call |
+| spider `2,2,2,2` | 391.3 us/call | 18.1 us/call |
+| spider `4,4,4,4` | 385.5 us/call | 19.0 us/call |
+| spider `2,4,8,4` | 386.1 us/call | 18.5 us/call |
+| spider `8,4,2,4` | 388.3 us/call | 18.5 us/call |
+
+A Guard evaluation on a coordination-4 spider now costs what one on a chain of
+the same size costs. End to end on the benchmark's own fixtures
+(`state::tests::profile_unequal_incident_bonds_at_coordination_four`, Guard
+on):
+
+| layout | sweep before | sweep after | guard before | guard after |
+|---|---|---|---|---|
+| `4,4,4,4` | 50.8 ms | 46.9 ms | 0 ns (rank-limited, never searches) | 0 ns |
+| `2,4,8,4` | 470.1 ms | **64.7 ms** | 412.5 ms | **9.4 ms** |
+| `8,4,2,4` | 803.5 ms | **83.0 ms** | 735.2 ms | **18.1 ms** |
+
+Per evaluated point that is `1.22`, `2.54` and `1.22` us against the equal
+layout's `1.22` us, so the `24x` this issue opened with is now at most `2.1x`,
+and what remains is the layouts' different convergence trajectories (sweep
+counts 2, 2 and 4) rather than a per-point penalty.
+
+### Correctness
+
+The kernels are pure performance: every route is checked against the generic
+`compute_stacked_message` contraction it replaces, not against itself.
+
+- `multi_branch_raw_message_matches_generic_contraction`: degrees 3, 4 and 5
+  (hubs of coordination 4, 5, 6), `f64` and `Complex64`, one point and 32
+  points, on a fixture with unequal bonds, unequal site dimensions, and the
+  physical index in the middle of the hub's axis order. Each case asserts
+  which of the two routes it took, and the matrix asserts that both routes
+  were exercised.
+- `multi_branch_grouped_and_flat_routes_agree`: the two routes against each
+  other *and* against a hand-computed reference element, on a spec with a
+  non-contiguous parent axis.
+- `cached_evaluator_matches_tree_evaluate_on_high_coordination_stars` and
+  `raw_center_contraction_covers_high_coordination_centers`: the public
+  `evaluate_batched` against `TreeTN::evaluate` for stars of 4, 5 and 6 arms,
+  centred both at a leaf (the message kernel) and at the hub (the centre
+  kernel), cold and warm.
+- The two eligibility tests that pinned the old boundary are inverted rather
+  than deleted: `degree_four_hub_keeps_raw_messages_when_center_is_a_leaf` now
+  asserts the raw representation is kept, and the degree-four case inside
+  `cached_evaluator_error_paths_and_unsupported_raw_dispatch_are_typed` keeps
+  its value comparison against `TreeTN::evaluate` while asserting the raw
+  path.
+
+Chain behaviour is unchanged by construction -- the zero-, one- and two-child
+kernels and their thresholds are untouched -- and the 13.8 -> 14.1 us chain
+row above is the measurement of that.
+
 ### Open items
 
-1. **DIAGNOSED on 2026-09-06 (#727), one step left.** The unequal-bond
-   asymmetry is a Guard-invocation difference plus a branched-tree evaluation
-   cost, not a cost of unequal bonds: with the Guard disabled the three layouts
-   are within 1.6x per evaluated point, and with it enabled the equal layout is
-   rank-limited and never searches at all. What remains open is the cause of
-   the branched cost -- `TreeTNCachedEvaluator::can_use_raw_messages` refuses
-   the raw kernels for the whole tree as soon as one node has more than three
-   neighbours, which is a fixed ~20x per-call penalty independent of bond
-   dimension. Generalizing those kernels past degree three is the remaining
-   work. See the `#726/#727/#728/#729` section above.
+1. **RESOLVED on 2026-09-06 (#727).** The asymmetry was a Guard-invocation
+   difference plus a branched-tree evaluation cost, not a cost of unequal
+   bonds. Both halves are now measured and the second is fixed: the raw
+   message and centre kernels cover any coordination, a Guard evaluation on a
+   coordination-4 spider costs what a chain of the same size costs, and the
+   fixture's `24x` per evaluated point is down to at most `2.1x`, which is its
+   different convergence trajectory. See the `#727 follow-up` section above.
+
 2. **PARTLY ADDRESSED on 2026-09-06 (#728).** The proposed consolidation of
    random starts into fewer larger calls was measured and rejected (0.21x at
    `chi=256`: a mixed-start batch loses the centre hint). The walk instead

--- a/docs/worklogs/2026-09-01-treeaci-provenance-performance-audit.md
+++ b/docs/worklogs/2026-09-01-treeaci-provenance-performance-audit.md
@@ -3184,23 +3184,211 @@ capture can resolve its fixed `../../tensor4all-rust/tensor4all-rs` path, and
 the raw logs) live outside the repository under `/root/downstream718` and are
 not part of this change. They are disposable; the numbers above are the record.
 
+## 2026-09-06 #726/#727/#728/#729: resource limits, and where the unequal-bond cost actually is
+
+Four follow-up issues opened by the #718 closure above. Two are behaviour
+changes with tests; two were open questions the closure deliberately left
+undiagnosed, and both are answered here by measurement.
+
+### #729: element ceilings now follow `max_working_bytes`
+
+`TreeAciOptions` carried two independent families of limit. Raising
+`max_working_bytes` did not raise `max_local_matrix_elements`,
+`max_core_elements`, or `max_frame_elements`, so the `gw-rs/sgw` R10 comb
+`pi_rtau` stage was refused at `requested 17958192, limit 16777216` while the
+runner had deliberately granted CTTN a 10 GiB budget.
+
+The three ceilings are now `Option<usize>`, unset by default, and an unset
+ceiling is a quarter of `max_working_bytes` in elements of the run's scalar
+type. At the 512 MiB default that is `2^24` f64 elements -- the constant it
+replaces, so `f64` defaults are unchanged -- and at the runner's 10 GiB it is
+`335,544,320`, so the refused 17.9M-element local matrix now fits the budget
+the caller actually set. A complex run gets half the elements and the same
+bytes, which is the intended correction: the ceilings and the budget measure
+the same resource. An explicitly set ceiling is a pin and does not follow the
+budget in either direction.
+
+Resolution happens once, in `prepare_problem` (now generic over the run's
+scalar type), and every enforcement site reads the resolved value from the
+prepared problem, so two sites cannot disagree. Within one preparation the byte
+budget is checked *before* any ceiling derived from it, so an impossible budget
+is still reported as `working bytes` -- `gw-rs` asserts exactly that message for
+its deliberately impossible one-byte budget, and
+`tests/resource_limits.rs::an_impossible_budget_is_reported_as_working_bytes`
+pins it here.
+
+### #726: the coordination>=4 pre-flight degrades instead of refusing
+
+The window the issue records is real: `enumerated_candidate_frame_scratch_elements`
+reported the batched charge whenever the Cartesian cross fit
+`max_working_bytes` *alone*, and `local_update.rs` then added the update's own
+live buffers before enforcing the budget, so a local update could be refused
+even though the scalar route it would have taken before #713 was affordable.
+
+Settled as **degrade**, by making both sides of the contract use the same
+number: `candidate_frames_for_edge`, its row-major counterpart, and the
+arbitrary-degree kernel now take `reserved_bytes`, the local update computes it
+once in `reserved_working_bytes`, and both the estimate and the kernel test the
+batched cross against the budget that *remains*. Degrading only in the
+pre-flight would have been the unsafe half of the fix: the kernel would still
+have batched and overrun the aggregate budget.
+
+No configuration that previously ran changes route. A run that took the batched
+route had `reserved + batched <= budget` already -- otherwise the aggregate
+check refused it -- and that inequality is exactly the new condition. What
+changes is only the previously refused window, which now runs on the scalar
+route at the pre-#713 cost.
+`frames::tests::local_update_degrades_instead_of_refusing_an_aggregate_overrun`
+pins the window (batched fits alone, not with the reservation) and asserts the
+degraded result matches the generous-budget one to rounding.
+
+### #727: the unequal-bond asymmetry is the Guard, not the bonds
+
+`state::tests::profile_unequal_incident_bonds_at_coordination_four` rebuilds
+the benchmark's three layouts and reports the phase split. Two measurements
+settle the question.
+
+**With the Guard disabled**, the asymmetry is not there at all:
+
+| layout | sweep total | evaluated points | us / evaluated point |
+|---|---|---|---|
+| `4,4,4,4` | 53.3 ms | 38,496 | 1.39 |
+| `2,4,8,4` | 57.5 ms | 25,136 | 2.29 |
+| `8,4,2,4` | 33.6 ms | 21,568 | 1.56 |
+
+Candidate-frame routing is identical across the three (32 batched groups, 0
+scalar in each), as are the cache hit/miss shape, packing counts, and the
+factorization split. So routing, cache keying, packing and factorization -- the
+four suspects the issue lists -- are all excluded.
+
+**With the Guard enabled**, which is what `default_options()` in the benchmark
+uses:
+
+| layout | sweep total | guard search | share | sweeps |
+|---|---|---|---|---|
+| `4,4,4,4` | 50.8 ms | **0 ns, 0 calls** | 0% | 2 |
+| `2,4,8,4` | 470.1 ms | 412.5 ms | 88% | 2 |
+| `8,4,2,4` | 803.5 ms | 735.2 ms | 92% | 4 |
+
+The equal layout never invokes the Guard: it is rank-limited on every edge, so
+`run_local_sweeps` skips the search. The unequal layouts are not, so they pay a
+full search -- and on `2,4,8,4` that search injects nothing at all for its
+412 ms. That is the whole of the reported `24x`: a Guard-invocation difference,
+not a cost of unequal bonds.
+
+What makes the Guard so expensive here is the second measurement,
+`global_guard::tests::diagnostic_guard_call_cost_on_a_branched_tree`. Same
+walk shape, same site count, two points per call:
+
+| fixture | us / call |
+|---|---|
+| 13-site chain, `chi=8` | 19.5 |
+| spider, hub bonds `2,2,2,2` | 391.3 |
+| spider, hub bonds `4,4,4,4` | 385.5 |
+| spider, hub bonds `2,4,8,4` | 386.1 |
+| spider, hub bonds `8,4,2,4` | 388.3 |
+
+The branched cost does not move when the hub shrinks from 8192 elements to 32,
+so it is not arithmetic: it is a fixed ~20x per-call penalty for the topology.
+`cached_evaluator::tests::diagnostic_hinted_walk_cost_on_a_chain_versus_a_branched_tree`
+attributes it inside `tensor4all-treetn`: 13.8 us/call on the chain against
+292.1 us/call on the spider, of which the message loop is 189.7 us and the
+centre contraction 90.1 us. The cause is
+`TreeTNCachedEvaluator::can_use_raw_messages`, which returns `false` as soon as
+any node has more than three neighbours; a single coordination-4 hub therefore
+disables the raw-message kernels for *every* node of the tree and routes the
+whole evaluation through the generic `IdxTensor` path.
+
+That last step is not fixed here. Generalizing the raw message and centre
+kernels past degree three is the `tensor4all-treetn` analogue of what #713 did
+for candidate frames in `tensor4all-treeaci`, and it needs its own derivation,
+differential tests against the generic path, and gates. It is recorded as the
+remaining work for #727.
+
+### #728: the proposed batching is a pessimization; the real redundancy is elsewhere
+
+The issue asks for option 1 -- consolidating the Guard's random starts into
+fewer, larger evaluator calls -- to be measured first, on the grounds that it
+keeps the search identical. It was, in
+`global_guard::tests::diagnostic_guard_batch_shape_on_the_high_rank_chain`,
+which evaluates exactly the same points in both shapes:
+
+| fixture | per-start calls | lockstep calls | speedup |
+|---|---|---|---|
+| 32-site chain, `chi=64` | 25.06 ms / 480 calls of 2 points | 27.32 ms / 96 calls of 10 points | 0.92x |
+| 32-site chain, `chi=256` | 56.29 ms / 480 calls of 2 points | 268.56 ms / 96 calls of 10 points | **0.21x** |
+
+Batching across starts is 4.8x *slower* at `chi=256`. The reason is structural:
+a batch mixing several starts no longer varies in a single site, so it carries
+no centre hint, and the evaluator falls back to its ordinary centre selection.
+Option 1 as stated is rejected on measurement.
+
+The redundancy that is real is inside the walk itself. `floating_zone_walk`
+evaluated every candidate value at a site, including the value the pivot
+already holds -- a point it had just evaluated one step earlier, whose error it
+already knows. It now skips that candidate and folds the known error into the
+same greedy comparison, so at `local_dim = 2` the walk asks for one point per
+call instead of two. To keep this from losing the centre hint (a one-point
+batch cannot be asked which site varies), the walk now *declares* the scan site
+to its callback, and the Guard uses that instead of re-deriving it from the
+batch; `sole_varying_site` is gone.
+
+`floating_zone::tests::skipping_the_held_candidate_matches_the_full_batch_walk`
+compares the walk against a full-batch reference implementation on several
+shapes and asserts identical pivots and identical reported error with strictly
+fewer evaluated points.
+
+Paired measurement on the fixture the issue names
+(`profile_high_rank_chain_phases_and_candidate_cache`, 32 sites, `chi=256`,
+Guard on, three repetitions per arm, same machine, medians):
+
+| | baseline | candidate | delta |
+|---|---|---|---|
+| sweep total | 1.8735 s | 1.7873 s | -4.6% |
+| guard search | 1.1894 s | 1.1209 s | -5.8% |
+| input evaluation | 1.1029 s | 1.0456 s | -5.2% |
+| input calls / scalars | 2218 / 8844 | 2090 / **4236** | -5.8% / **-52.1%** |
+| output evaluation | 84.33 ms | 73.40 ms | -13.0% |
+| output calls / scalars | 2211 / 4387 | 2083 / **2083** | -5.8% / **-52.5%** |
+
+The baseline's own run-to-run spread is 6.7% on the sweep total and 8.2% on the
+guard search, so the ~5% wall-time gain is **inside the noise floor and is not
+claimed**. The efficiency pass is the resource counters: half the evaluated
+points, ~6% fewer calls, and no time regression on any counter. Halving
+evaluated points is not cosmetic downstream -- the Guard calls the caller's
+operator on exactly those points, and in `sgw` that operator is a full
+elementwise contraction.
+
+The trajectory is unchanged, which is the correctness claim that matters here:
+both arms report `commits=217`, `completed=7`, and candidate cache
+`hits/misses = 9104/21992` at `chi=256`.
+
+On the branched fixture of #727 the same change halves the Guard's evaluated
+scalars (1652 -> 742 input, 816 -> 361 output) with wall time flat within noise
+(412.5 ms -> 419.5 ms), because the candidate it drops is the one whose messages
+were already cached. The branched per-call penalty above is what dominates
+there, and it is the open item.
+
 ### Open items
 
-1. **Unequal incident bonds cost an order of magnitude more per unit of
-   required work.** At coordination 4 with a fixed hub bond product of 256, the
-   `8,4,2,4` layout takes `6.06 us` per evaluated point against the equal
-   layout's `0.25 us`, while the topology-required `outgoing_dim *
-   product(incoming bonds)` is identical (256) on every outward arc and the
-   unequal layout evaluates *fewer* points. Reproducible across three
-   repetitions. Not diagnosed here; it needs a profile of the routing, cache,
-   and factorization paths under an unequal layout. This is a new finding of
-   the #718 gate and is not covered by any existing #699 subissue.
-2. **The Guard's random-start search still dominates the 32-site high-rank
-   chain.** At `chi=256` with the Guard enabled it is `1.231894 s` of a
-   `1.498733 s` sweep total, `1.147752 s` of which is input evaluation across
-   2,218 calls returning 8,844 scalars. Not a regression -- #709 is what makes
-   the fixture finish at all -- but it is the largest remaining single cost on
-   that fixture and no subissue owns it.
+1. **DIAGNOSED on 2026-09-06 (#727), one step left.** The unequal-bond
+   asymmetry is a Guard-invocation difference plus a branched-tree evaluation
+   cost, not a cost of unequal bonds: with the Guard disabled the three layouts
+   are within 1.6x per evaluated point, and with it enabled the equal layout is
+   rank-limited and never searches at all. What remains open is the cause of
+   the branched cost -- `TreeTNCachedEvaluator::can_use_raw_messages` refuses
+   the raw kernels for the whole tree as soon as one node has more than three
+   neighbours, which is a fixed ~20x per-call penalty independent of bond
+   dimension. Generalizing those kernels past degree three is the remaining
+   work. See the `#726/#727/#728/#729` section above.
+2. **PARTLY ADDRESSED on 2026-09-06 (#728).** The proposed consolidation of
+   random starts into fewer larger calls was measured and rejected (0.21x at
+   `chi=256`: a mixed-start batch loses the centre hint). The walk instead
+   stopped re-evaluating the candidate the pivot already holds, which halves
+   the Guard's evaluated points on an unchanged trajectory; the wall-time gain
+   is inside the noise floor and is not claimed. The Guard still dominates this
+   fixture, and the next lever is item 1's branched per-call penalty rather
+   than the search's shape. See the section above.
 3. **The workspace-wide pre-PR gate is pending.** `cargo clippy --workspace`,
    `cargo nextest run --cargo-profile ci --workspace --exclude tensor4all-hdf5`,
    `cargo test --profile ci -p tensor4all-hdf5`,


### PR DESCRIPTION
## Summary

- Derive TreeACI element ceilings from `max_working_bytes` and scalar size, while keeping explicit ceilings as independent user pins.
- Make the coordination preflight reserve-aware and degrade coordination `>= 4` to the bounded scalar route instead of rejecting the run.
- Generalize TreeTN raw message/center contractions to arbitrary coordination and keep the optimized chain routes.
- Skip the floating-zone walk's already-held pivot and pass the scan-site hint through the chain Guard.
- Keep `tensor4all-treeaci` independent of both `tensor4all-aci` and `tensor4all-simplett`: there are no direct or transitive dependencies on either crate. Any shared behavior is internal/copied implementation, and TreeACI uses `tensor4all-treetn` with `default-features = false`.

## Performance evidence

| Case | Before | After |
| --- | ---: | ---: |
| 13-site coordination-4 spider raw TreeTN call | 385–391 us/call | 18–19 us/call |
| Same chain raw call | 13.8 us/call | 14.1 us/call |
| #718 unequal-bond gates | 470/803 ms per sweep | 65/83 ms per sweep |
| #718 per-evaluated-point asymmetry | about 24x | at most 2.1x |
| Guard pivot-skip, chi=256 chain: evaluated input scalars | 8,844 | 4,236 |
| Guard pivot-skip, chi=256 chain: evaluated output scalars | 4,387 | 2,083 |

The pivot skip also reduces callback count by 5.8% and output evaluation by 13.0%. The measured wall-time change is 4.6%, within the 6.7% run-to-run spread, so this PR does not claim a wall-clock speedup for that case.

The downstream `R10_*_fix729` runs provide additional context: simplett ACI Pi/W/Sigma = 33.25/1.42/12.45 s, NBlock TreeACI = 48.04/0.74/6.72 s, NBlock TreeACI+SRC = 91.40/2.33/38.56 s, and CTTN TreeACI = 356.90/11.32/80.50 s. Their recorded provenance currently contains `upstream_head=2205972`, so these rows are retained as downstream context rather than claimed as fresh measurements of this PR head; a rerun with provenance at this head is still appropriate for attributing downstream deltas specifically to this branch.

## Issues

Closes #729
Closes #726
Closes #727
Closes #728
Related to #671 and #732, which track the remaining branch-point performance work.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc`
- `cargo run -p xtask --release -- api-dump`
- Repository-rules self-tests and dry-run review
- Release all-target tests for ACI, TreeACI, TreeTN, and TensorCI
- `cargo test --profile ci --workspace --exclude tensor4all-hdf5 --all-targets`
- `cargo test --profile ci -p tensor4all-hdf5`
- `cargo test --doc --profile ci --workspace -j 8`
- `cargo doc --workspace --no-deps`
- `./scripts/test-mdbook.sh`

`cargo nextest` was not installed in the local environment; the equivalent CI-profile workspace test command passed, and CI remains authoritative for the nextest job.
