### PR TITLE
docs: scope local validation and manage Cargo artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,15 @@ Then read `README.md` and `REPOSITORY_RULES.md`. Read `PERFORMANCE_TIPS.md`
 evaluation, interpolation, caches, contraction hot paths) and when reviewing
 any PR touching those areas; `skills/audit-performance/` launches that audit.
 
+## Session-start artifact report
+
+Once per session, at the start of work, measure and report the total allocated
+Cargo artifact size across registered worktrees and their configured targets.
+Follow [the inventory procedure](docs/design/build-profiles.md#session-start-inventory):
+deduplicate shared paths and report unavailable measurements. Do not scan the
+whole disk or delete artifacts automatically. Re-reading this file does not
+require another measurement.
+
 ## Development Stage
 
 **Early development**: no backward compatibility. Remove deprecated code
@@ -76,11 +85,13 @@ Every public type, trait, and function **must** have doc comments:
 - mdBook guide code blocks follow the same rules, with hidden lines (`# `
   prefix) for `use` statements and `fn main()` wrappers.
 
-### CI Verification
+### Documentation Verification
 
-- `cargo test --doc --release --workspace` must pass.
-- `./scripts/test-mdbook.sh` must pass (raw `mdbook test docs/book` lacks the
-  resolved `--extern` flags the guide snippets need).
+- Locally, run `cargo test --doc -p <crate>` for affected rustdoc examples or
+  APIs they use. Prose-only changes need link and consistency checks, not builds.
+- Run `./scripts/test-mdbook.sh` when guide snippets or their APIs change (raw
+  `mdbook test docs/book` lacks the resolved `--extern` flags they need).
+- Hosted CI retains full workspace doctests and guide tests.
 
 ### Public Surface Drift
 
@@ -126,12 +137,17 @@ rules in `docs/CAPI_DESIGN.md`.
 ## Testing
 
 ```bash
-cargo nextest run --release --workspace          # Full suite
-cargo nextest run --release --test test_name     # Specific test
-cargo nextest run --release -p crate_name        # Single crate
+cargo test -p <crate> <test_filter>              # Focused regression
+cargo nextest run -p <crate>                     # Changed crate (non-HDF5)
+cargo test -p tensor4all-hdf5                    # HDF5 uses cargo test
 ```
 
-**Always use `--release` for tests**; debug builds are too slow.
+Use non-release builds for ordinary local edit-test loops. Use focused release
+checks for performance claims, release-only failures, unsafe or
+optimization-sensitive behavior, or an explicit maintainer request. If a
+numerical regression is impractically slow without optimization, run that test
+in release mode and record why. Do not run both `release` and `ci` by default.
+See the [local validation table](CONTRIBUTING.md#validate-locally).
 
 - Private functions: `#[cfg(test)]` module in the source file. Integration
   tests: `tests/`.
@@ -260,20 +276,18 @@ link the related Julia-side issue.
 - After updating, re-monitor CI; earlier green checks do not cover the
   synchronized branch.
 
-### Pre-PR Checks (matches CI)
+### Pre-PR Checks
 
-Run before pushing.
+Use the change/risk-tiered [local validation table](CONTRIBUTING.md#validate-locally)
+before pushing; do not duplicate the full hosted suite for every change.
+Required hosted CI and repository-rules review remain authoritative and must
+pass. Report exact local checks and any unavailable validation. Numerical,
+FFI, unsafe, release, and human-only publication safety gates still apply.
 
-```bash
-cargo fmt --all                        # Auto-fix formatting
-cargo fmt --all -- --check             # Dry-run (matches CI)
-cargo clippy --workspace --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
-cargo test -p <changed-crate> --release # Quick check first
-cargo nextest run --cargo-profile ci --workspace --exclude tensor4all-hdf5
-cargo test --profile ci -p tensor4all-hdf5
-cargo test --doc --profile ci --workspace -j 8
-cargo doc --workspace --no-deps        # Build rustdoc
-```
+Keep reusable active-worktree artifacts. Clean owned disposable output when
+work ends, and review long-lived targets periodically according to available
+space. Follow [artifact ownership and cleanup](docs/design/build-profiles.md#artifact-cleanup);
+never clean another task's or a shared target without owner approval.
 
 ### Repository Rules Review Bot
 
@@ -327,7 +341,7 @@ an unrouted section is never shown to the reviewer and
 ```bash
 # Minor: branch workflow
 git checkout -b fix-name && git add -A && git commit -m "msg"
-cargo fmt --all && cargo clippy --workspace  # Lint before push
+# Run the applicable CONTRIBUTING.md local validation tier before push
 git push -u origin fix-name
 gh pr create --base main --title "Title" --body "Desc"
 gh pr merge --auto --squash --delete-branch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,41 @@ Use `max_bond_dim: Option<usize>` for bond caps and `SvdTruncationPolicy` for SV
 
 ## Validate locally
 
-Run focused changed-crate tests first, then the CI-equivalent repository gates. These require `cargo-nextest`, mdBook 0.5.2, the HDF5 development library, and (for C-header checks) cbindgen 0.29.2; see `.github/workflows/CI_rs.yml` for platform setup.
+Choose checks by the changed surface and risk, rather than duplicating hosted
+CI before every push. Ordinary local checks use non-release profiles; the
+existing `debug = 0` settings remain unchanged.
+
+| Change | Local validation before pushing |
+|--------|---------------------------------|
+| Crate-local code | Formatting, focused changed-crate regression tests (or `cargo check` for compile-only changes), changed-crate Clippy, and relevant deterministic scripts. |
+| Documentation/API | For prose only, check links and consistency. For changed examples/APIs, run affected crate doctests and rustdoc; run `./scripts/test-mdbook.sh` when guide snippets or their APIs change. |
+| Cross-crate, manifests, dependencies, features | Expand checks to affected dependents and feature configurations; use the full workspace when the impact is workspace-wide or uncertain. Run boundary checks for dependency changes. |
+| Numerical, FFI, unsafe, optimization-sensitive code | Run focused numerical/boundary regressions and relevant audits; include release tests where optimized behavior matters (including unsafe changes), and benchmarks for performance claims. C API changes require the header check and affected binding validation. |
+| CI/helpers | Run the changed helper's tests and relevant deterministic checks; reproduce affected jobs as needed. Unknown changes use the conservative code-change tier. |
+| Release preparation or hosted-CI failure reproduction | Run the applicable release gates or failing job commands; full local CI-equivalent validation is appropriate for broad failures or explicit maintainer requests. Publication remains human-only. |
+
+Typical crate-local commands (replace the placeholders):
+
+```bash
+cargo fmt --all -- --check
+cargo test -p <changed-crate> <test_filter>
+cargo clippy -p <changed-crate> --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+```
+
+Use `cargo test`, not Nextest, for HDF5 tests. A numerical regression that is
+impractically slow without optimization may use release mode with the reason
+recorded. Do not routinely run the same tests in both `release` and `ci`.
+Numerical tolerances, coverage requirements, unsafe/FFI safety, and release or
+publication approvals are not weakened by choosing focused local checks.
+
+### Full validation reference (not an unconditional local gate)
+
+Hosted CI remains required and authoritative for comprehensive tests, coverage,
+documentation and feature/backend checks. Consult `.github/workflows/CI_rs.yml`
+for the current commands and platform setup. The following commands are useful
+when broader local validation is needed, not as a checklist for every push.
+They require `cargo-nextest`, mdBook 0.5.2, the HDF5 development library, and
+(for C-header checks) cbindgen 0.29.2.
 
 ```bash
 cargo fmt --all -- --check
@@ -57,6 +91,16 @@ python3 scripts/audit-library-panics.py
 python3 scripts/check-public-error-docs.py
 python3 scripts/check-crate-boundaries.py
 ```
+
+### Build artifacts
+
+At session start, agents report the total allocated size of registered
+worktrees' targets, including configured external targets, once per session.
+See [inventory and cleanup](docs/design/build-profiles.md#artifact-cleanup) for
+scope, deduplication and unavailable-path reporting. Keep reusable active
+output, remove owned disposable output at task/worktree retirement, and review
+long-lived targets periodically based on free space. Never automatically delete
+shared or another task's output. No fixed machine-specific size limit applies.
 
 Do not commit `target/`, coverage output, generated API dumps, or other build artifacts.
 

--- a/docs/design/build-profiles.md
+++ b/docs/design/build-profiles.md
@@ -55,19 +55,65 @@ instrumentation-owned profile and does not use `ci`.
 
 ## Rationale
 
-The repository normally runs tests, documentation examples, tutorials, and benchmarks in release mode. Full debuginfo or line tables are therefore multiplied across many independently linked test and example executables. A controlled full-workspace measurement found that changing ordinary release from line tables to `debug = 0` reduced allocated target output from 14,759,100,416 to 3,354,374,144 bytes (77.27%); see `docs/worklogs/2026-08-09-release-debug-info-reduction.md`.
+Ordinary local checks use non-release profiles; comprehensive CI and benchmarks
+use optimized builds. Choose local checks using the
+[change/risk table](../../CONTRIBUTING.md#validate-locally), not full CI parity.
+Full debuginfo or line tables multiply across independently linked test and
+example executables. A controlled full-workspace measurement found that changing ordinary release from line tables to `debug = 0` reduced allocated target output from 14,759,100,416 to 3,354,374,144 bytes (77.27%); see `docs/worklogs/2026-08-09-release-debug-info-reduction.md`.
 
 Most development does not debug Rust through Tensor4all.jl or the C API and does not benefit from this metadata. The named profile preserves the diagnostic capability without imposing its storage cost on every release build.
 
 ## Artifact cleanup
 
-Profile changes prevent new oversized outputs but do not delete artifacts from
-older dependency revisions, feature sets, or profile settings. Inspect the
-workspace target with `du -sh target`. When stale output dominates and a cold
-rebuild is acceptable, remove only the relevant profile with, for example,
-`cargo clean --profile release`; use `cargo clean` when all historical variants
-should be discarded. Persistent self-hosted targets should be cleaned
-periodically based on available disk space rather than on every CI run.
+Profile settings reduce individual builds but do not delete older dependency,
+feature or profile variants, nor prevent duplication across worktrees.
+
+### Session-start inventory
+
+Once at the start of each agent session (not on every `AGENTS.md` read):
+
+1. Enumerate this repository's registered worktrees with
+   `git worktree list --porcelain`. Include each existing `<worktree>/target`,
+   even if its current configuration points elsewhere.
+2. Resolve each worktree's effective target using
+   `cargo metadata --offline --no-deps --format-version 1` from that worktree
+   and read `target_directory`. This accounts for the current environment and
+   Cargo configuration without compiling or downloading dependencies. Include
+   known task-specific `--target-dir` or `CARGO_TARGET_DIR` paths as well.
+3. Canonicalize paths, count shared targets once, and omit nested targets
+   already covered by a parent. Measure allocated disk usage with `du -sk`
+   (or the platform equivalent), sum it, and report the total and largest paths.
+4. Report inaccessible paths, missing worktrees, metadata failures or timed-out
+   measurements explicitly; label the total partial if anything is unmeasured.
+   Missing target directories contribute zero. Do not build to obtain a number.
+
+This is a scoped inventory, not a whole-disk search: unregistered checkouts and
+unknown historical external targets are not included. A shared target may also
+contain other repositories' artifacts; report that limitation rather than
+claiming exact attribution. Do not delete anything as part of this report.
+
+### Ownership and cleanup
+
+- Before a large build, identify the effective target and its owner (the task
+  or developer), whether it is shared, and whether its output will be reused.
+  Do not build every worktree merely because it exists.
+- Keep reusable output for active worktrees; cleaning on every edit or push
+  wastes subsequent rebuilds.
+- Give one-off large builds a dedicated target when practical and remove their
+  owned disposable output at completion. Before retiring a disposable worktree,
+  remove its dedicated build output, including external targets; removing the
+  worktree alone does not remove external output.
+- Review long-lived and self-hosted targets periodically and before large builds
+  when free space is low relative to expected build growth, or when stale
+  variants dominate. Propose cleanup rather than imposing a fixed GiB limit.
+- Clean only output owned by the completed task, after confirming no build uses
+  it. Shared or other tasks' targets require owner approval; if ownership is
+  unclear, ask rather than delete. Report deferred cleanup at handoff.
+
+For an identified target, `cargo clean --target-dir <path> --profile release`
+removes that profile's output; `cargo clean --target-dir <path>` discards all
+Cargo build output there when a cold rebuild is acceptable. Check the path and
+ownership first. No automatic deletion or background cleanup service is needed.
 
 ## Compatibility and non-goals
 


### PR DESCRIPTION
## Summary
- Replace unconditional local CI/release builds with change- and risk-proportionate validation; retain required hosted CI and numerical, FFI, unsafe, release and publication safeguards.
- Define ownership and cleanup for reusable, disposable and retired worktree targets without automatic deletion.
- Require one session-start artifact inventory across registered worktrees and configured targets, with deduplication and partial-measurement reporting.

Closes #745

## Validation
- cargo fmt --all -- --check: passed; cargo fmt --all before commit.
- git diff --check: passed.
- python3 scripts/repository-rules-review.py --base origin/main --worktree --dry-run: passed.
- Checked 10 relative documentation links/anchors: passed.
- Exercised inventory using offline Cargo metadata and allocated disk usage: 25 registered worktrees, 6 existing unique targets, 32.01 GiB; no artifacts deleted.
- Self-reviewed the three-document diff and retained README/public API accuracy. No production code paths removed; coverage impact not applicable.
- Documentation-only change: no local Rust builds or full test suite. Hosted CI remains required.