### PR TITLE
fix(treeaci): require per-edge rank stability

### DIFF
--- a/crates/tensor4all-treeaci/examples/reproduce_741.rs
+++ b/crates/tensor4all-treeaci/examples/reproduce_741.rs
@@ -1,0 +1,66 @@
+//! Independent low-temperature slice check for issue #741.
+#[path = "../tests/support/g0.rs"]
+mod g0;
+
+use num_complex::Complex64;
+use tensor4all_core::ColMajorArrayRef;
+use tensor4all_treeaci::tree_elementwise_batched;
+use tensor4all_treetn::{CachedEvaluatorOptions, EvaluationHint, TreeTNCachedEvaluator};
+
+fn main() -> g0::TestResult<()> {
+    let args: Vec<_> = std::env::args().collect();
+    let r: usize = args.get(1).map_or(Ok(4), |v| v.parse())?;
+    assert!((2..=10).contains(&r));
+    let mode = args.get(2).map_or("cttn", String::as_str);
+    let (sites, inputs) = g0::fixture(r, mode)?;
+    let mut options = g0::options();
+    if let Some(value) = args.get(3) {
+        options.max_sweeps = value.parse()?;
+        options.min_sweeps = options.max_sweeps;
+    }
+    let started = std::time::Instant::now();
+    let result = tree_elementwise_batched(g0::operator, &inputs, &options)?;
+    eprintln!(
+        "r={r} mode={mode} seconds={} points={} termination={:?} ranks={:?} errors={:?} guard={:?}",
+        started.elapsed().as_secs_f64(),
+        result.diagnostics.evaluated_points,
+        result.termination,
+        result.max_ranks,
+        result.max_errors,
+        result.global_pivots_found
+    );
+    let mut evaluator =
+        TreeTNCachedEvaluator::new(&result.tree, &sites, CachedEvaluatorOptions::default())?;
+    let size = 1usize << r;
+    let mut max_error = 0.0_f64;
+    let mut worst = (0, 0, 0);
+    for n in [size / 2 - 1, size / 2] {
+        for y in 0..size {
+            let mut coords = Vec::with_capacity(3 * r * size);
+            for x in 0..size {
+                for bit in 0..r {
+                    for value in [x, y, n] {
+                        coords.push((value >> (r - 1 - bit)) & 1);
+                    }
+                }
+            }
+            let values = evaluator.evaluate_batched_typed::<Complex64>(
+                ColMajorArrayRef::new(&coords, &[3 * r, size])?,
+                EvaluationHint::default(),
+            )?;
+            for (x, value) in values.into_iter().enumerate() {
+                let error = (value - g0::exact(r, x, y, n)).norm();
+                if error > max_error {
+                    max_error = error;
+                    worst = (x, y, n);
+                }
+            }
+        }
+    }
+    println!(
+        "r={r} mode={mode} max_abs={max_error:e} normalized={:e} worst={worst:?}",
+        max_error / 31.830555038989377
+    );
+    assert!(max_error <= options.tolerance * options.global_tolerance_margin);
+    Ok(())
+}

--- a/crates/tensor4all-treeaci/src/options.rs
+++ b/crates/tensor4all-treeaci/src/options.rs
@@ -19,7 +19,7 @@ const WORKING_BUDGET_OBJECT_SHARE: usize = 4;
 
 /// Controls tree ACI sweeps, global validation, and allocation limits.
 ///
-/// The defaults match train ACI's convergence policy and add conservative
+/// The defaults use per-edge rank stability and conservative
 /// hard allocation ceilings. Increase a ceiling explicitly only after the
 /// topology preflight identifies the resource that needs it.
 ///
