### PR TITLE
perf: address issue 697 performance findings

### DIFF
--- a/crates/tensor4all-core/src/defaults/idx_tensor.rs
+++ b/crates/tensor4all-core/src/defaults/idx_tensor.rs
@@ -1266,7 +1266,11 @@ impl IdxTensor {
 
         let mut root_to_class = std::collections::HashMap::new();
         let mut next_class = 0usize;
-        let mut axis_classes = Vec::new();
+        let mut axis_classes = Vec::with_capacity(
+            lhs_axis_classes
+                .len()
+                .saturating_add(rhs_axis_classes.len()),
+        );
 
         for (axis, &class_id) in lhs_axis_classes.iter().enumerate() {
             if !lhs_contracted[axis] {
@@ -8287,6 +8291,14 @@ mod tests {
         assert_eq!(result.storage_kind(), StorageKind::Structured);
         assert!(result.eager_cache.get().is_none());
         assert_eq!(result.storage().unwrap().payload_len(), n * 3);
+    }
+
+    #[test]
+    fn binary_contraction_axis_classes_preserve_uncontracted_order() {
+        let axis_classes =
+            IdxTensor::binary_contraction_axis_classes(&[0, 1, 0], &[1], &[0, 1], &[0]).unwrap();
+
+        assert_eq!(axis_classes, vec![0, 0, 1]);
     }
 
     #[test]

--- a/crates/tensor4all-core/src/matrixluci/dense.rs
+++ b/crates/tensor4all-core/src/matrixluci/dense.rs
@@ -8,7 +8,7 @@ use crate::scalar::Scalar as LegacyScalar;
 use crate::{rrlu, RrLUOptions};
 use num_complex::{Complex32, Complex64};
 use tenferro_tensor::TensorScalar;
-use tensor4all_tensorbackend::{full_piv_lu_matrix, Matrix};
+use tensor4all_tensorbackend::{full_piv_lu_matrix_owned, Matrix};
 
 /// Dense full-pivoting LU kernel backed by the configured tensor backend.
 ///
@@ -145,7 +145,7 @@ impl DenseLuKernel {
     ) -> Result<PivotSelectionCore> {
         let matrix = Matrix::from_col_major_vec(n, n, data.to_vec());
         let decomp =
-            full_piv_lu_matrix(&matrix).map_err(|err| MatrixLuciError::InvalidArgument {
+            full_piv_lu_matrix_owned(matrix).map_err(|err| MatrixLuciError::InvalidArgument {
                 message: format!("tenferro full_piv_lu failed: {err}"),
             })?;
 

--- a/crates/tensor4all-itensorlike/Cargo.toml
+++ b/crates/tensor4all-itensorlike/Cargo.toml
@@ -12,11 +12,16 @@ categories = ["science", "mathematics"]
 
 [features]
 default = ["tenferro-cpu-faer"]
+backend-tenferro = ["tensor4all-tensorbackend/backend-tenferro"]
 tenferro-cpu-faer = [
+    "backend-tenferro",
+    "tensor4all-tensorbackend/tenferro-cpu-faer",
     "tensor4all-core/tenferro-cpu-faer",
     "tensor4all-treetn/tenferro-cpu-faer",
 ]
 tenferro-provider-inject = [
+    "backend-tenferro",
+    "tensor4all-tensorbackend/tenferro-provider-inject",
     "tensor4all-core/tenferro-provider-inject",
     "tensor4all-treetn/tenferro-provider-inject",
 ]
@@ -24,6 +29,7 @@ tenferro-provider-inject = [
 [dependencies]
 tensor4all-core = { path = "../tensor4all-core", default-features = false }
 tensor4all-treetn = { path = "../tensor4all-treetn", default-features = false }
+tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend", default-features = false }
 num-complex.workspace = true
 thiserror.workspace = true
 petgraph.workspace = true
@@ -35,4 +41,3 @@ approx.workspace = true
 tenferro.workspace = true
 tenferro-ad.workspace = true
 tenferro-cpu.workspace = true
-tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend", default-features = false, features = ["tenferro-cpu-faer"] }

--- a/crates/tensor4all-itensorlike/src/tensortrain.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain.rs
@@ -132,6 +132,7 @@ struct PackedSiteTensor<T> {
 }
 
 impl<T: Copy> PackedSiteTensor<T> {
+    #[cfg(any(test, not(feature = "backend-tenferro")))]
     fn get(&self, left: usize, physical: usize, right: usize) -> T {
         debug_assert!(left < self.left_dim);
         debug_assert!(physical < self.physical_dim);
@@ -854,13 +855,6 @@ impl TensorTrain {
         Self::new(new_tensors)
     }
 
-    fn normalize_site_tensor_orders(&mut self) -> Result<()> {
-        for site in 0..self.len() {
-            self.normalize_site_tensor_order(site)?;
-        }
-        Ok(())
-    }
-
     fn has_simple_linear_links(&self) -> Result<bool> {
         if self.len() <= 1 {
             return Ok(true);
@@ -874,24 +868,6 @@ impl TensorTrain {
             }
         }
         Ok(true)
-    }
-
-    fn can_normalize_site_tensor_order(&self, site: usize) -> Result<bool> {
-        let left_ok = if site > 0 {
-            let left = self.tensor_checked(site - 1)?;
-            let current = self.tensor_checked(site)?;
-            common_inds(left.indices(), current.indices()).len() <= 1
-        } else {
-            true
-        };
-        let right_ok = if site + 1 < self.len() {
-            let current = self.tensor_checked(site)?;
-            let right = self.tensor_checked(site + 1)?;
-            common_inds(current.indices(), right.indices()).len() <= 1
-        } else {
-            true
-        };
-        Ok(left_ok && right_ok)
     }
 
     fn with_explicit_unit_links(&self) -> Result<Self> {
@@ -967,54 +943,6 @@ impl TensorTrain {
         }
 
         Self::new(tensors)
-    }
-
-    fn normalize_site_tensor_order(&mut self, site: usize) -> Result<()> {
-        if !self.can_normalize_site_tensor_order(site)? {
-            return Ok(());
-        }
-
-        let tensor = self.tensor_checked(site)?.clone();
-        let current = tensor.indices().to_vec();
-        let left = if site > 0 {
-            self.linkind(site - 1)
-        } else {
-            None
-        };
-        let right = if site + 1 < self.len() {
-            self.linkind(site)
-        } else {
-            None
-        };
-
-        let mut desired = Vec::with_capacity(current.len());
-        if let Some(ref left_link) = left {
-            desired.push(left_link.clone());
-        }
-        desired.extend(
-            current
-                .iter()
-                .filter(|idx| Some(*idx) != left.as_ref() && Some(*idx) != right.as_ref())
-                .cloned(),
-        );
-        if let Some(ref right_link) = right {
-            desired.push(right_link.clone());
-        }
-
-        if desired == current {
-            return Ok(());
-        }
-
-        let normalized =
-            tensor
-                .permuteinds(&desired)
-                .map_err(|e| TensorTrainError::InvalidStructure {
-                    message: format!(
-                        "Failed to normalize site tensor index order at site {}: {}",
-                        site, e
-                    ),
-                })?;
-        self.set_tensor_raw(site, normalized)
     }
 
     /// Get the site indices (non-link indices) for all sites.
@@ -1603,14 +1531,11 @@ impl TensorTrain {
             return Ok(None);
         }
 
-        let mut normalized = self.clone();
-        normalized.normalize_site_tensor_orders()?;
-
-        if let Some(sites) = Self::pack_normalized_sites::<f64>(&normalized)? {
-            return Ok(Some(Self::norm_squared_from_packed_sites(&sites)?));
+        if let Some(sites) = Self::pack_normalized_sites::<f64>(self)? {
+            return Ok(Some(Self::norm_squared_from_packed_sites(sites)?));
         }
-        if let Some(sites) = Self::pack_normalized_sites::<Complex64>(&normalized)? {
-            return Ok(Some(Self::norm_squared_from_packed_sites(&sites)?));
+        if let Some(sites) = Self::pack_normalized_sites::<Complex64>(self)? {
+            return Ok(Some(Self::norm_squared_from_packed_sites(sites)?));
         }
 
         Ok(None)
@@ -1665,18 +1590,62 @@ impl TensorTrain {
                 return Ok(None);
             }
 
+            let current = tensor.indices().to_vec();
+            let left = if site > 0 { tt.linkind(site - 1) } else { None };
+            let right = if site + 1 < tt.len() {
+                tt.linkind(site)
+            } else {
+                None
+            };
+
+            let mut desired = Vec::with_capacity(current.len());
+            if let Some(ref left_link) = left {
+                desired.push(left_link.clone());
+            }
+            desired.extend(
+                current
+                    .iter()
+                    .filter(|idx| Some(*idx) != left.as_ref() && Some(*idx) != right.as_ref())
+                    .cloned(),
+            );
+            if let Some(ref right_link) = right {
+                desired.push(right_link.clone());
+            }
+
+            // The fast-path precondition guarantees at most one link per
+            // boundary.  Permute only this site when its stored order is not
+            // already [left, physical..., right], avoiding a whole-train clone.
+            let data = if desired == current {
+                tensor.to_vec::<T>().map_err(TensorTrainError::from)?
+            } else {
+                tensor
+                    .permuteinds(&desired)
+                    .map_err(|e| TensorTrainError::InvalidStructure {
+                        message: format!(
+                            "Failed to normalize site tensor index order at site {}: {}",
+                            site, e
+                        ),
+                    })?
+                    .to_vec::<T>()
+                    .map_err(TensorTrainError::from)?
+            };
+
             sites.push(PackedSiteTensor {
                 left_dim,
                 physical_dim: total_size / boundary_size,
                 right_dim,
-                data: tensor.to_vec::<T>().map_err(TensorTrainError::from)?,
+                data,
             });
         }
 
         Ok(Some(sites))
     }
 
-    fn norm_squared_from_packed_sites<T: NormAccumScalar>(
+    /// Reference implementation for differential tests and builds without a
+    /// process-global tensorbackend. Its nested loops are intentionally kept
+    /// out of the optimized default path.
+    #[cfg(any(test, not(feature = "backend-tenferro")))]
+    fn norm_squared_from_packed_sites_oracle<T: NormAccumScalar>(
         sites: &[PackedSiteTensor<T>],
     ) -> Result<f64> {
         if sites.is_empty() {
@@ -1723,6 +1692,129 @@ impl TensorTrain {
         Ok(current[0].into_nonnegative_real())
     }
 
+    #[cfg(feature = "backend-tenferro")]
+    fn norm_squared_from_packed_sites<T>(sites: Vec<PackedSiteTensor<T>>) -> Result<f64>
+    where
+        T: NormAccumScalar + tensor4all_tensorbackend::TensorElement,
+    {
+        if sites.is_empty() {
+            return Ok(0.0);
+        }
+
+        let mut current = tensor4all_tensorbackend::dense_native_tensor_from_col_major_owned(
+            vec![T::one()],
+            &[1, 1],
+        )
+        .map_err(|error| {
+            TensorTrainError::operation_source("failed to initialize the norm environment", error)
+        })?;
+
+        for site in sites {
+            let expected_shape = [site.left_dim, site.left_dim];
+            if current.shape() != expected_shape {
+                return Err(TensorTrainError::InvalidStructure {
+                    message: format!(
+                        "norm environment shape {:?} does not match site left shape {:?}",
+                        current.shape(),
+                        expected_shape
+                    ),
+                });
+            }
+
+            let site_shape = [site.left_dim, site.physical_dim, site.right_dim];
+            let site_tensor = tensor4all_tensorbackend::dense_native_tensor_from_col_major_owned(
+                site.data,
+                &site_shape,
+            )
+            .map_err(|error| {
+                TensorTrainError::operation_source(
+                    "failed to build a packed norm site tensor",
+                    error,
+                )
+            })?;
+
+            // Real f64 data is already self-conjugate; avoid duplicating it.
+            // Complex64 needs an explicit conjugate because the backend einsum
+            // API does not attach conjugation semantics to an operand label.
+            let conjugated_site = if TypeId::of::<T>() == TypeId::of::<f64>() {
+                None
+            } else {
+                Some(
+                    tensor4all_tensorbackend::conj_native_tensor(&site_tensor).map_err(
+                        |error| {
+                            TensorTrainError::operation_source(
+                                "failed to conjugate a packed norm site tensor",
+                                anyhow::Error::new(error),
+                            )
+                        },
+                    )?,
+                )
+            };
+            let conjugated_site = conjugated_site.as_ref().unwrap_or(&site_tensor);
+
+            // current[a,b] * A[b,p,r] -> mid[a,p,r]
+            let middle = tensor4all_tensorbackend::einsum_native_tensors(
+                &[(&current, &[0, 1]), (&site_tensor, &[1, 2, 3])],
+                &[0, 2, 3],
+            )
+            .map_err(|error| {
+                TensorTrainError::operation_source(
+                    "failed to contract the norm environment with a site",
+                    error,
+                )
+            })?;
+
+            // conj(A[a,p,s]) * mid[a,p,r] -> next[s,r]
+            current = tensor4all_tensorbackend::einsum_native_tensors(
+                &[(conjugated_site, &[0, 1, 2]), (&middle, &[0, 1, 3])],
+                &[2, 3],
+            )
+            .map_err(|error| {
+                TensorTrainError::operation_source(
+                    "failed to close the norm environment at a site",
+                    error,
+                )
+            })?;
+        }
+
+        if current.shape() != [1, 1] {
+            return Err(TensorTrainError::InvalidStructure {
+                message: format!(
+                    "norm contraction did not close to a scalar environment: got shape {:?}",
+                    current.shape()
+                ),
+            });
+        }
+
+        let mut values =
+            tensor4all_tensorbackend::native_tensor_primal_to_dense_col_major::<T>(&current)
+                .map_err(|error| {
+                    TensorTrainError::operation_source(
+                        "failed to read the contracted norm environment",
+                        anyhow::Error::new(error),
+                    )
+                })?;
+        let value = values
+            .pop()
+            .ok_or_else(|| TensorTrainError::InvalidStructure {
+                message: "contracted norm environment has no scalar value".to_string(),
+            })?;
+        if !values.is_empty() {
+            return Err(TensorTrainError::InvalidStructure {
+                message: "contracted norm environment has multiple scalar values".to_string(),
+            });
+        }
+        Ok(value.into_nonnegative_real())
+    }
+
+    #[cfg(not(feature = "backend-tenferro"))]
+    fn norm_squared_from_packed_sites<T: NormAccumScalar>(
+        sites: Vec<PackedSiteTensor<T>>,
+    ) -> Result<f64> {
+        Self::norm_squared_from_packed_sites_oracle(&sites)
+    }
+
+    #[cfg(any(test, not(feature = "backend-tenferro")))]
     fn checked_norm_square(dim: usize) -> Result<usize> {
         if dim == 0 {
             return Err(TensorTrainError::InvalidStructure {

--- a/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
@@ -47,6 +47,75 @@ fn test_single_site_tt() {
     assert_eq!(tt.bond_dims(), Vec::<usize>::new());
 }
 
+#[test]
+fn norm_squared_single_site_has_expected_value() {
+    let tensor = IdxTensor::from_dense(vec![idx(10, 2)], vec![3.0_f64, 4.0]).unwrap();
+    let tt = TensorTrain::new(vec![tensor]).unwrap();
+
+    assert_eq!(tt.norm_squared().unwrap(), 25.0);
+}
+
+#[cfg(feature = "backend-tenferro")]
+fn make_norm_packed_sites<T>(
+    specs: &[(usize, usize, usize)],
+    mut value: impl FnMut(usize, usize) -> T,
+) -> Vec<PackedSiteTensor<T>> {
+    specs
+        .iter()
+        .enumerate()
+        .map(|(site, &(left_dim, physical_dim, right_dim))| {
+            let size = left_dim * physical_dim * right_dim;
+            let data = (0..size)
+                .map(|offset| value(site, offset))
+                .collect::<Vec<_>>();
+            PackedSiteTensor {
+                left_dim,
+                physical_dim,
+                right_dim,
+                data,
+            }
+        })
+        .collect()
+}
+
+#[cfg(feature = "backend-tenferro")]
+fn assert_packed_norm_matches_oracle<T>(sites: Vec<PackedSiteTensor<T>>, label: &str)
+where
+    T: NormAccumScalar + tensor4all_tensorbackend::TensorElement,
+{
+    let expected = TensorTrain::norm_squared_from_packed_sites_oracle(&sites).unwrap();
+    let actual = TensorTrain::norm_squared_from_packed_sites(sites).unwrap();
+    let tolerance = 1.0e-10 * expected.abs().max(1.0);
+    assert!(
+        (actual - expected).abs() <= tolerance,
+        "{label}: backend={actual:.16e}, oracle={expected:.16e}, tolerance={tolerance:.3e}"
+    );
+}
+
+#[cfg(feature = "backend-tenferro")]
+#[test]
+fn packed_norm_backend_matches_oracle_for_real_and_complex_layouts() {
+    let cases: &[&[(usize, usize, usize)]] = &[
+        &[(1, 2, 1)],
+        &[(1, 2, 2), (2, 3, 1)],
+        &[(1, 2, 3), (3, 2, 2), (2, 3, 1)],
+    ];
+
+    for (case_index, specs) in cases.iter().enumerate() {
+        let real_sites = make_norm_packed_sites(specs, |site, offset| {
+            0.1 + ((site * 19 + offset * 7 + 3) % 31) as f64 / 37.0
+        });
+        assert_packed_norm_matches_oracle(real_sites, &format!("f64 case {case_index}"));
+
+        let complex_sites = make_norm_packed_sites(specs, |site, offset| {
+            let real = 0.1 + ((site * 19 + offset * 7 + 3) % 31) as f64 / 37.0;
+            let imag = -0.2 + ((site * 11 + offset * 5 + 1) % 23) as f64 / 29.0;
+            Complex64::new(real, imag)
+        });
+        assert_packed_norm_matches_oracle(complex_sites, &format!("Complex64 case {case_index}"));
+    }
+}
+
 fn dense_tt_svd_round_trip<T: TensorElement>(data: Vec<T>, tolerance: f64) {
     let sites = [
         DynIndex::new_dyn(2),

--- a/crates/tensor4all-tensorbackend/src/backend.rs
+++ b/crates/tensor4all-tensorbackend/src/backend.rs
@@ -1211,6 +1211,22 @@ where
         .map_err(BackendLinalgError::from)
 }
 
+fn full_piv_lu_tensor<T>(
+    tensor: Tensor,
+) -> std::result::Result<FullPivLuResult<T>, BackendLinalgError>
+where
+    T: BackendLinalgScalar,
+{
+    let (p, l, u, q, _parity) = with_default_session(|session| tensor.full_piv_lu(session))
+        .map_err(|e| anyhow!("complete-pivoting LU failed via tenferro-tensor: {e}"))?;
+    Ok(FullPivLuResult {
+        p: require_host_linalg_tensor("full_piv_lu", convert_for_typed::<T>("full_piv_lu", p)?)?,
+        l: require_host_linalg_tensor("full_piv_lu", convert_for_typed::<T>("full_piv_lu", l)?)?,
+        u: require_host_linalg_tensor("full_piv_lu", convert_for_typed::<T>("full_piv_lu", u)?)?,
+        q: require_host_linalg_tensor("full_piv_lu", convert_for_typed::<T>("full_piv_lu", q)?)?,
+    })
+}
+
 /// Compute complete-pivoting LU with the configured tenferro backend.
 /// # Errors
 ///
@@ -1230,14 +1246,7 @@ where
             .to_vec(),
     )
     .map_err(|e| anyhow!("LU input tensor construction failed: {e}"))?;
-    let (p, l, u, q, _parity) = with_default_session(|session| tensor.full_piv_lu(session))
-        .map_err(|e| anyhow!("complete-pivoting LU failed via tenferro-tensor: {e}"))?;
-    Ok(FullPivLuResult {
-        p: require_host_linalg_tensor("full_piv_lu", convert_for_typed::<T>("full_piv_lu", p)?)?,
-        l: require_host_linalg_tensor("full_piv_lu", convert_for_typed::<T>("full_piv_lu", l)?)?,
-        u: require_host_linalg_tensor("full_piv_lu", convert_for_typed::<T>("full_piv_lu", u)?)?,
-        q: require_host_linalg_tensor("full_piv_lu", convert_for_typed::<T>("full_piv_lu", q)?)?,
-    })
+    full_piv_lu_tensor(tensor)
 }
 
 /// Compute complete-pivoting LU for a column-major [`Matrix`].
@@ -1265,6 +1274,73 @@ where
 {
     let tensor = matrix_to_typed_tensor(a);
     let decomp = full_piv_lu_backend(&tensor)?;
+    Ok(FullPivLuMatrixResult {
+        p: typed_tensor_to_matrix("full_piv_lu", decomp.p)?,
+        l: typed_tensor_to_matrix("full_piv_lu", decomp.l)?,
+        u: typed_tensor_to_matrix("full_piv_lu", decomp.u)?,
+        q: typed_tensor_to_matrix("full_piv_lu", decomp.q)?,
+    })
+}
+
+/// Compute complete-pivoting LU for an owned column-major [`Matrix`].
+///
+/// This is the owned-buffer counterpart of [`full_piv_lu_matrix`]. It consumes
+/// the matrix so its column-major buffer can be transferred to tenferro without
+/// cloning the input before factorization.
+/// The returned factors satisfy `P * A * Qᵀ = L * U` when interpreted as
+/// column-major matrices.
+///
+/// # Errors
+///
+/// Returns [`BackendLinalgError`] when the input is not square (tenferro
+/// reports an incompatible shape), the configured backend rejects the scalar
+/// dtype, the complete-pivoting factorization fails, or a factor produced by
+/// the backend cannot be converted back to a matrix.
+///
+/// # Examples
+/// ```
+/// use tensor4all_tensorbackend::{from_vec2d, full_piv_lu_matrix_owned, Matrix};
+///
+/// fn matmul(a: &Matrix<f64>, b: &Matrix<f64>) -> Matrix<f64> {
+///     let mut out = Matrix::zeros(a.nrows(), b.ncols());
+///     for col in 0..b.ncols() {
+///         for k in 0..a.ncols() {
+///             for row in 0..a.nrows() {
+///                 out[[row, col]] += a[[row, k]] * b[[k, col]];
+///             }
+///         }
+///     }
+///     out
+/// }
+///
+/// fn transpose(a: &Matrix<f64>) -> Matrix<f64> {
+///     let mut out = Matrix::zeros(a.ncols(), a.nrows());
+///     for col in 0..a.ncols() {
+///         for row in 0..a.nrows() {
+///             out[[col, row]] = a[[row, col]];
+///         }
+///     }
+///     out
+/// }
+///
+/// let matrix = from_vec2d(vec![vec![2.0_f64, 1.0], vec![1.0, 2.0]]);
+/// let factors = full_piv_lu_matrix_owned(matrix.clone()).unwrap();
+/// let lhs = matmul(&factors.p, &matmul(&matrix, &transpose(&factors.q)));
+/// let rhs = matmul(&factors.l, &factors.u);
+/// for row in 0..2 {
+///     for col in 0..2 {
+///         assert!((lhs[[row, col]] - rhs[[row, col]]).abs() < 1.0e-12);
+///     }
+/// }
+/// ```
+pub fn full_piv_lu_matrix_owned<T>(
+    a: Matrix<T>,
+) -> std::result::Result<FullPivLuMatrixResult<T>, BackendLinalgError>
+where
+    T: BackendLinalgScalar + Copy,
+{
+    let tensor = T::typed_tensor_into_tensor(a.into_typed_tensor());
+    let decomp = full_piv_lu_tensor(tensor)?;
     Ok(FullPivLuMatrixResult {
         p: typed_tensor_to_matrix("full_piv_lu", decomp.p)?,
         l: typed_tensor_to_matrix("full_piv_lu", decomp.l)?,

--- a/crates/tensor4all-tensorbackend/src/backend/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/backend/tests/mod.rs
@@ -493,3 +493,37 @@ fn full_piv_lu_matrix_returns_square_factors() {
     assert_eq!(decomp.q.nrows(), 2);
     assert_eq!(decomp.q.ncols(), 2);
 }
+
+#[test]
+fn full_piv_lu_matrix_owned_matches_borrowed_factors() {
+    let input = crate::from_vec2d(vec![vec![0.0_f64, 1.0], vec![2.0, 3.0]]);
+    let borrowed = full_piv_lu_matrix(&input).unwrap();
+    let owned = full_piv_lu_matrix_owned(input).unwrap();
+
+    assert_eq!(
+        owned.p.as_col_major_slice(),
+        borrowed.p.as_col_major_slice()
+    );
+    assert_eq!(
+        owned.l.as_col_major_slice(),
+        borrowed.l.as_col_major_slice()
+    );
+    assert_eq!(
+        owned.u.as_col_major_slice(),
+        borrowed.u.as_col_major_slice()
+    );
+    assert_eq!(
+        owned.q.as_col_major_slice(),
+        borrowed.q.as_col_major_slice()
+    );
+}
+
+#[test]
+fn full_piv_lu_matrix_owned_preserves_shape_error() {
+    let input = crate::Matrix::from_col_major_vec(2, 3, vec![1.0_f64; 6]);
+    let borrowed_error = full_piv_lu_matrix(&input).unwrap_err().to_string();
+    let owned_error = full_piv_lu_matrix_owned(input).unwrap_err().to_string();
+
+    assert_eq!(owned_error, borrowed_error);
+    assert!(owned_error.contains("incompatible shapes"), "{owned_error}");
+}

--- a/crates/tensor4all-tensorbackend/src/lib.rs
+++ b/crates/tensor4all-tensorbackend/src/lib.rs
@@ -47,8 +47,8 @@ mod tensor_element;
 pub use any_scalar::BackendScalar;
 #[cfg(feature = "global-defaults")]
 pub use backend::{
-    full_piv_lu_backend, full_piv_lu_matrix, qr_backend, solve_backend, solve_matrix,
-    solve_matrix_owned, src_error_estimate, src_error_estimate_general, svd_backend,
+    full_piv_lu_backend, full_piv_lu_matrix, full_piv_lu_matrix_owned, qr_backend, solve_backend,
+    solve_matrix, solve_matrix_owned, src_error_estimate, src_error_estimate_general, svd_backend,
     triangular_solve_backend, triangular_solve_matrix, triangular_solve_matrix_owned,
     BackendLinalgError, BackendLinalgScalar, FullPivLuMatrixResult, FullPivLuResult,
     FullPivLuScalar, MatrixSolveScalar, MatrixTriangularSolveScalar, SrcErrorEstimate, SvdResult,

--- a/crates/tensor4all-tensorbackend/src/matrix.rs
+++ b/crates/tensor4all-tensorbackend/src/matrix.rs
@@ -1301,7 +1301,7 @@ where
 
     let n = matrix.nrows();
     let input_tensor =
-        T::into_tensor(vec![n, n], matrix.as_col_major_slice().to_vec()).map_err(|source| {
+        T::into_tensor(vec![n, n], matrix.into_col_major_vec()).map_err(|source| {
             HermitianEigenError::Backend {
                 source: Box::new(source),
             }
@@ -1622,8 +1622,8 @@ pub fn try_from_vec2d<T: Clone + Zero>(
         }
     }
     let mut m = Matrix::zeros(nrows, ncols);
-    for i in 0..nrows {
-        for j in 0..ncols {
+    for j in 0..ncols {
+        for i in 0..nrows {
             m[[i, j]] = data[i][j].clone();
         }
     }

--- a/crates/tensor4all-tensorbackend/src/matrix/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/matrix/tests/mod.rs
@@ -422,6 +422,13 @@ fn try_from_vec2d_rejects_shorter_rows() {
 }
 
 #[test]
+fn try_from_vec2d_preserves_column_major_storage() {
+    let matrix = try_from_vec2d(vec![vec![1.0_f64, 2.0, 3.0], vec![4.0, 5.0, 6.0]]).unwrap();
+
+    assert_eq!(matrix.as_col_major_slice(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+}
+
+#[test]
 #[should_panic(expected = "row 1 has length 3, expected 2")]
 fn from_vec2d_panics_with_shape_error_for_ragged_rows() {
     let _ = from_vec2d(vec![vec![1.0_f64, 2.0], vec![3.0, 4.0, 5.0]]);

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -787,8 +787,8 @@ where
         }
 
         let mut component_interner = KeyInterner::<Vec<KeyId>>::default();
-        let mut directed_keys: HashMap<(V, V), Vec<KeyId>> =
-            HashMap::with_capacity(tree.edge_count() * 2);
+        let mut directed_keys: HashMap<V, HashMap<V, Vec<KeyId>>> =
+            HashMap::with_capacity(neighbors.len());
 
         for node in order.iter().rev() {
             let Some(parent_node) = parent.get(node).and_then(Clone::clone) else {
@@ -802,7 +802,8 @@ where
                 .filter(|neighbor| *neighbor != &parent_node)
                 .map(|neighbor| {
                     directed_keys
-                        .get(&(neighbor.clone(), node.clone()))
+                        .get(neighbor)
+                        .and_then(|by_target| by_target.get(node))
                         .with_context(|| {
                             format!(
                                 "ComponentCostIndex::new: missing child key {:?}->{:?}",
@@ -820,7 +821,10 @@ where
                 n_points,
                 &mut component_interner,
             );
-            directed_keys.insert((node.clone(), parent_node), keys);
+            directed_keys
+                .entry(node.clone())
+                .or_default()
+                .insert(parent_node, keys);
         }
 
         for node in &order {
@@ -835,7 +839,8 @@ where
                     .filter(|neighbor| *neighbor != child)
                     .map(|neighbor| {
                         directed_keys
-                            .get(&(neighbor.clone(), node.clone()))
+                            .get(neighbor)
+                            .and_then(|by_target| by_target.get(node))
                             .with_context(|| {
                                 format!(
                                     "ComponentCostIndex::new: missing incoming key {:?}->{:?}",
@@ -853,17 +858,20 @@ where
                     n_points,
                     &mut component_interner,
                 );
-                directed_keys.insert((node.clone(), child.clone()), keys);
+                directed_keys
+                    .entry(node.clone())
+                    .or_default()
+                    .insert(child.clone(), keys);
             }
         }
 
-        let directed_counts = directed_keys
-            .into_iter()
-            .map(|(edge, keys)| {
+        let mut directed_counts = HashMap::with_capacity(tree.edge_count() * 2);
+        for (source, targets) in directed_keys {
+            for (target, keys) in targets {
                 let count = keys.into_iter().collect::<HashSet<_>>().len();
-                (edge, count)
-            })
-            .collect();
+                directed_counts.insert((source.clone(), target), count);
+            }
+        }
 
         Ok(Self {
             neighbors,
@@ -4462,7 +4470,7 @@ where
                 .message_caches
                 .entry(directed_edge.clone())
                 .or_insert_with(|| PackedMessageCache::new(bond_dim, message_cache_max_bytes));
-            cache.get_all_cached(&hit_keys); // counted above; discard positions here
+            cache.record_hits(hit_keys.len());
         }
 
         // A parent cache hit returned above before this point, so descendants
@@ -7316,6 +7324,11 @@ where
         Some(positions)
     }
 
+    /// Records keys already confirmed as cached by a partial lookup.
+    fn record_hits(&mut self, count: usize) {
+        self.hits += count;
+    }
+
     fn contains(&self, key: &K) -> bool {
         self.positions.contains_key(key)
     }
@@ -9193,6 +9206,22 @@ mod tests {
         let positions = cache.get_all_cached(&[1u32]).unwrap();
         assert_eq!(cache.column(positions[0]), &[1.0, 0.0]);
         assert_eq!((cache.hits(), cache.misses()), (1, 1));
+    }
+
+    #[test]
+    fn packed_message_cache_records_confirmed_partial_hits() {
+        let mut cache = PackedMessageCache::<u32, f64>::new(2, usize::MAX);
+        cache
+            .get_or_compute_batch(&[1u32, 2u32], |missing| {
+                Ok::<_, anyhow::Error>(missing.iter().map(|k| vec![*k as f64, 0.0]).collect())
+            })
+            .unwrap();
+
+        let hit_keys = [1u32, 1u32, 2u32];
+        assert!(hit_keys.iter().all(|key| cache.contains(key)));
+        cache.record_hits(hit_keys.len());
+
+        assert_eq!((cache.hits(), cache.misses()), (3, 2));
     }
 
     #[test]

--- a/docs/worklogs/2026-09-07-issue-697-performance-stream.md
+++ b/docs/worklogs/2026-09-07-issue-697-performance-stream.md
@@ -1,0 +1,136 @@
+# Issue #697 performance stream
+
+## Session summary
+
+Issue #697 is a routing umbrella for twelve findings from the broad
+performance audit. Items 1--11 are routed to #734--#739; item 12 remains
+deferred to the future variational MPO fitting work because its only production
+consumer is still an unsupported stub. This work starts from the fresh
+`perf/issue-697-subissues` branch at `origin/main`; the previously checked-out
+TreeACI branch was already merged and is not part of this stream.
+
+## Code and documents read
+
+- Issue #697 and sub-issues #734--#739, including the 2026-09-06 re-verification
+  and disposition comment.
+- Open PR #656, which overlaps `crates/tensor4all-treetn/src/treetn/fit.rs`.
+- `README.md`, `REPOSITORY_RULES.md`, `PERFORMANCE_TIPS.md`, the applicable
+  shared tensor4all common/Rust rules, and the generated API inventory under
+  `target/api-dump/`.
+- The owning backend, TreeTN fit, structured-index selection, LUCI, and
+  TensorTrain norm implementations plus their existing tests/benchmarks.
+
+## Ordering and parallelism decision
+
+The first implementation wave is intentionally disjoint:
+
+1. **#734**: low-risk redundant lookups/copies in the cached evaluator,
+   backend matrix helpers, and binary-contraction metadata.
+2. **#736**: the owned complete-pivoting LU seam and its single LUCI caller.
+3. **#739**: the dedicated TensorTrain norm-squared GEMM rewrite.
+
+These three can proceed concurrently: their production write sets are
+`cached_evaluator.rs`/`matrix.rs`/`idx_tensor.rs`, `backend.rs`/LUCI dense
+factorization, and `tensortrain.rs`, respectively. Every implementation agent
+must benchmark and test the untouched `origin/main` baseline before editing,
+then rerun the identical cases after editing.
+
+The remaining work is sequenced:
+
+- **#735** waits for coordination with or resolution of PR #656 because both
+  change `crates/tensor4all-treetn/src/treetn/fit.rs` and its fit tests. Once
+  that conflict is resolved, it is a medium mechanical cache-layout refactor
+  with a required fit differential test and paired measurement.
+- **#737** first performs its reachability/frequency gate. If the structured
+  selection branch is exercised, it follows #734 because both edit
+  `crates/tensor4all-core/src/defaults/idx_tensor.rs`; otherwise the finding is
+  recorded as a cold-path deferral without a speculative rewrite.
+- **#738** follows #734 because both edit `crates/tensor4all-tensorbackend/src/matrix.rs`.
+  It gets a dedicated blocked-transpose benchmark before choosing the tile size
+  and small-matrix threshold; a loop-nesting swap is not an accepted substitute.
+
+Item 12 is not scheduled as an independent change. The cache representation
+  should be chosen with the eventual `contract_fit` consumer under #182.
+
+## Benchmark gate
+
+For each performance-sensitive lane, record before editing:
+
+- exact baseline commit (`origin/main`), source/benchmark revision, release
+  profile, host/CPU and affinity;
+- backend/provider and all thread settings (`RAYON_NUM_THREADS`,
+  `BLAS_NUM_THREADS`, `OMP_NUM_THREADS`, `OPENBLAS_NUM_THREADS`, and
+  `MKL_NUM_THREADS` where applicable);
+- the complete case ladder, repetitions, correctness oracle, and every result.
+
+Correctness is a gate, not a timing observation: the baseline and candidate
+must both pass the same focused tests and value-dependent checks. Candidate
+results must be measured with the same cases and settings. Noise, failed
+correctness, or an incomplete case set is recorded as inconclusive; no speedup
+claim is made from a favorable subset. The paired experiment and its remaining
+risks will be added here before the stream is considered complete.
+
+## Current risks and deferred decisions
+
+- #735's implementation order depends on the open #656 branch and cannot be
+  safely parallelized against it without an explicit reconciliation.
+- #735 must preserve directed-entry `len()` semantics and `NodeIndex.index()`
+  neighbor ordering; replacing tuple keys with nested maps is not sufficient
+  by itself. Its neighbor metadata must be built from the actual fit state,
+  especially if #656 changes the initializer topology.
+- #737's severity is deliberately unknown until a real structured-storage
+  workload is shown to reach the branch.
+- #737's reachability audit found additional structured-storage constructors
+  (`from_storage`, `from_structured_storage`, `from_copy_selector`, and
+  `from_inner_with_axis_classes`), but current TreeTN/SRC/TreeACI fixtures are
+  dense. Frequency measurement must therefore use temporary instrumentation or
+  profiling and must not add counters to #734's shared files.
+- #738 and #739 are algorithmic rewrites requiring differential tests and
+  dedicated review; they are not drive-by cleanups.
+- #738 needs a predeclared tile/threshold grid and both direct-transpose and
+  end-to-end evidence; skinny, empty, scalar-type, and tile-boundary cases are
+  part of the decision, not post-hoc exclusions.
+- #736 changes a public backend surface and must preserve concrete errors,
+  rustdoc examples, and downstream crate boundaries.
+
+## First-wave validation
+
+The first-wave candidate changes are currently uncommitted on
+`perf/issue-697-subissues`, whose base is the fetched `origin/main` commit
+`1059be68e4a068562eaffc1081aea08429ea13dd`. No push or PR was created.
+
+Correctness and API checks completed after integration:
+
+- `tensor4all-tensorbackend` library tests: 232 passed, 1 ignored.
+- `tensor4all-core` structured tests: 9 passed; MatrixLUCI tests: 36 passed.
+- `tensor4all-treetn` cached evaluator tests: 81 passed, 3 ignored.
+- Full `tensor4all-itensorlike` library tests: 134 passed.
+- TensorTrain inner tests: 2 passed; complex-inner tests: 3 passed;
+  large-TT norm tests: 4 passed; packed backend/oracle differential test and
+  single-site norm test passed.
+- Core, tensorbackend, and itensorlike doc tests passed (317, 156, and 29
+  tests respectively).
+- API dump, `cargo fmt --all -- --check`, `git diff --check`, and focused
+  clippy with the repository's required missing-doc lints passed.
+
+The previously incomplete #734 temporary harness was rerun for the candidate
+with the same release/thread settings as its recorded baseline. Median timing
+screening results were:
+
+| case | baseline | candidate |
+|---|---:|---:|
+| `try_from_vec2d` 128x128 | 76,053 ns | 69,902 ns |
+| `try_from_vec2d` 512x512 | 2,942,548 ns | 2,359,259 ns |
+| Hermitian eig 8x8 | 22,893 ns | 23,073 ns |
+| Hermitian eig 16x16 | 34,836 ns | 33,583 ns |
+| Hermitian eig 32x32 | 90,840 ns | 80,822 ns |
+| structured binary contraction | 21,060 ns | 20,599 ns |
+
+This is a screening result from one 30/12-repetition harness run, not a
+formal speedup claim; the #734 evaluator Criterion comparison remains
+inconclusive because its cold and warm results move in opposite directions
+within a short noisy run. The #736 exact caller allocation check was 703 to
+700 allocations with unchanged 176.29 KiB peak heap. The #739 norm ladder was
+20/45/90 sites at 0.003/0.007/0.013 s baseline versus 0.003/0.005/0.011 s
+candidate; its focused TT-inner benchmark is not a norm benchmark and remains
+noise-sensitive.

--- a/docs/worklogs/2026-09-07-issue-739-norm-gemm.md
+++ b/docs/worklogs/2026-09-07-issue-739-norm-gemm.md
@@ -1,0 +1,128 @@
+# Issue #739 baseline and implementation log
+
+## Baseline
+
+- Baseline branch: detached worktree from `origin/main`.
+- Baseline SHA: `1059be68e4a068562eaffc1081aea08429ea13dd`.
+- `HEAD` and `origin/main` matched at the start of the baseline run.
+- The previously used `fix/treeaci-741-convergence` branch was not included.
+- Source worktree: `/root/projects/tensor4all-rust/tensor4all-rs-issue739`.
+- Build artifacts: `/root/projects/tensor4all-rust/tensor4all-rs/target`.
+- Backend/features: workspace default `tenferro-cpu-faer` (therefore the
+  tensorbackend tenferro bridge/global defaults used by the crate).
+- CPU/thread controls used for every command below:
+  `taskset -c 0`, `RAYON_NUM_THREADS=1`, `BLAS_NUM_THREADS=1`,
+  `OMP_NUM_THREADS=1`, `OPENBLAS_NUM_THREADS=1`, `MKL_NUM_THREADS=1`, and
+  `CARGO_BUILD_JOBS=2`.
+
+Focused correctness commands, before source edits:
+
+```text
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 CARGO_TARGET_DIR=/root/projects/tensor4all-rust/tensor4all-rs/target CARGO_BUILD_JOBS=2 taskset -c 0 cargo test --release -p tensor4all-itensorlike --test tensortrain_inner -- --nocapture
+running 2 tests
+test test_inner_empty_tensor_trains ... ok
+test test_inner_single_site ... ok
+test result: ok. 2 passed; 0 failed; 0 ignored
+
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 CARGO_TARGET_DIR=/root/projects/tensor4all-rust/tensor4all-rs/target CARGO_BUILD_JOBS=2 taskset -c 0 cargo test --release -p tensor4all-itensorlike --test bug_complex_inner -- --nocapture
+running 3 tests
+test test_inner_wrong_3site_nonstandard ... ok
+test test_inner_wrong_with_nonstandard_index_order ... ok
+test test_inner_wrong_with_two_site_indices_per_site_nonstandard_order ... ok
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured
+
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 CARGO_TARGET_DIR=/root/projects/tensor4all-rust/tensor4all-rs/target CARGO_BUILD_JOBS=2 taskset -c 0 cargo test --release -p tensor4all-itensorlike --test bug_norm_oom_large_tt -- --nocapture
+running 4 tests
+test test_long_tt_residual_uses_norm_without_dense_maxabs ... ok
+test test_norm_25_site_tt_matches_local_reference ... ok
+test test_norm_90_site_tt_uses_scalable_structured_path ... ok
+test test_norm_small_tt_works ... ok
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured
+```
+
+Existing norm benchmark command and output (site ladder, fixed `bd=16`):
+
+```text
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 CARGO_TARGET_DIR=/root/projects/tensor4all-rust/tensor4all-rs/target CARGO_BUILD_JOBS=2 taskset -c 0 cargo test --release -p tensor4all-itensorlike --test bench_basic_ops -- --ignored --nocapture
+norm(20 sites, bd=16): 0.003s
+norm(45 sites, bd=16): 0.007s
+norm(90 sites, bd=16): 0.013s
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured
+```
+
+Existing TensorTrain benchmark command and output (chi ladder, `L=32`, `d=2`;
+the `tensor4all_inner_mps` rows are the representative TensorTrain rows):
+
+```text
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 CARGO_TARGET_DIR=/root/projects/tensor4all-rust/tensor4all-rs/target CARGO_BUILD_JOBS=2 taskset -c 0 cargo run --release -p tensor4all-itensorlike --example benchmark_tt_ops -- --L 32 --d 2 --zipup-L 10 --chis 4,8,16,32,64 --warm-up-time 0.1 --measurement-time 0.2 --min-samples 3 --inner-only
+tensor4all_inner_mps,L_32_chi_4_d_2,198,0.865877,0.978368,1.010772,1.299592,0,...
+tensor4all_inner_mps,L_32_chi_8_d_2,175,0.920760,1.098464,1.143838,1.637036,0,...
+tensor4all_inner_mps,L_32_chi_16_d_2,230,0.667805,0.738098,0.875133,1.458521,0,...
+tensor4all_inner_mps,L_32_chi_32_d_2,82,2.000288,2.460934,2.449682,2.853923,0,...
+tensor4all_inner_mps,L_32_chi_64_d_2,17,11.594281,12.282173,12.359557,13.072608,0,...
+```
+
+The full stdout also reported paired raw eager and sitewise comparison rows
+for every chi. The short timing windows are intended as an A/B smoke
+measurement, not a stable performance claim.
+
+## Planned implementation
+
+The packed tensor layout is column-major `[left, physical, right]`. The
+environment is stored as `[first_link, second_link]`, flattened as
+`first_link + left_dim * second_link`, matching the old loop's
+`current[left * left_dim + left_conj]` indexing. For each site the backend
+formulation is:
+
+```text
+mid[a,p,r] = sum_b environment[a,b] * A[b,p,r]
+next[s,r]  = sum_{a,p} conj(A[a,p,s]) * mid[a,p,r]
+```
+
+This is two backend einsum/GEMM-compatible contractions, with the second
+input explicitly conjugated for `Complex64`; it preserves the existing
+column-major output ordering. The old nested loop remains as a private
+correctness oracle and is used by differential tests. Empty, boundary, and
+single-site cases remain explicit.
+
+The whole-train clone used only to normalize site order will be removed by
+performing the same per-site permutation while packing. A canonical site is
+copied directly; only a noncanonical site allocates a temporary permuted site.
+No full train or dense full-train tensor is materialized.
+
+## Candidate
+
+The exact baseline correctness commands were rerun after the edit:
+
+```text
+tensortrain_inner: 2 passed; 0 failed
+bug_complex_inner: 3 passed; 0 failed
+bug_norm_oom_large_tt: 4 passed; 0 failed
+packed_norm_backend_matches_oracle_for_real_and_complex_layouts: 1 passed; 0 failed
+norm_squared_single_site_has_expected_value: 1 passed; 0 failed
+```
+
+Post-edit norm benchmark, same command and settings:
+
+```text
+norm(20 sites, bd=16): 0.003s
+norm(45 sites, bd=16): 0.005s
+norm(90 sites, bd=16): 0.011s
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured
+```
+
+Post-edit TensorTrain benchmark, same command and settings (all
+`tensor4all_inner_mps` rows):
+
+```text
+tensor4all_inner_mps,L_32_chi_4_d_2,373,0.501582,0.532741,0.536894,0.618962,0,...
+tensor4all_inner_mps,L_32_chi_8_d_2,342,0.545916,0.579609,0.585998,1.041076,0,...
+tensor4all_inner_mps,L_32_chi_16_d_2,160,1.009808,1.259406,1.252876,1.621597,0,...
+tensor4all_inner_mps,L_32_chi_32_d_2,126,1.247614,1.353779,1.594971,2.342150,0,...
+tensor4all_inner_mps,L_32_chi_64_d_2,19,10.575740,11.058436,11.005752,11.282277,0,...
+```
+
+The focused `--no-default-features` check was also attempted, but fails in
+the pre-existing `tenferro-cpu` dependency because no CPU backend is selected
+(`compile_error!("enable at least one CPU backend: cpu-faer or cpu-blas")`).
+It does not reach the #739 crate code and is not a default-feature regression.

--- a/scripts/library-panics-baseline.json
+++ b/scripts/library-panics-baseline.json
@@ -1,5 +1,5 @@
 [
-  "crates/tensor4all-core/src/defaults/idx_tensor.rs:7320:debug_assert_eq",
+  "crates/tensor4all-core/src/defaults/idx_tensor.rs:7324:debug_assert_eq",
   "crates/tensor4all-core/src/matrixlu.rs:741:debug_assert_eq",
   "crates/tensor4all-core/src/matrixluci/source.rs:103:assert",
   "crates/tensor4all-core/src/matrixluci/source.rs:108:assert_eq",


### PR DESCRIPTION
## Summary

This is the first implementation wave for umbrella issue #697.

- Closes #734: reduce avoidable cache/key allocations, improve column-major conversion and eigendecomposition ownership, and reserve contraction bookkeeping.
- Closes #736: add the owned full-pivot LU backend seam and route DenseLuKernel through it.
- Closes #739: compute TT/MPS norms through the backend GEMM/einsum path, preserve column-major packing and complex conjugation, and add differential/oracle coverage.
- Adds reproducible performance/correctness worklogs under `docs/worklogs/`.

## Scope intentionally left for follow-up

- #735: FitEnvironment/SumFitEnvironment lookup refactor; sequenced after draft PR #656 because of overlapping fit.rs/test changes.
- #737: structured selection allocation change; needs a representative frequency/reachability gate before implementation.
- #738: blocked Matrix transpose; needs a dedicated tile/threshold benchmark before choosing the implementation.
- Umbrella #697 item 12: dense environment clone removal is deferred to the future `contract_fit` work tracked by #182.

## Benchmark baseline

Baseline revision: `1059be68e4a068562eaffc1081aea08429ea13dd` (current `origin/main` at branch creation).

The screening benchmark used release builds with pinned single-thread settings.

| Case | Baseline median | Candidate median |
| --- | ---: | ---: |
| `try_from_vec2d` 128x128 | 76,053 ns | 69,902 ns |
| `try_from_vec2d` 512x512 | 2,942,548 ns | 2,359,259 ns |
| Hermitian eig 8x8 | 22,893 ns | 23,073 ns |
| Hermitian eig 16x16 | 34,836 ns | 33,583 ns |
| Hermitian eig 32x32 | 90,840 ns | 80,822 ns |
| Structured binary contraction | 21,060 ns | 20,599 ns |

The TreeTN evaluator microbenchmark was noisy/inconclusive, so no speedup claim is made for it. DenseLuKernel heaptrack showed caller allocations decreasing from 703 to 700. TT norm measurements improved from 0.013 s to 0.011 s at 90 sites (bond dimension 16), but those runs are also screening measurements rather than a formal performance gate.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc`
- `cargo test --profile ci --workspace --exclude tensor4all-hdf5`
- `cargo test --doc --profile ci --workspace -j 8`
- `cargo doc --workspace --no-deps`
- focused release tests for tensorbackend, core, TreeTN cached evaluation, and itensorlike TT/norm paths
- API dump verification

The local environment does not have cargo-nextest installed, so the workspace fallback uses `cargo test`. The standalone HDF5 package test was not completed locally because its first-time dependency build was still compiling; the HDF5 documentation tests passed and CI should provide the complete package check.