@@ -40,7 +40,10 @@ const WORKING_BUDGET_OBJECT_SHARE: usize = 4;
 pub struct TreeAciOptions<V: TreeAciNode> {
     /// Maximum number of complete sweeps. Default: `20`.
     pub max_sweeps: usize,
-    /// Minimum stable sweeps required before convergence. Default: `2`.
+    /// Minimum consecutive passes with no rank growth on any edge, including
+    /// the baseline pass. Default: `2`. A growing cut restarts this window
+    /// even if the network's maximum rank stays constant; rank decreases are
+    /// allowed. The local error and global-guard criteria must also pass.
     pub min_sweeps: usize,
     /// Optional rank cap on every output edge. Default: no explicit cap.
     pub max_bond_dim: Option<usize>,

--- a/crates/tensor4all-treeaci/src/result.rs
+++ b/crates/tensor4all-treeaci/src/result.rs
@@ -16,7 +16,9 @@ use crate::TreeAciNode;
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum TreeAciTermination {
-    /// Error and rank stability criteria were satisfied.
+    /// The local error target, per-edge rank stability, and enabled global
+    /// guard criteria were satisfied. Local residuals and randomized guard
+    /// searches are not a certificate of the full-grid maximum error.
     Converged,
     /// At least one inaccurate edge reached its algebraic or configured rank cap.
     RankLimited,

--- a/crates/tensor4all-treeaci/src/schedule.rs
+++ b/crates/tensor4all-treeaci/src/schedule.rs
@@ -84,6 +84,8 @@ where
     let mut max_errors = Vec::with_capacity(options.max_sweeps);
     let mut global_pivots = Vec::with_capacity(options.max_sweeps);
     let mut rank_limited = Vec::with_capacity(options.max_sweeps);
+    let mut previous_ranks = state.edge_ranks.clone();
+    let mut stable_rank_passes = 0;
     let mut evaluated_points = 0u64;
     let mut termination = TreeAciTermination::MaxSweeps;
     // Guard evaluators own sizeable topology/message-cache state and are not
@@ -98,6 +100,8 @@ where
             PassDirection::Reverse
         };
         let report = run_directional_pass(state, options, direction, operator)?;
+        stable_rank_passes =
+            track_rank_stability(&mut previous_ranks, &state.edge_ranks, stable_rank_passes);
         evaluated_points = evaluated_points
             .checked_add(report.evaluated_points)
             .ok_or(TreeAciError::SizeOverflow {
@@ -162,7 +166,7 @@ where
         let completed = pass + 1;
         if convergence_criterion(
             completed,
-            &max_ranks,
+            stable_rank_passes,
             &max_errors,
             &global_pivots,
             options.min_sweeps,
@@ -339,9 +343,26 @@ where
     Ok(())
 }
 
+// A stable maximum can hide growth on a smaller cut, particularly when the
+// forward walk visits side branches but the return visits only the spine.
+// Keep one rank per cut, updated in place once per pass: O(edges) storage and
+// work, with no extra contractions, samples, or per-pass allocations.
+fn track_rank_stability(previous: &mut [usize], current: &[usize], stable: usize) -> usize {
+    let mut grew = false;
+    for (old, &new) in previous.iter_mut().zip(current) {
+        grew |= new > *old;
+        *old = new;
+    }
+    if grew {
+        1
+    } else {
+        stable.saturating_add(1)
+    }
+}
+
 fn convergence_criterion(
     completed: usize,
-    max_ranks: &[usize],
+    stable_rank_passes: usize,
     errors: &[f64],
     global_pivots: &[usize],
     min_sweeps: usize,
@@ -350,11 +371,7 @@ fn convergence_criterion(
     if min_sweeps == 0 || completed < min_sweeps || errors[completed - 1] > tolerance {
         return false;
     }
-    let baseline = max_ranks[completed - min_sweeps];
-    if max_ranks[(completed - min_sweeps)..completed]
-        .iter()
-        .any(|&rank| rank > baseline)
-    {
+    if stable_rank_passes < min_sweeps {
         return false;
     }
     global_pivots[(completed - min_sweeps)..completed]

--- a/crates/tensor4all-treeaci/src/schedule/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/schedule/tests/mod.rs
@@ -5,7 +5,8 @@ use tensor4all_treetn::{CanonicalForm, TreeTN};
 
 use super::{
     convergence_criterion, current_state_is_rank_limited, edge_error_metric,
-    global_injection_capacities, run_directional_pass, run_local_sweeps, PassDirection,
+    global_injection_capacities, run_directional_pass, run_local_sweeps, track_rank_stability,
+    PassDirection,
 };
 use crate::global_guard::input_evaluator_debug_stats;
 use crate::transaction::update_edge_transaction;
@@ -162,45 +163,31 @@ fn failed_update_preserves_all_commits_before_the_failing_edge() {
 }
 
 #[test]
-fn convergence_requires_stable_max_rank_and_minimum_dwell() {
-    // Network max is 2 at both sweeps (2 and 2), even though this scenario's
-    // real-world equivalent is an individual edge fluctuating underneath
-    // that max -- exactly the scenario `crates/tensor4all-treeaci/src/schedule.rs`'s
-    // old per-edge-vector check used to reject. `max_ranks` is what
-    // `run_local_sweeps` already computes from `state.edge_ranks.iter().max()`
-    // every pass; this test operates directly on that scalar sequence, the
-    // same shape `tensor4all-aci`'s `convergence_criterion_like_julia` takes.
-    let max_ranks = vec![2usize, 2];
+fn convergence_requires_stable_edge_ranks_and_minimum_dwell() {
     let errors = vec![0.0, 0.0];
     let global = vec![0, 0];
 
     // Below the minimum dwell (only 1 completed sweep): never converges.
     assert!(!convergence_criterion(
         1,
-        &max_ranks[..1],
+        1,
         &errors[..1],
         &global[..1],
         2,
         1.0e-12
     ));
 
-    // Two sweeps, stable max rank, error at tolerance, no global pivots
+    // Two sweeps, stable edge ranks, error at tolerance, no global pivots
     // found in the window: must converge.
-    assert!(convergence_criterion(
-        2, &max_ranks, &errors, &global, 2, 1.0e-12
-    ));
+    assert!(convergence_criterion(2, 2, &errors, &global, 2, 1.0e-12));
 
-    // A max rank that actually increases within the window must still
-    // block convergence (this part of the rule is unchanged).
-    let growing = vec![2usize, 3];
-    assert!(!convergence_criterion(
-        2, &growing, &errors, &global, 2, 1.0e-12
-    ));
+    // Growth on any edge restarts the rank-stability window.
+    assert!(!convergence_criterion(2, 1, &errors, &global, 2, 1.0e-12));
 
     // Error above tolerance still blocks convergence, independent of rank.
     assert!(!convergence_criterion(
         2,
-        &max_ranks,
+        2,
         &[0.0, 1.0e-6],
         &global,
         2,
@@ -209,13 +196,36 @@ fn convergence_requires_stable_max_rank_and_minimum_dwell() {
 
     // A global pivot found within the window still blocks convergence
     // (its error estimate is stale with respect to the injected pivot).
-    assert!(!convergence_criterion(
-        2,
-        &max_ranks,
-        &errors,
-        &[1, 0],
-        2,
-        1.0e-12
+    assert!(!convergence_criterion(2, 2, &errors, &[1, 0], 2, 1.0e-12));
+}
+
+#[test]
+fn smaller_cut_growth_blocks_convergence_even_when_the_maximum_does_not_grow() {
+    for largest in [233, 232] {
+        let mut previous = vec![192, 229, 233, 18];
+        let current = [195, 229, largest, 19];
+        let stable = track_rank_stability(&mut previous, &current, 4);
+        assert_eq!(stable, 1);
+        assert_eq!(previous, current);
+        assert!(!convergence_criterion(
+            2, stable, &[0.0; 2], &[0; 2], 2, 1e-12
+        ));
+    }
+}
+
+#[test]
+fn rank_stability_allows_shrinkage_but_restarts_on_regrowth() {
+    let mut previous = vec![4, 3];
+    let mut stable = track_rank_stability(&mut previous, &[4, 3], 0);
+    assert_eq!(stable, 1);
+    stable = track_rank_stability(&mut previous, &[4, 2], stable);
+    assert_eq!(stable, 2);
+    stable = track_rank_stability(&mut previous, &[4, 3], stable);
+    assert_eq!(stable, 1);
+    stable = track_rank_stability(&mut previous, &[4, 3], stable);
+    assert_eq!(stable, 2);
+    assert!(convergence_criterion(
+        2, stable, &[0.0; 2], &[0; 2], 2, 1e-12
     ));
 }
 

--- a/crates/tensor4all-treeaci/tests/g0_convergence.rs
+++ b/crates/tensor4all-treeaci/tests/g0_convergence.rs
@@ -1,0 +1,100 @@
+#[path = "support/g0.rs"]
+mod g0;
+
+use num_complex::Complex64;
+use tensor4all_core::{ColMajorArrayRef, IdxTensor};
+use tensor4all_treeaci::{tree_elementwise_batched, TreeAciTermination};
+use tensor4all_treetn::{CachedEvaluatorOptions, EvaluationHint, TreeTNCachedEvaluator};
+
+#[test]
+fn low_temperature_g0_full_grid() -> g0::TestResult<()> {
+    for r in [3, 4, 5] {
+        for mode in ["cttn", "swap", "nblock"] {
+            let (sites, inputs) = g0::fixture(r, mode)?;
+            let expected_values: Vec<_> = (0..1usize << (3 * r))
+                .map(|flat| {
+                    let mut point = [0; 3];
+                    for bit in 0..r {
+                        for (var, x) in point.iter_mut().enumerate() {
+                            *x = 2 * *x + ((flat >> (3 * bit + var)) & 1);
+                        }
+                    }
+                    g0::exact(r, point[0], point[1], point[2])
+                })
+                .collect();
+            let expected = IdxTensor::from_dense(sites.clone(), expected_values)?;
+            let dense_inputs: Vec<Vec<Complex64>> = inputs
+                .iter()
+                .map(|tree| {
+                    Ok(tree
+                        .to_dense()?
+                        .permute_indices(&sites)?
+                        .to_vec::<Complex64>()?)
+                })
+                .collect::<g0::TestResult<_>>()?;
+            let direct = IdxTensor::from_dense(
+                sites.clone(),
+                (0..dense_inputs[0].len())
+                    .map(|i| {
+                        1.0 / (Complex64::new(0.5, 0.0)
+                            + 2.0 * dense_inputs[0][i]
+                            + 2.0 * dense_inputs[1][i]
+                            + Complex64::i() * dense_inputs[2][i]
+                            - dense_inputs[3][i])
+                    })
+                    .collect::<Vec<_>>(),
+            )?;
+            assert!(direct.sub(&expected)?.maxabs()? < 1e-10);
+            let options = g0::options();
+            let result = tree_elementwise_batched(g0::operator, &inputs, &options)?;
+            let error = result.tree.to_dense()?.sub(&expected)?.maxabs()?;
+            assert!(
+                error <= options.tolerance * options.global_tolerance_margin,
+                "r={r}, mode={mode}, max absolute residual={error:e}"
+            );
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn low_temperature_branch_convergence_does_not_hide_growth_on_smaller_cuts() -> g0::TestResult<()> {
+    let r = 9;
+    let (sites, inputs) = g0::fixture(r, "cttn")?;
+    let options = g0::options();
+    let result = tree_elementwise_batched(g0::operator, &inputs, &options)?;
+    assert_eq!(result.termination, TreeAciTermination::Converged);
+    // Independent witnesses from #741 and their reflection partners. Before
+    // the fix the first point has absolute error 0.247, despite Converged.
+    let points = [
+        (292, 70, 256),
+        (292, 442, 256),
+        (242, 70, 256),
+        (230, 442, 256),
+        (243, 454, 256),
+    ];
+    let mut coordinates = Vec::with_capacity(points.len() * 3 * r);
+    for &(x, y, n) in &points {
+        for bit in 0..r {
+            for value in [x, y, n] {
+                coordinates.push((value >> (r - 1 - bit)) & 1);
+            }
+        }
+    }
+    let mut evaluator =
+        TreeTNCachedEvaluator::new(&result.tree, &sites, CachedEvaluatorOptions::default())?;
+    let actual = evaluator.evaluate_batched_typed::<Complex64>(
+        ColMajorArrayRef::new(&coordinates, &[3 * r, points.len()])?,
+        EvaluationHint::default(),
+    )?;
+    let error = actual
+        .iter()
+        .zip(&points)
+        .map(|(&value, &(x, y, n))| (value - g0::exact(r, x, y, n)).norm())
+        .fold(0.0_f64, f64::max);
+    assert!(
+        error <= options.tolerance * options.global_tolerance_margin,
+        "max absolute witness residual={error:e}"
+    );
+    Ok(())
+}

--- a/crates/tensor4all-treeaci/tests/support/g0.rs
+++ b/crates/tensor4all-treeaci/tests/support/g0.rs
@@ -1,0 +1,205 @@
+//! Exact separable inputs for the low-temperature Green's function in #741.
+
+use std::f64::consts::PI;
+
+use num_complex::Complex64;
+use tensor4all_core::{DynIndex, IdxTensor, IndexLike};
+use tensor4all_treetn::TreeTN;
+
+pub(crate) type TestResult<T> = Result<T, Box<dyn std::error::Error>>;
+type Fixture = (Vec<DynIndex>, Vec<TreeTN<IdxTensor, usize>>);
+
+pub(crate) fn fixture(r: usize, mode: &str) -> TestResult<Fixture> {
+    assert!((2..=10).contains(&r));
+    let sites: Vec<_> = (0..3 * r).map(|_| DynIndex::new_dyn(2)).collect();
+    let edges = match mode {
+        "cttn" | "swap" => {
+            let mut edges = if mode == "swap" {
+                vec![(0, 2), (1, 2)]
+            } else {
+                vec![(0, 1), (1, 2)]
+            };
+            for var in 0..3 {
+                edges.extend((1..r).map(|bit| (var + 3 * (bit - 1), var + 3 * bit)));
+            }
+            edges
+        }
+        "nblock" => {
+            let order: Vec<_> = (0..r)
+                .map(|bit| 2 + 3 * bit)
+                .chain((0..r).flat_map(|bit| [3 * bit, 1 + 3 * bit]))
+                .collect();
+            order.windows(2).map(|pair| (pair[0], pair[1])).collect()
+        }
+        _ => return Err("topology must be cttn, swap, or nblock".into()),
+    };
+    let mut adjacency = vec![Vec::new(); sites.len()];
+    for &(a, b) in &edges {
+        adjacency[a].push(b);
+        adjacency[b].push(a);
+    }
+    let mut inputs = Vec::new();
+    for var in 0..4 {
+        // The unique path between the first and last owner carries a rank-2
+        // rotation/affine state; intervening non-owner sites pass it through.
+        let mut path = Vec::new();
+        if var < 3 {
+            let mut parents = vec![usize::MAX; sites.len()];
+            parents[var] = var;
+            let mut stack = vec![var];
+            while let Some(node) = stack.pop() {
+                for &next in &adjacency[node] {
+                    if parents[next] == usize::MAX {
+                        parents[next] = node;
+                        stack.push(next);
+                    }
+                }
+            }
+            let mut node = var + 3 * (r - 1);
+            while node != var {
+                path.push(node);
+                node = parents[node];
+            }
+            path.push(var);
+            path.reverse();
+            assert_eq!(
+                path.iter()
+                    .copied()
+                    .filter(|node| node % 3 == var)
+                    .collect::<Vec<_>>(),
+                (0..r).map(|bit| var + 3 * bit).collect::<Vec<_>>()
+            );
+        }
+        let bonds: Vec<_> = edges
+            .iter()
+            .map(|&(a, b)| {
+                DynIndex::new_dyn(
+                    if path.windows(2).any(|pair| pair == [a, b] || pair == [b, a]) {
+                        2
+                    } else {
+                        1
+                    },
+                )
+            })
+            .collect();
+        let mut tensors = Vec::new();
+        for (node, site) in sites.iter().enumerate() {
+            let mut indices = vec![site.clone()];
+            let mut prev = None;
+            let mut next = None;
+            let position = path.iter().position(|&site| site == node);
+            for (edge, &(a, b)) in edges.iter().enumerate() {
+                if a == node || b == node {
+                    let other = if a == node { b } else { a };
+                    if bonds[edge].dim() == 2 {
+                        if position.is_some_and(|pos| pos > 0 && path[pos - 1] == other) {
+                            prev = Some(indices.len());
+                        } else {
+                            next = Some(indices.len());
+                        }
+                    }
+                    indices.push(bonds[edge].clone());
+                }
+            }
+            let dims: Vec<_> = indices.iter().map(IndexLike::dim).collect();
+            let values = (0..dims.iter().product())
+                .map(|flat| {
+                    if var == 3 {
+                        return Complex64::new(0.0, 0.0);
+                    }
+                    if position.is_none() {
+                        return Complex64::new(1.0, 0.0);
+                    }
+                    let mut rest = flat;
+                    let coords: Vec<_> = dims
+                        .iter()
+                        .map(|d| {
+                            let x = rest % d;
+                            rest /= d;
+                            x
+                        })
+                        .collect();
+                    let bit = node / 3;
+                    let m = if node % 3 != var {
+                        [1.0, 0.0, 0.0, 1.0]
+                    } else if var < 2 {
+                        let (s, c) = (coords[0] as f64 * PI / (1usize << bit) as f64).sin_cos();
+                        [c, -s, s, c]
+                    } else {
+                        [
+                            1.0,
+                            coords[0] as f64 * 2.0 * PI * 0.01 * (1usize << (r - 1 - bit)) as f64,
+                            0.0,
+                            1.0,
+                        ]
+                    };
+                    let initial = if var < 2 { [1.0, 0.0] } else { [0.0, 1.0] };
+                    let incoming = prev.map_or(initial, |axis| {
+                        if coords[axis] == 0 {
+                            [1.0, 0.0]
+                        } else {
+                            [0.0, 1.0]
+                        }
+                    });
+                    let after = [
+                        m[0] * incoming[0] + m[1] * incoming[1],
+                        m[2] * incoming[0] + m[3] * incoming[1],
+                    ];
+                    let value = next.map_or_else(
+                        || {
+                            let beta = if var < 2 {
+                                0.0
+                            } else {
+                                -2.0 * PI * 0.01 * (1usize << (r - 1)) as f64 + PI * 0.01
+                            };
+                            after[0] + beta * after[1]
+                        },
+                        |axis| after[coords[axis]],
+                    );
+                    Complex64::new(value, 0.0)
+                })
+                .collect();
+            tensors.push(IdxTensor::from_dense(indices, values)?);
+        }
+        inputs.push(TreeTN::from_tensors(tensors, (0..3 * r).collect())?);
+    }
+    Ok((sites, inputs))
+}
+
+pub(crate) fn operator(
+    batch: tensor4all_treeaci::TreeElementwiseBatch<'_, Complex64>,
+    output: &mut [Complex64],
+) -> tensor4all_treeaci::Result<()> {
+    for (p, value) in output.iter_mut().enumerate() {
+        *value = 1.0
+            / (Complex64::new(0.5, 0.0)
+                + 2.0 * batch.get(0, p)?
+                + 2.0 * batch.get(1, p)?
+                + Complex64::i() * batch.get(2, p)?
+                - batch.get(3, p)?);
+    }
+    Ok(())
+}
+
+pub(crate) fn exact(r: usize, x: usize, y: usize, n: usize) -> Complex64 {
+    let size = (1usize << r) as f64;
+    1.0 / Complex64::new(
+        0.5 + 2.0 * (2.0 * PI * x as f64 / size).cos() + 2.0 * (2.0 * PI * y as f64 / size).cos(),
+        2.0 * PI * 0.01 * (n as f64 - size / 2.0 + 0.5),
+    )
+}
+
+pub(crate) fn options() -> tensor4all_treeaci::TreeAciOptions<usize> {
+    tensor4all_treeaci::TreeAciOptions {
+        tolerance: 3.183055503898938e-3,
+        scale_tolerance: false,
+        max_sweeps: 50,
+        max_bond_dim: Some(2000),
+        rng_seed: 42,
+        max_working_bytes: 8usize << 30,
+        max_frame_bytes: 8usize << 30,
+        max_sample_arena_bytes: 8usize << 30,
+        message_cache_max_bytes: 8usize << 30,
+        ..Default::default()
+    }
+}

--- a/docs/design/tree-aci.md
+++ b/docs/design/tree-aci.md
@@ -80,6 +80,24 @@ is removed from the active projection mask as soon as that capacity is used.
 Thus one Guard scan offering several pivots cannot overshoot a cut that had
 only one rank available.
 
+Convergence requires a window of `min_sweeps` consecutive pass results with
+no growth on **any** output edge, starting with the first result as the
+baseline. A rank decrease is allowed, but subsequent regrowth restarts the
+window. Network-maximum rank stability alone is insufficient: on the #741
+low-temperature CTTN, the maximum stayed at 233 while smaller cuts were still
+growing and the reconstructed output retained a large localized error.
+The implementation retains one previous rank per edge and a stability counter,
+requiring O(edges) storage and work per pass without extra contractions,
+sampling, or per-pass allocation. Returned `max_ranks` remains a summary for
+diagnostics, not the rank-stability decision input.
+
+The local LUCI residual and enabled global-guard conditions still apply.
+`Converged` is an algorithmic stopping condition, not a certified bound on the
+full-grid maximum error: the tolerance controls edge-local residuals, and the
+guard performs bounded randomized coordinate searches with its configured
+acceptance margin. Independent validation remains necessary. Exhaustive
+checks belong only in small tests or explicit diagnostic programs.
+
 ## Caches
 
 TreeACI owns three cache families. None outlives one `tree_elementwise` call;

--- a/docs/worklogs/2026-09-06-treeaci-rank-stability.md
+++ b/docs/worklogs/2026-09-06-treeaci-rank-stability.md
@@ -1,0 +1,35 @@
+# TreeACI per-edge rank stability (#741)
+
+## Problem and decision
+
+TreeACI previously used the maximum output-edge rank as its convergence
+stability signal. On the low-temperature CTTN reported in #741, a smaller cut
+could continue growing while the network maximum stayed unchanged, allowing a
+large localized reconstruction error to be returned as `Converged`.
+
+The scheduler now retains one previous rank per output edge and increments a
+stability counter only when no edge grows during a pass. Any growth restarts
+the counter; rank decreases are allowed. The existing local residual and
+global-guard criteria remain required. This keeps the check O(edges) in storage
+and work without extra contractions, samples, or allocations.
+
+`max_ranks` remains a diagnostic summary. `Converged` documents an algorithmic
+stopping condition, not a full-grid error certificate, because local residuals
+and bounded guard searches do not exhaustively validate every coordinate.
+
+## Reading and verification
+
+The relevant TreeACI scheduler, options, result, tests, design document, and
+the repository README/rules were reviewed. The regression fixture exercises the
+low-temperature Green's function on CTTN, swapped, and non-block topologies;
+the executable reproducer is retained for independent investigation.
+
+Verification completed:
+
+- `cargo fmt --all -- --check`
+- `git diff --check`
+- `cargo test -p tensor4all-treeaci --release`
+- `cargo clippy -p tensor4all-treeaci --all-targets --release -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc`
+
+The TreeACI release suite passed, including the two #741 regression tests and
+all crate doctests. No tolerance or existing test was weakened.


### PR DESCRIPTION
## Summary

- require per-edge rank stability before TreeACI convergence
- add #741 low-temperature regression coverage and reproducer
- document the stopping condition and validation limits

## Validation

- cargo test -p tensor4all-treeaci --release
- cargo clippy -p tensor4all-treeaci --all-targets --release -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
- cargo fmt --all -- --check

Fixes #741